### PR TITLE
Persistent keycloak

### DIFF
--- a/components/management-controller/.gitignore
+++ b/components/management-controller/.gitignore
@@ -4,3 +4,5 @@ app
 npm-debug.log*
 .DS_store
 .idea
+
+keycloak.json

--- a/components/management-controller/keycloak.json
+++ b/components/management-controller/keycloak.json
@@ -1,0 +1,8 @@
+{
+  "realm": "keycloak realm",
+  "auth-server-url": "keycloak url",
+  "ssl-required": "external",
+  "resource": "keycloak client ID",
+  "public-client": true,
+  "confidential-port": 0
+}

--- a/yaml/keycloak-config.yaml
+++ b/yaml/keycloak-config.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: keycloak service
+  labels:
+    application: 'keycloak'
+  name: 'keycloak'
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: 'keycloak'
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: 'keycloak'
+  name: 'keycloak'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: 'keycloak'
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: 'keycloak'
+        app: 'keycloak'
+    spec:
+      containers:
+        - env:
+            - name: KEYCLOAK_ADMIN
+              value: 'admin'
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              value: 'admin'
+            - name: KC_PROXY
+              value: 'edge'
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL
+              value: 'jdbc:postgresql://postgres/studiodb'
+            - name: KC_DB_USERNAME
+              value: 'access'
+            - name: KC_DB_PASSWORD
+              value: 'password'
+          image: quay.io/keycloak/keycloak:24.0.4
+          livenessProbe:
+            failureThreshold: 300
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 120
+          name: 'keycloak'
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 300
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 120
+          securityContext:
+            privileged: false
+          volumeMounts:
+            - mountPath: /opt/keycloak/data
+              name: empty
+          args: ["start-dev"]
+      volumes:
+        - name: empty
+          emptyDir: {}


### PR DESCRIPTION
Keycloak data and configurations are stored in Postgres, so if you restart, remove, and recreate Keycloak (or even the database itself), the configurations remain permanent. Additionally, in the previous version, it was possible to access GET routes without needing the van-owner realm privilege. Now, this check is enforced, and if the user does not have this role, they will receive an 'access denied' message

**Test:**
https://skupper-x-vb-skupper-x-2.skupper-0-153f1de160110098c1928a6c05e19444-0000.us-east.containers.appdomain.cloud

**user**: _myskupper_  and **pass**: _skupper_

**Other config:**
Two new Realm roles were created: **van-owner** and **backbone-admin**, then applied to the user _myskypper_ (no need to set the admin role).
![keycloack-config](https://github.com/ted-ross/skupper-X/assets/79913332/cd557179-4d1c-43f2-9fe9-3491b208dc52)
