### PR TITLE
James keycloak integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,9 +106,6 @@ dist
 # Keycloak file
 keycloak.json
 
-# Keycloak realm export folder
-realms/
-
 # js config file
 jsconfig.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ dist
 # Keycloak file
 keycloak.json
 
+# Keycloak realm export folder
+realms/
+
 # js config file
 jsconfig.json
 

--- a/components/compose-web-app/modules/app_old.js
+++ b/components/compose-web-app/modules/app_old.js
@@ -152,6 +152,43 @@ async function AppForm() {
         }
     }
 
+    // create owner group selector dropdown
+    let ownerGroupSelector = document.createElement('select');
+    ownerGroupSelector.id = 'ownerGroupSelector';
+
+    try {
+        const ownerGroupResult = await fetch('/api/v1alpha1/user/groups');
+        if (ownerGroupResult.ok) {
+            const ownerGroupList = await ownerGroupResult.json();
+            
+            // Add a default/empty option
+            let defaultOption = document.createElement('option');
+            defaultOption.textContent = '-- Select a group --';
+            defaultOption.value = '';
+            ownerGroupSelector.appendChild(defaultOption);
+            
+            // Add user's groups
+            for (const ownerGroup of ownerGroupList) {
+                let option = document.createElement('option');
+                option.textContent = ownerGroup.name;
+                option.value = ownerGroup.id;
+                ownerGroupSelector.appendChild(option);
+            }
+        } else {
+            // Handle error case
+            let errorOption = document.createElement('option');
+            errorOption.textContent = 'Error loading groups';
+            errorOption.disabled = true;
+            ownerGroupSelector.appendChild(errorOption);
+        }
+    } catch (error) {
+        console.error('Error fetching user groups:', error);
+        let errorOption = document.createElement('option');
+        errorOption.textContent = 'Error loading groups';
+        errorOption.disabled = true;
+        ownerGroupSelector.appendChild(errorOption);
+    }
+
     const form = await FormLayout(
         //
         // Form fields
@@ -159,6 +196,7 @@ async function AppForm() {
         [
             ['Application Name:', appName],
             ['Root Block:',       rootSelector],
+            ['Owner Group:', ownerGroupSelector]
         ],
 
         //
@@ -173,6 +211,7 @@ async function AppForm() {
                 body: JSON.stringify({
                     name      : appName.value,
                     rootblock : rootSelector.value,
+                    ownerGroup: ownerGroupSelector.value
                 }),
             });
         

--- a/components/compose-web-app/modules/app_old.js
+++ b/components/compose-web-app/modules/app_old.js
@@ -18,7 +18,7 @@
 */
 
 import { LibDetail } from "./library.js";
-import { FormLayout, SetupTable, TextArea } from "./util.js";
+import { FormLayout, SetupTable, TextArea, OwnerGroupSelector } from "./util.js";
 
 export async function BuildApplicationTable() {
     const response = await fetch('compose/v1alpha1/applications');
@@ -152,42 +152,7 @@ async function AppForm() {
         }
     }
 
-    // create owner group selector dropdown
-    let ownerGroupSelector = document.createElement('select');
-    ownerGroupSelector.id = 'ownerGroupSelector';
-
-    try {
-        const ownerGroupResult = await fetch('/api/v1alpha1/user/groups');
-        if (ownerGroupResult.ok) {
-            const ownerGroupList = await ownerGroupResult.json();
-            
-            // Add a default/empty option
-            let defaultOption = document.createElement('option');
-            defaultOption.textContent = '-- Select a group --';
-            defaultOption.value = '';
-            ownerGroupSelector.appendChild(defaultOption);
-            
-            // Add user's groups
-            for (const ownerGroup of ownerGroupList) {
-                let option = document.createElement('option');
-                option.textContent = ownerGroup.name;
-                option.value = ownerGroup.id;
-                ownerGroupSelector.appendChild(option);
-            }
-        } else {
-            // Handle error case
-            let errorOption = document.createElement('option');
-            errorOption.textContent = 'Error loading groups';
-            errorOption.disabled = true;
-            ownerGroupSelector.appendChild(errorOption);
-        }
-    } catch (error) {
-        console.error('Error fetching user groups:', error);
-        let errorOption = document.createElement('option');
-        errorOption.textContent = 'Error loading groups';
-        errorOption.disabled = true;
-        ownerGroupSelector.appendChild(errorOption);
-    }
+    const ownerGroupSelector = await OwnerGroupSelector();
 
     const form = await FormLayout(
         //

--- a/components/compose-web-app/modules/backbone.js
+++ b/components/compose-web-app/modules/backbone.js
@@ -617,8 +617,9 @@ async function SiteForm(backbone) {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                    name     : siteName.value,
-                    platform : platformSelector.value,
+                    name       : siteName.value,
+                    platform   : platformSelector.value,
+                    ownerGroup : backbone.ownergroup
                 }),
             });
 
@@ -676,8 +677,9 @@ async function AccessPointForm(div, backbone, siteId) {
         //
         async () => {
             let body = {
-                name     : apName.value,
-                kind     : kindSelector.value,
+                name       : apName.value,
+                kind       : kindSelector.value,
+                ownerGroup : backbone.ownergroup,
             };
             if (bindHost.value != '') {
                 body.bindhost = bindHost.value;
@@ -768,6 +770,7 @@ async function LinkForm(div, backbone, siteId) {
             let body = {
                 connectingsite : siteId,
                 cost           : cost.value,
+                ownerGroup     : backbone.ownergroup,
             };
             const response = await fetch(`api/v1alpha1/accesspoints/${peerSelector.value}/links`, {
                 method: 'POST',

--- a/components/compose-web-app/modules/backbone.js
+++ b/components/compose-web-app/modules/backbone.js
@@ -69,12 +69,49 @@ async function BackboneForm() {
     let bbName = document.createElement('input');
     bbName.type = 'text';
 
+    let ownerGroupSelector = document.createElement('select');
+    ownerGroupSelector.id = 'ownerGroupSelector';
+
+    try {
+        const ownerGroupResult = await fetch('/api/v1alpha1/user/groups');
+        if (ownerGroupResult.ok) {
+            const ownerGroupList = await ownerGroupResult.json();
+            
+            // Add a default/empty option
+            let defaultOption = document.createElement('option');
+            defaultOption.textContent = '-- Select a group --';
+            defaultOption.value = '';
+            ownerGroupSelector.appendChild(defaultOption);
+            
+            // Add user's groups
+            for (const ownerGroup of ownerGroupList) {
+                let option = document.createElement('option');
+                option.textContent = ownerGroup.name;
+                option.value = ownerGroup.id;
+                ownerGroupSelector.appendChild(option);
+            }
+        } else {
+            // Handle error case
+            let errorOption = document.createElement('option');
+            errorOption.textContent = 'Error loading groups';
+            errorOption.disabled = true;
+            ownerGroupSelector.appendChild(errorOption);
+        }
+    } catch (error) {
+        console.error('Error fetching user groups:', error);
+        let errorOption = document.createElement('option');
+        errorOption.textContent = 'Error loading groups';
+        errorOption.disabled = true;
+        ownerGroupSelector.appendChild(errorOption);
+    }
+
     const form = await FormLayout(
         //
         // Form fields
         //
         [
             ['Backbone Name:', bbName],
+            ['Owner Group:', ownerGroupSelector],
         ],
 
         //
@@ -88,6 +125,7 @@ async function BackboneForm() {
                 },
                 body: JSON.stringify({
                     name : bbName.value,
+                    ownerGroup : ownerGroupSelector.value,
                 }),
             });
         

--- a/components/compose-web-app/modules/backbone.js
+++ b/components/compose-web-app/modules/backbone.js
@@ -18,7 +18,7 @@
 */
 
 import { toBackboneTab } from "../page.js";
-import { FormLayout, LayoutRow, PollObject, PollTable, SetupTable, TimeAgo, ConfirmDialog } from "./util.js";
+import { FormLayout, LayoutRow, PollObject, PollTable, SetupTable, TimeAgo, ConfirmDialog, OwnerGroupSelector } from "./util.js";
 
 export async function BuildBackboneTable() {
     const response = await fetch('api/v1alpha1/backbones');
@@ -69,41 +69,7 @@ async function BackboneForm() {
     let bbName = document.createElement('input');
     bbName.type = 'text';
 
-    let ownerGroupSelector = document.createElement('select');
-    ownerGroupSelector.id = 'ownerGroupSelector';
-
-    try {
-        const ownerGroupResult = await fetch('/api/v1alpha1/user/groups');
-        if (ownerGroupResult.ok) {
-            const ownerGroupList = await ownerGroupResult.json();
-            
-            // Add a default/empty option
-            let defaultOption = document.createElement('option');
-            defaultOption.textContent = '-- Select a group --';
-            defaultOption.value = '';
-            ownerGroupSelector.appendChild(defaultOption);
-            
-            // Add user's groups
-            for (const ownerGroup of ownerGroupList) {
-                let option = document.createElement('option');
-                option.textContent = ownerGroup.name;
-                option.value = ownerGroup.id;
-                ownerGroupSelector.appendChild(option);
-            }
-        } else {
-            // Handle error case
-            let errorOption = document.createElement('option');
-            errorOption.textContent = 'Error loading groups';
-            errorOption.disabled = true;
-            ownerGroupSelector.appendChild(errorOption);
-        }
-    } catch (error) {
-        console.error('Error fetching user groups:', error);
-        let errorOption = document.createElement('option');
-        errorOption.textContent = 'Error loading groups';
-        errorOption.disabled = true;
-        ownerGroupSelector.appendChild(errorOption);
-    }
+    const ownerGroupSelector = await OwnerGroupSelector();
 
     const form = await FormLayout(
         //

--- a/components/compose-web-app/modules/deploy.js
+++ b/components/compose-web-app/modules/deploy.js
@@ -19,7 +19,7 @@
 
 import { toDeploymentTab } from "../page.js";
 import { AppDetail } from "./app_old.js";
-import { FormLayout, SetupTable, TextArea } from "./util.js";
+import { FormLayout, SetupTable, TextArea, OwnerGroupSelector } from "./util.js";
 
 export async function BuildDeploymentTable() {
     const response = await fetch('compose/v1alpha1/deployments');
@@ -158,6 +158,7 @@ async function DeploymentForm() {
 
     let appSelector = document.createElement('select');
     let vanSelector = document.createElement('select');
+    let ownerGroupSelector = await OwnerGroupSelector();
 
     //
     // Populate the application selector
@@ -186,6 +187,7 @@ async function DeploymentForm() {
         [
             ['Application:', appSelector],
             ['VAN:',         vanSelector],
+            ['Owner Group:', ownerGroupSelector],
         ],
 
         //
@@ -200,6 +202,7 @@ async function DeploymentForm() {
                 body: JSON.stringify({
                     app : appSelector.value,
                     van : vanSelector.value,
+                    ownerGroup: ownerGroupSelector.value,
                 }),
             });
 

--- a/components/compose-web-app/modules/deploy.js
+++ b/components/compose-web-app/modules/deploy.js
@@ -39,7 +39,7 @@ export async function BuildDeploymentTable() {
 
             anchor = document.createElement('a');
             anchor.setAttribute('href', '#');
-            anchor.addEventListener('click', () => { AppDetail(item.applicaion); });
+            anchor.addEventListener('click', () => { AppDetail(item.application); });
             anchor.textContent = item.appname;
             row.insertCell().appendChild(anchor);
 

--- a/components/compose-web-app/modules/library.js
+++ b/components/compose-web-app/modules/library.js
@@ -25,7 +25,7 @@ import { LibraryHistory } from "./library-history.js";
 import { LibraryEditInterfaces } from "./library-interfaces.js";
 import { LibraryEditSimple } from "./library-simple.js";
 import { TabSheet } from "./tabsheet.js";
-import { FormLayout, LayoutRow, SetupTable, TextArea } from "./util.js";
+import { FormLayout, LayoutRow, SetupTable, TextArea, OwnerGroupSelector } from "./util.js";
 
 export async function BuildLibraryTable() {
     const response = await fetch('/compose/v1alpha1/library/blocks');
@@ -113,42 +113,7 @@ async function BlockForm(blockTypes, interfaceRoles) {
     composite.textContent = 'Composite';
     bodySelector.appendChild(composite);
 
-    // create owner group selector dropdown
-    let ownerGroupSelector = document.createElement('select');
-    ownerGroupSelector.id = 'ownerGroupSelector';
-
-    try {
-        const ownerGroupResult = await fetch('/api/v1alpha1/user/groups');
-        if (ownerGroupResult.ok) {
-            const ownerGroupList = await ownerGroupResult.json();
-            
-            // Add a default/empty option
-            let defaultOption = document.createElement('option');
-            defaultOption.textContent = '-- Select a group --';
-            defaultOption.value = '';
-            ownerGroupSelector.appendChild(defaultOption);
-            
-            // Add user's groups
-            for (const ownerGroup of ownerGroupList) {
-                let option = document.createElement('option');
-                option.textContent = ownerGroup.name;
-                option.value = ownerGroup.id;
-                ownerGroupSelector.appendChild(option);
-            }
-        } else {
-            // Handle error case
-            let errorOption = document.createElement('option');
-            errorOption.textContent = 'Error loading groups';
-            errorOption.disabled = true;
-            ownerGroupSelector.appendChild(errorOption);
-        }
-    } catch (error) {
-        console.error('Error fetching user groups:', error);
-        let errorOption = document.createElement('option');
-        errorOption.textContent = 'Error loading groups';
-        errorOption.disabled = true;
-        ownerGroupSelector.appendChild(errorOption);
-    }
+    const ownerGroupSelector = await OwnerGroupSelector();
 
     const form = await FormLayout(
         //

--- a/components/compose-web-app/modules/library.js
+++ b/components/compose-web-app/modules/library.js
@@ -113,6 +113,43 @@ async function BlockForm(blockTypes, interfaceRoles) {
     composite.textContent = 'Composite';
     bodySelector.appendChild(composite);
 
+    // create owner group selector dropdown
+    let ownerGroupSelector = document.createElement('select');
+    ownerGroupSelector.id = 'ownerGroupSelector';
+
+    try {
+        const ownerGroupResult = await fetch('/api/v1alpha1/user/groups');
+        if (ownerGroupResult.ok) {
+            const ownerGroupList = await ownerGroupResult.json();
+            
+            // Add a default/empty option
+            let defaultOption = document.createElement('option');
+            defaultOption.textContent = '-- Select a group --';
+            defaultOption.value = '';
+            ownerGroupSelector.appendChild(defaultOption);
+            
+            // Add user's groups
+            for (const ownerGroup of ownerGroupList) {
+                let option = document.createElement('option');
+                option.textContent = ownerGroup.name;
+                option.value = ownerGroup.id;
+                ownerGroupSelector.appendChild(option);
+            }
+        } else {
+            // Handle error case
+            let errorOption = document.createElement('option');
+            errorOption.textContent = 'Error loading groups';
+            errorOption.disabled = true;
+            ownerGroupSelector.appendChild(errorOption);
+        }
+    } catch (error) {
+        console.error('Error fetching user groups:', error);
+        let errorOption = document.createElement('option');
+        errorOption.textContent = 'Error loading groups';
+        errorOption.disabled = true;
+        ownerGroupSelector.appendChild(errorOption);
+    }
+
     const form = await FormLayout(
         //
         // Form fields
@@ -122,6 +159,7 @@ async function BlockForm(blockTypes, interfaceRoles) {
             ['Block Type:',          btSelector],
             ['Provider (optional):', provider],
             ['Body Type:',           bodySelector],
+            ['Owner Group:',         ownerGroupSelector]
         ],
 
         //
@@ -139,6 +177,7 @@ async function BlockForm(blockTypes, interfaceRoles) {
                     type      : btSelector.value,
                     provider  : provider.value,
                     bodystyle : bodySelector.value,
+                    ownerGroup: ownerGroupSelector.value
                 }),
             });
             console.log('   fetch completed');

--- a/components/compose-web-app/modules/util.js
+++ b/components/compose-web-app/modules/util.js
@@ -374,9 +374,13 @@ export async function OwnerGroupSelector() {
             
             // Add a default/empty option
             let defaultOption = document.createElement('option');
+            let publicOption = document.createElement('option');
             defaultOption.textContent = '-- Select a group --';
             defaultOption.value = '';
+            publicOption.textContent = 'public';
+            publicOption.value = 'public';
             ownerGroupSelector.appendChild(defaultOption);
+            ownerGroupSelector.appendChild(publicOption);
             
             // Add user's groups
             for (const ownerGroup of ownerGroupList) {

--- a/components/compose-web-app/modules/util.js
+++ b/components/compose-web-app/modules/util.js
@@ -362,3 +362,43 @@ export function MultiSelectWithCheckbox(items) {
 
     return layout;
 }
+
+export async function OwnerGroupSelector() {
+    let ownerGroupSelector = document.createElement('select');
+    ownerGroupSelector.id = 'ownerGroupSelector';
+
+    try {
+        const ownerGroupResult = await fetch('/api/v1alpha1/user/groups');
+        if (ownerGroupResult.ok) {
+            const ownerGroupList = await ownerGroupResult.json();
+            
+            // Add a default/empty option
+            let defaultOption = document.createElement('option');
+            defaultOption.textContent = '-- Select a group --';
+            defaultOption.value = '';
+            ownerGroupSelector.appendChild(defaultOption);
+            
+            // Add user's groups
+            for (const ownerGroup of ownerGroupList) {
+                let option = document.createElement('option');
+                option.textContent = ownerGroup.name;
+                option.value = ownerGroup.id;
+                ownerGroupSelector.appendChild(option);
+            }
+        } else {
+            // Handle error case
+            let errorOption = document.createElement('option');
+            errorOption.textContent = 'Error loading groups';
+            errorOption.disabled = true;
+            ownerGroupSelector.appendChild(errorOption);
+        }
+    } catch (error) {
+        console.error('Error fetching user groups:', error);
+        let errorOption = document.createElement('option');
+        errorOption.textContent = 'Error loading groups';
+        errorOption.disabled = true;
+        ownerGroupSelector.appendChild(errorOption);
+    }
+
+    return ownerGroupSelector;
+}

--- a/components/compose-web-app/modules/van.js
+++ b/components/compose-web-app/modules/van.js
@@ -159,6 +159,7 @@ async function ExternalVanForm() {
         let option = document.createElement('option');
         option.textContent = bb.name;
         option.value       = bb.id;
+        option.ownerGroup = bb.ownergroup;
         bbSelector.appendChild(option);
     }
 
@@ -178,6 +179,7 @@ async function ExternalVanForm() {
             let body = {
                 name   : vanName.value,
                 tenant : 'false',
+                ownerGroup: bbSelector.selectedOptions[0].ownerGroup,
             };
             const response = await fetch(`api/v1alpha1/backbones/${bbSelector.value}/vans`, {
                 method: 'POST',

--- a/components/compose-web-app/modules/van.js
+++ b/components/compose-web-app/modules/van.js
@@ -20,7 +20,7 @@
 import { InvitationsTab } from "./invitations.js";
 import { MembersTab } from "./members.js";
 import { TabSheet } from "./tabsheet.js";
-import { FormLayout, PollTable, SetupTable } from "./util.js";
+import { FormLayout, PollTable, SetupTable, OwnerGroupSelector } from "./util.js";
 import { ConfigTab } from "./vanconfig.js";
 import { DetailTab } from "./vandetail.js";
 
@@ -152,6 +152,8 @@ async function ExternalVanForm() {
     let vanName = document.createElement('input');
     vanName.type = 'text';
 
+    const ownerGroupSelector = await OwnerGroupSelector();
+
     let bbSelector = document.createElement('select');
     const bbResult = await fetch('/api/v1alpha1/backbones');
     const bbList   = await bbResult.json();
@@ -159,7 +161,6 @@ async function ExternalVanForm() {
         let option = document.createElement('option');
         option.textContent = bb.name;
         option.value       = bb.id;
-        option.dataset.ownerGroup = bb.ownergroup || '';
         bbSelector.appendChild(option);
     }
 
@@ -170,6 +171,7 @@ async function ExternalVanForm() {
         [
             ['VAN Name:', vanName],
             ['Backbone:', bbSelector],
+            ['Owner Group:', ownerGroupSelector],
         ],
 
         //
@@ -179,7 +181,7 @@ async function ExternalVanForm() {
             let body = {
                 name   : vanName.value,
                 tenant : 'false',
-                ownerGroup: bbSelector.selectedOptions[0]?.dataset.ownerGroup || '',
+                ownerGroup: ownerGroupSelector.value,
             };
             const response = await fetch(`api/v1alpha1/backbones/${bbSelector.value}/vans`, {
                 method: 'POST',

--- a/components/compose-web-app/modules/van.js
+++ b/components/compose-web-app/modules/van.js
@@ -159,7 +159,7 @@ async function ExternalVanForm() {
         let option = document.createElement('option');
         option.textContent = bb.name;
         option.value       = bb.id;
-        option.ownerGroup = bb.ownergroup;
+        option.dataset.ownerGroup = bb.ownergroup || '';
         bbSelector.appendChild(option);
     }
 
@@ -179,7 +179,7 @@ async function ExternalVanForm() {
             let body = {
                 name   : vanName.value,
                 tenant : 'false',
-                ownerGroup: bbSelector.selectedOptions[0].ownerGroup,
+                ownerGroup: bbSelector.selectedOptions[0]?.dataset.ownerGroup || '',
             };
             const response = await fetch(`api/v1alpha1/backbones/${bbSelector.value}/vans`, {
                 method: 'POST',

--- a/components/compose-web-app/modules/van.js
+++ b/components/compose-web-app/modules/van.js
@@ -219,6 +219,8 @@ async function MultiTenantVanForm() {
     let vanName = document.createElement('input');
     vanName.type = 'text';
 
+    const ownerGroupSelector = await OwnerGroupSelector();
+
     let bbSelector = document.createElement('select');
     const bbResult = await fetch('/api/v1alpha1/backbones');
     const bbList   = await bbResult.json();
@@ -226,7 +228,6 @@ async function MultiTenantVanForm() {
         let option = document.createElement('option');
         option.textContent = bb.name;
         option.value       = bb.id;
-        option.dataset.ownerGroup = bb.ownergroup || '';
         bbSelector.appendChild(option);
     }
 
@@ -284,6 +285,7 @@ async function MultiTenantVanForm() {
             ['Backbone:',   bbSelector],
             ['Start Time:', startTimeGroup],
             ['End Time:',   endTimeGroup],
+            ['Owner Group:', ownerGroupSelector],
         ],
 
         //
@@ -293,7 +295,7 @@ async function MultiTenantVanForm() {
             let body = {
                 name   : vanName.value,
                 tenant : 'true',
-                ownerGroup: bbSelector.selectedOptions[0]?.dataset.ownerGroup || '',
+                ownerGroup: ownerGroupSelector.value,
             };
             if (!startNow.checked) {
                 body.starttime = startTime.value;

--- a/components/compose-web-app/modules/van.js
+++ b/components/compose-web-app/modules/van.js
@@ -224,6 +224,7 @@ async function MultiTenantVanForm() {
         let option = document.createElement('option');
         option.textContent = bb.name;
         option.value       = bb.id;
+        option.dataset.ownerGroup = bb.ownergroup || '';
         bbSelector.appendChild(option);
     }
 
@@ -290,6 +291,7 @@ async function MultiTenantVanForm() {
             let body = {
                 name   : vanName.value,
                 tenant : 'true',
+                ownerGroup: bbSelector.selectedOptions[0]?.dataset.ownerGroup || '',
             };
             if (!startNow.checked) {
                 body.starttime = startTime.value;

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -49,7 +49,6 @@ const createBackbone = async function(req, res) {
             returnStatus = 201;
             res.status(returnStatus).json({id: result.rows[0].id});
         } catch (error) {
-            await client.query("ROLLBACK");
             returnStatus = 500;
             res.status(returnStatus).send(error.message);
         } finally {
@@ -114,7 +113,6 @@ const createBackboneSite = async function(req, res) {
             returnStatus = 201;
             res.status(returnStatus).json({id: siteId});
         } catch (error) {
-            await client.query("ROLLBACK");
             returnStatus = 500
             res.status(returnStatus).send(error.message);
         } finally {
@@ -173,7 +171,6 @@ const updateBackboneSite = async function(req, res) {
 
             res.status(returnStatus).end();
         } catch (error) {
-            await client.query("ROLLBACK");
             returnStatus = 500;
             res.status(returnStatus).send(error.message);
         } finally {
@@ -245,7 +242,6 @@ const createAccessPoint = async function(req, res) {
                 await ManageIngressAdded(sid);
             }
         } catch (error) {
-            await client.query("ROLLBACK");
             returnStatus = 500
             res.status(returnStatus).send(error.message);
         } finally {
@@ -333,7 +329,6 @@ const createBackboneLink = async function(req, res) {
                 Log(error.stack);
             }
         } catch (error) {
-            await client.query("ROLLBACK");
             returnStatus = 400;
             res.status(returnStatus).send(error.message);
         } finally {
@@ -390,7 +385,6 @@ const updateBackboneLink = async function(req, res) {
                 await LinkChanged(linkChanged, lid);
             }
         } catch (error) {
-            await client.query("ROLLBACK");
             returnStatus = 500;
             res.status(returnStatus).send(error.message);
         } finally {
@@ -433,7 +427,6 @@ const deleteBackbone = async function(req, res) {
         });
         res.status(returnStatus).end();
     } catch (error) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -485,7 +478,6 @@ const deleteBackboneSite = async function(req, res) {
 
         res.status(returnStatus).end();
     } catch (error) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.stack);
     } finally {
@@ -528,7 +520,6 @@ const deleteAccessPoint = async function(req, res) {
         await SiteIngressChanged(siteId, apid);
 
     } catch (error) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.stack);
     } finally {
@@ -576,7 +567,6 @@ const deleteBackboneLink = async function(req, res) {
             }
         }
     } catch (error) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.stack);
     } finally {
@@ -821,7 +811,8 @@ const listSiteIngresses = async function(req, res) {
                 return await client.query("SELECT Id, Name, Lifecycle, Failure, Kind, Hostname, Port FROM BackboneAccessPoints WHERE Id = $1 OR Id = $2 OR Id = $3 OR Id = $4",
                 [site.claimaccess, site.peeraccess, site.memberaccess, site.manageaccess]);
             }
-            return []
+            // Return empty result object with rows array
+            return { rows: [] };
         })
 
         res.json(result.rows);

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -36,7 +36,7 @@ const createBackbone = async function(req, res) {
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
             'name' : {type: 'string', optional: false},
-            'ownerGroup': {type: 'string', optional: true},
+            'ownerGroup': {type: 'string', optional: true, default: ''},
         });
 
         const client = await ClientFromPool();

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -889,7 +889,7 @@ export async function Initialize(app, keycloak) {
     .get(keycloak.protect('realm:backbone-owner'), listAccessPointsSite);      // LIST for Site
 
     app.route(API_PREFIX + 'backbones/:bid/accesspoints')
-    .get(keycloak.protect('realm:backbone-owner'), listAccessPointsBackbone);  // LIST for Backbone
+    .get(keycloak.protect('realm:can-list-accesspoints-backbone'), listAccessPointsBackbone);  // LIST for Backbone
 
     app.route(API_PREFIX + 'accesspoints/:apid')
     .get(keycloak.protect('realm:backbone-owner'), readAccessPoint)            // READ

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -850,11 +850,11 @@ export async function Initialize(app, keycloak) {
     // Backbones
     //========================================
 
-    app.route(API_PREFIX + 'backbones', keycloak.protect('realm:backbone-admin'))
-    .post(createBackbone)       // CREATE
-    .get(listBackbones);        // LIST
+    app.route(API_PREFIX + 'backbones')
+    .post(keycloak.protect('realm:backbone-admin'), createBackbone)       // CREATE
+    .get(keycloak.protect('realm:backbone-admin'), listBackbones);        // LIST
 
-    app.route(API_PREFIX + 'backbones/:bid', keycloak.protect('realm:backbone-admin'))
+    app.route(API_PREFIX + 'backbones/:bid')
     .get(listBackbones)         // READ
     .delete(deleteBackbone);    // DELETE
 
@@ -862,46 +862,46 @@ export async function Initialize(app, keycloak) {
     // Backbone/Interior Sites
     //========================================
 
-    app.route(API_PREFIX + 'backbones/:bid/sites', keycloak.protect('realm:backbone-admin'))
-    .post(createBackboneSite)     // CREATE
-    .get(listBackboneSites);      // LIST
+    app.route(API_PREFIX + 'backbones/:bid/sites')
+    .post(keycloak.protect('realm:backbone-admin'), createBackboneSite)     // CREATE
+    .get(keycloak.protect('realm:backbone-admin'), listBackboneSites);      // LIST
 
-    app.route(API_PREFIX + 'backbonesites/:sid', keycloak.protect('realm:backbone-admin'))
-    .get(listBackboneSites)       // READ
-    .put(updateBackboneSite)      // UPDATE
-    .delete(deleteBackboneSite);  // DELETE
+    app.route(API_PREFIX + 'backbonesites/:sid')
+    .get(keycloak.protect('realm:backbone-admin'), listBackboneSites)       // READ
+    .put(keycloak.protect('realm:backbone-admin'), updateBackboneSite)      // UPDATE
+    .delete(keycloak.protect('realm:backbone-admin'), deleteBackboneSite);  // DELETE
 
     //========================================
     // Interior Access Points
     //========================================
 
-    app.route(API_PREFIX + 'backbonesites/:sid/accesspoints', keycloak.protect('realm:backbone-admin'))
-    .post(createAccessPoint)         // CREATE
-    .get(listAccessPointsSite);      // LIST for Site
+    app.route(API_PREFIX + 'backbonesites/:sid/accesspoints')
+    .post(keycloak.protect('realm:backbone-admin'), createAccessPoint)         // CREATE
+    .get(keycloak.protect('realm:backbone-admin'), listAccessPointsSite);      // LIST for Site
 
-    app.route(API_PREFIX + 'backbones/:bid/accesspoints', keycloak.protect('realm:backbone-admin'))
-    .get(listAccessPointsBackbone);  // LIST for Backbone
+    app.route(API_PREFIX + 'backbones/:bid/accesspoints')
+    .get(keycloak.protect('realm:backbone-admin'), listAccessPointsBackbone);  // LIST for Backbone
 
-    app.route(API_PREFIX + 'accesspoints/:apid', keycloak.protect('realm:backbone-admin'))
-    .get(readAccessPoint)            // READ
-    .delete(deleteAccessPoint);      // DELETE
+    app.route(API_PREFIX + 'accesspoints/:apid')
+    .get(keycloak.protect('realm:backbone-admin'), readAccessPoint)            // READ
+    .delete(keycloak.protect('realm:backbone-admin'), deleteAccessPoint);      // DELETE
 
     //========================================
     // Interior Site Links
     //========================================
 
-    app.route(API_PREFIX + 'accesspoints/:apid/links', keycloak.protect('realm:backbone-admin'))
-    .post(createBackboneLink);
+    app.route(API_PREFIX + 'accesspoints/:apid/links')
+    .post(keycloak.protect('realm:backbone-admin'), createBackboneLink);
 
-    app.route(API_PREFIX + 'backbones/:bid/links', keycloak.protect('realm:backbone-admin'))
-    .get(listBackboneLinks);
+    app.route(API_PREFIX + 'backbones/:bid/links')
+    .get(keycloak.protect('realm:backbone-admin'), listBackboneLinks);
 
-    app.route(API_PREFIX + 'backbonesites/:sid/links', keycloak.protect('realm:backbone-admin'))
-    .get(listBackboneLinksForSite);
+    app.route(API_PREFIX + 'backbonesites/:sid/links')
+    .get(keycloak.protect('realm:backbone-admin'), listBackboneLinksForSite);
 
-    app.route(API_PREFIX + 'backbonelinks/:lid', keycloak.protect('realm:backbone-admin'))
-    .put(updateBackboneLink)
-    .delete(deleteBackboneLink);
+    app.route(API_PREFIX + 'backbonelinks/:lid')
+    .put(keycloak.protect('realm:backbone-admin'), updateBackboneLink)
+    .delete(keycloak.protect('realm:backbone-admin'), deleteBackboneLink);
 
     //========================================
     // Backbone Access Points

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -20,7 +20,7 @@
 "use strict";
 
 import { IncomingForm } from 'formidable';
-import { ClientFromPool } from './db.js';
+import { ClientFromPool, queryWithContext, convertArrayLiteral } from './db.js';
 import { SiteIngressChanged, LinkChanged } from './sync-management.js';
 import { Log } from '@skupperx/modules/log'
 import { ManageIngressAdded, LinkAddedOrDeleted, ManageIngressDeleted } from './site-deployment-state.js';
@@ -30,7 +30,7 @@ const API_PREFIX   = '/api/v1alpha1/';
 const INGRESS_LIST = ['claim', 'peer', 'member', 'manage'];
 
 const createBackbone = async function(req, res) {
-    var returnStatus;
+    let returnStatus;
     const form = new IncomingForm();
     try {
         const [fields, files] = await form.parse(req);
@@ -40,9 +40,11 @@ const createBackbone = async function(req, res) {
 
         const client = await ClientFromPool();
         try {
-            await client.query("BEGIN");
-            const result = await client.query("INSERT INTO Backbones(Name, LifeCycle) VALUES ($1, 'new') RETURNING Id", [norm.name]);
-            await client.query("COMMIT");
+            const result = await queryWithContext(req, client, async (client, credentials) => {
+                const ownerId = credentials.userId;
+                const ownerGroups = credentials.userGroups;
+                return await client.query("INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroups) VALUES ($1, 'new', $2, $3) RETURNING Id", [norm.name, ownerId, ownerGroups]);
+            });
 
             returnStatus = 201;
             res.status(returnStatus).json({id: result.rows[0].id});
@@ -62,12 +64,12 @@ const createBackbone = async function(req, res) {
 }
 
 const createBackboneSite = async function(req, res) {
-    var returnStatus;
+    let returnStatus;
     const bid = req.params.bid;
     const form = new IncomingForm();
     try {
         if (!IsValidUuid(bid)) {
-            throw(Error('Backbone-Id is not a valid uuid'));
+            throw new Error('Backbone-Id is not a valid uuid');
         }
 
         const [fields, files] = await form.parse(req)
@@ -79,35 +81,35 @@ const createBackboneSite = async function(req, res) {
 
         const client = await ClientFromPool();
         try {
-            await client.query("BEGIN");
-            var extraCols = "";
-            var extraVals = "";
+            let extraCols = "";
+            let extraVals = "";
 
-            //
-            // If the name is not unique within the backbone, modify it to be unique.
-            //
-            const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1", [bid]);
-            var existingNames = [];
-            for (const row of namesResult.rows) {
-                existingNames.push(row.name);
-            }
-            const uniqueName = UniquifyName(norm.name, existingNames);
+            const siteId = await queryWithContext(req, client, async (client) => {
+                const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1", [bid]);
 
-            //
-            // Handle the optional metadata
-            //
-            if (norm.metadata) {
-                extraCols += ', Metadata';
-                extraVals += `, '${norm.metadata}'`;
-            }
+                let existingNames = [];
+                for (const row of namesResult.rows) {
+                    existingNames.push(row.name);
+                }
+                const uniqueName = UniquifyName(norm.name, existingNames);
 
-            //
-            // Create the site
-            //
-            const result = await client.query(`INSERT INTO InteriorSites(Name, TargetPlatform, Backbone${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`,
-                                              [uniqueName, norm.platform, bid]);
-            const siteId = result.rows[0].id;
-            await client.query("COMMIT");
+                //
+                // Handle the optional metadata
+                //
+                if (norm.metadata) {
+                    extraCols += ', Metadata';
+                    extraVals += `, '${norm.metadata}'`;
+                }
+
+                //
+                // Create the site
+                //
+                const result = await client.query(`INSERT INTO InteriorSites(Name, TargetPlatform, Backbone${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`,
+                                                [uniqueName, norm.platform, bid]);
+                const site_id = result.rows[0].id;
+
+                return site_id
+            })
 
             returnStatus = 201;
             res.status(returnStatus).json({id: siteId});
@@ -127,7 +129,7 @@ const createBackboneSite = async function(req, res) {
 }
 
 const updateBackboneSite = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const sid = req.params.sid;
     const form = new IncomingForm();
     try {
@@ -143,30 +145,31 @@ const updateBackboneSite = async function(req, res) {
     
         const client = await ClientFromPool();
         try {
-            await client.query("BEGIN");
             let nameChanged   = false;
-            const siteResult = await client.query("SELECT * FROM InteriorSites WHERE Id = $1", [sid]);
-            if (siteResult.rowCount == 1) {
-                const site = siteResult.rows[0];
-                var   siteName = site.name;
 
-                //
-                // If the name has been changed, update the site record in the database
-                //
-                if (norm.name != null && norm.name != site.name) {
-                    nameChanged = true;
-                    await client.query("UPDATE InteriorSites SET Name = $1 WHERE Id = $2", [norm.name, sid]);
-                    siteName = norm.name;
-                }
+            await queryWithContext(req, client, async (client) => {
+                const siteResult = await client.query("SELECT * FROM InteriorSites WHERE Id = $1", [sid]);
+                if (siteResult.rowCount == 1) {
+                    const site = siteResult.rows[0];
+                    let siteName = site.name;
 
-                //
-                // Update the metadata if needed
-                //
-                if (norm.metadata != null && norm.metadata != site.metadata) {
-                    await client.query("UPDATE InteriorSites SET Metadata = $1 WHERE Id = $2", [norm.metadata, sid]);
+                    //
+                    // If the name has been changed, update the site record in the database
+                    //
+                    if (norm.name != null && norm.name != site.name) {
+                        nameChanged = true;
+                        await client.query("UPDATE InteriorSites SET Name = $1 WHERE Id = $2", [norm.name, sid]);
+                        siteName = norm.name;
+                    }
+
+                    //
+                    // Update the metadata if needed
+                    //
+                    if (norm.metadata != null && norm.metadata != site.metadata) {
+                        await client.query("UPDATE InteriorSites SET Metadata = $1 WHERE Id = $2", [norm.metadata, sid]);
+                    }
                 }
-            }
-            await client.query("COMMIT");
+            })
 
             res.status(returnStatus).end();
         } catch (error) {
@@ -202,33 +205,30 @@ const createAccessPoint = async function(req, res) {
 
         const client = await ClientFromPool();
         try {
-            await client.query("BEGIN");
-
-            const siteResult = await client.query("SELECT Name from InteriorSites WHERE Id = $1", [sid]);
-            if (siteResult.rowCount == 0) {
-                throw(Error(`Referenced interior site not found: ${sid}`));
-            }
-
-            var extraCols = "";
-            var extraVals = "";
-            const name = norm.name || norm.kind;
-
-            // TODO - If name will collide with another access point on the same site, add a differentiation number to the end
-
-            //
-            // Handle the optional bind host
-            //
-            if (norm.bindhost) {
-                extraCols += ', BindHost';
-                extraVals += `, '${norm.bindhost}'`;
-            }
-
-            //
-            // Create the access point
-            //
-            const result = await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`, [name, norm.kind, sid]);
+            const result = await queryWithContext(req, client, async (client) => {
+                const siteResult = await client.query("SELECT Name from InteriorSites WHERE Id = $1", [sid]);
+                if (siteResult.rowCount == 0) {
+                    throw new Error(`Referenced interior site not found: ${sid}`);
+                }
+                
+                let extraCols = "";
+                let extraVals = "";
+                const name = norm.name || norm.kind;
+                
+                // TODO - If name will collide with another access point on the same site, add a differentiation number to the end
+                
+                //
+                // Handle the optional bind host
+                //
+                if (norm.bindhost) {
+                    extraCols += ', BindHost';
+                    extraVals += `, '${norm.bindhost}'`;
+                }
+                
+                return await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`, [name, norm.kind, sid]);
+            })
+            
             const apId = result.rows[0].id;
-            await client.query("COMMIT");
 
             returnStatus = 201;
             res.status(returnStatus).json({id: apId});
@@ -265,7 +265,7 @@ const createBackboneLink = async function(req, res) {
     const form = new IncomingForm();
     try {
         if (!IsValidUuid(apid)) {
-            throw(Error('AccessPoint-Id is not a valid uuid'));
+            throw new Error('AccessPoint-Id is not a valid uuid');
         }
 
         const [fields, files] = await form.parse(req);
@@ -276,49 +276,92 @@ const createBackboneLink = async function(req, res) {
 
         const client = await ClientFromPool();
         try {
-            await client.query("BEGIN");
+            // await client.query("BEGIN");
 
-            //
-            // Get the referenced access point for validation
-            //
-            const accessResult = await client.query("SELECT Kind, InteriorSite, InteriorSites.Id as siteId, InteriorSites.Backbone FROM BackboneAccessPoints " +
-                                                    "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
-                                                    "WHERE BackboneAccessPoints.Id = $1", [apid]);
+            // //
+            // // Get the referenced access point for validation
+            // //
+            // const accessResult = await client.query("SELECT Kind, InteriorSite, InteriorSites.Id as siteId, InteriorSites.Backbone FROM BackboneAccessPoints " +
+            //                                         "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
+            //                                         "WHERE BackboneAccessPoints.Id = $1", [apid]);
 
-            //
-            // Validate that the referenced access point exists
-            //
-            if (accessResult.rowCount == 0) {
-                throw(Error(`Referenced access point not found: ${apid}`));
-            }
-            const accessPoint = accessResult.rows[0];
+            // //
+            // // Validate that the referenced access point exists
+            // //
+            // if (accessResult.rowCount == 0) {
+            //     throw(Error(`Referenced access point not found: ${apid}`));
+            // }
+            // const accessPoint = accessResult.rows[0];
 
-            //
-            // Validate that the referenced access point is of kind 'peer'
-            //
-            if (accessPoint.kind != 'peer') {
-                throw(Error(`Referenced access point must be 'peer', found '${accessPoint.kind}'`));
-            }
+            // //
+            // // Validate that the referenced access point is of kind 'peer'
+            // //
+            // if (accessPoint.kind != 'peer') {
+            //     throw(Error(`Referenced access point must be 'peer', found '${accessPoint.kind}'`));
+            // }
 
-            //
-            // Validate that the referenced site is in the specified backbone network
-            //
-            const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1", [norm.connectingsite]);
-            if (siteResult.rowCount == 0) {
-                throw(Error(`Referenced connecting site not found: ${norm.connectingsite}`));
-            }
+            // //
+            // // Validate that the referenced site is in the specified backbone network
+            // //
+            // const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1", [norm.connectingsite]);
+            // if (siteResult.rowCount == 0) {
+            //     throw(Error(`Referenced connecting site not found: ${norm.connectingsite}`));
+            // }
 
-            if (siteResult.rows[0].backbone != accessPoint.backbone) {
-                throw(Error(`Referenced connecting site is not in the same backbone network as the access-point`));
-            }
+            // if (siteResult.rows[0].backbone != accessPoint.backbone) {
+            //     throw(Error(`Referenced connecting site is not in the same backbone network as the access-point`));
+            // }
 
-            //
-            // Create the new link
-            //
-            const linkResult = await client.query("INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost) VALUES ($1, $2, $3) RETURNING Id", [apid, norm.connectingsite, norm.cost]);
+            // //
+            // // Create the new link
+            // //
+            // const linkResult = await client.query("INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost) VALUES ($1, $2, $3) RETURNING Id", [apid, norm.connectingsite, norm.cost]);
+            // const linkId = linkResult.rows[0].id;
+
+            // await client.query("COMMIT");
+
+            const linkResult = await queryWithContext(req, client, async (client) => {
+                //
+                // Get the referenced access point for validation
+                //
+                const accessResult = await client.query("SELECT Kind, InteriorSite, InteriorSites.Id as siteId, InteriorSites.Backbone FROM BackboneAccessPoints " +
+                                                        "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
+                                                        "WHERE BackboneAccessPoints.Id = $1", [apid]);
+
+                //
+                // Validate that the referenced access point exists
+                //
+                if (accessResult.rowCount == 0) {
+                    throw(Error(`Referenced access point not found: ${apid}`));
+                }
+                const accessPoint = accessResult.rows[0];
+
+                //
+                // Validate that the referenced access point is of kind 'peer'
+                //
+                if (accessPoint.kind != 'peer') {
+                    throw(Error(`Referenced access point must be 'peer', found '${accessPoint.kind}'`));
+                }
+
+                //
+                // Validate that the referenced site is in the specified backbone network
+                //
+                const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1", [norm.connectingsite]);
+                if (siteResult.rowCount == 0) {
+                    throw(Error(`Referenced connecting site not found: ${norm.connectingsite}`));
+                }
+
+                if (siteResult.rows[0].backbone != accessPoint.backbone) {
+                    throw(Error(`Referenced connecting site is not in the same backbone network as the access-point`));
+                }
+
+                //
+                // Create the new link
+                //
+                return await client.query("INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost) VALUES ($1, $2, $3) RETURNING Id", [apid, norm.connectingsite, norm.cost]);
+            })
+
             const linkId = linkResult.rows[0].id;
-
-            await client.query("COMMIT");
             returnStatus = 201;
             res.status(returnStatus).json({id: linkId});
 
@@ -363,22 +406,24 @@ const updateBackboneLink = async function(req, res) {
 
         const client = await ClientFromPool();
         try {
-            var linkChanged = null;
-            await client.query("BEGIN");
-            const linkResult = await client.query("SELECT * FROM InterRouterLinks WHERE Id = $1", [lid]);
-            if (linkResult.rowCount == 1) {
-                const link = linkResult.rows[0];
+            let linkChanged = null;
 
-                //
-                // If the cost has been changed, update the link record in the database
-                //
-                if (norm.cost != null && norm.cost != link.cost) {
-                    await client.query("UPDATE InterRouterLinks SET Cost = $1 WHERE Id = $2", [norm.cost, lid]);
-                    returnStatus = 200;
-                    linkChanged = link.connectinginteriorsite;
+            await queryWithContext(req, client, async (client) => {
+                const linkResult = await client.query("SELECT * FROM InterRouterLinks WHERE Id = $1", [lid]);
+                if (linkResult.rowCount == 1) {
+                    const link = linkResult.rows[0];
+
+                    //
+                    // If the cost has been changed, update the link record in the database
+                    //
+                    if (norm.cost != null && norm.cost != link.cost) {
+                        await client.query("UPDATE InterRouterLinks SET Cost = $1 WHERE Id = $2", [norm.cost, lid]);
+                        returnStatus = 200;
+                        linkChanged = link.connectinginteriorsite;
+                    }
                 }
-            }
-            await client.query("COMMIT");
+            })
+            
             res.status(returnStatus).end();
 
             //
@@ -404,35 +449,33 @@ const updateBackboneLink = async function(req, res) {
 
 
 const deleteBackbone = async function(req, res) {
-    var returnStatus = 204;
+    let returnStatus = 204;
     const bid = req.params.bid;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
         if (!IsValidUuid(bid)) {
-            throw(Error('Backbone-Id is not a valid uuid'));
+            throw new Error('Backbone-Id is not a valid uuid');
         }
 
-        const vanResult = await client.query("SELECT Id FROM ApplicationNetworks WHERE Backbone = $1 and LifeCycle = 'ready' LIMIT 1", [bid]);
-        if (vanResult.rowCount > 0) {
-            throw(Error('Cannot delete a backbone with active application networks'));
-        }
-        const siteResult = await client.query("SELECT Id FROM InteriorSites WHERE Backbone = $1 LIMIT 1", [bid]);
-        if (siteResult.rowCount > 0) {
-            throw(Error('Cannot delete a backbone with interior sites'));
-        }
-        const bbResult = await client.query("DELETE FROM Backbones WHERE Id = $1 RETURNING Certificate", [bid]);
-        if (bbResult.rowCount == 1) {
-            const row = bbResult.rows[0];
-            if (row.certificate) {
-                await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+        await queryWithContext(req, client, async (client) => {
+            const vanResult = await client.query("SELECT Id FROM ApplicationNetworks WHERE Backbone = $1 and LifeCycle = 'ready' LIMIT 1", [bid]);
+            if (vanResult.rowCount > 0) {
+                throw new Error('Cannot delete a backbone with active application networks');
             }
-        }
-        await client.query("COMMIT");
-
+            const siteResult = await client.query("SELECT Id FROM InteriorSites WHERE Backbone = $1 LIMIT 1", [bid]);
+            if (siteResult.rowCount > 0) {
+                throw new Error('Cannot delete a backbone with interior sites');
+            }
+            const bbResult = await client.query("DELETE FROM Backbones WHERE Id = $1 RETURNING Certificate", [bid]);
+            if (bbResult.rowCount == 1) {
+                const row = bbResult.rows[0];
+                if (row.certificate) {
+                    await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                }
+            }
+        });
         res.status(returnStatus).end();
     } catch (error) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -443,18 +486,18 @@ const deleteBackbone = async function(req, res) {
 }
 
 const deleteBackboneSite = async function(req, res) {
-    var returnStatus = 204;
+    let returnStatus = 204;
     const sid = req.params.sid;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
         if (!IsValidUuid(sid)) {
-            throw(Error('Site-Id is not a valid uuid'));
+            throw new Error('Site-Id is not a valid uuid');
         }
 
-        const result = await client.query("SELECT Certificate FROM InteriorSites WHERE Id = $1", [sid]);
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query("SELECT Certificate FROM InteriorSites WHERE Id = $1", [sid]);
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
 
             //
             // Delete all of the site's access points
@@ -468,19 +511,19 @@ const deleteBackboneSite = async function(req, res) {
                 await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1", [row.id]);
             }
 
-            //
-            // Delete the site.  Note that involved inter-router links will be automatically deleted by the database.
-            //
-            await client.query("DELETE FROM InteriorSites WHERE Id = $1", [sid]);
+                //
+                // Delete the site.  Note that involved inter-router links will be automatically deleted by the database.
+                //
+                await client.query("DELETE FROM InteriorSites WHERE Id = $1", [sid]);
 
-            //
-            // Delete the TLS certificate
-            //
-            if (row.certificate) {
-                await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate])
+                //
+                // Delete the TLS certificate
+                //
+                if (row.certificate) {
+                    await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate])
+                }
             }
-        }
-        await client.query("COMMIT");
+        })
 
         res.status(returnStatus).end();
     } catch (error) {
@@ -501,23 +544,24 @@ const deleteAccessPoint = async function(req, res) {
     var wasManage = false;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
         if (!IsValidUuid(apid)) {
-            throw(Error('AccessPoint-Id is not a valid uuid'));
+            throw new Error('AccessPoint-Id is not a valid uuid');
         }
 
-        const apResult = await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 Returning Certificate, Kind, InteriorSite", [apid]);
-        if (apResult.rowCount == 1) {
-            const row = apResult.rows[0];
-            if (row.certificate) {
-                await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+        await queryWithContext(req, client, async (client) => {
+            const apResult = await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 Returning Certificate, Kind, InteriorSite", [apid]);
+            if (apResult.rowCount == 1) {
+                const row = apResult.rows[0];
+                if (row.certificate) {
+                    await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                }
+                siteId = row.interiorsite;
+                if (row.kind == 'manage') {
+                    wasManage = true;
+                }
             }
-            siteId = row.interiorsite;
-            if (row.kind == 'manage') {
-                wasManage = true;
-            }
-        }
-        await client.query("COMMIT");
+        })
+
         res.status(returnStatus).end();
 
         //
@@ -541,23 +585,24 @@ const deleteAccessPoint = async function(req, res) {
 }
 
 const deleteBackboneLink = async function(req, res) {
-    var returnStatus = 204;
+    let returnStatus = 204;
     const lid = req.params.lid;
     const client = await ClientFromPool();
     try {
-        var connectingSite = null;
-        var accessPoint    = null;
-        await client.query("BEGIN");
+        let connectingSite = null;
+        let accessPoint    = null;
         if (!IsValidUuid(lid)) {
-            throw(Error('Link-Id is not a valid uuid'));
+            throw new Error('Link-Id is not a valid uuid');
         }
 
-        const result = await client.query("DELETE FROM InterRouterLinks WHERE Id = $1 RETURNING ConnectingInteriorSite, AccessPoint", [lid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("DELETE FROM InterRouterLinks WHERE Id = $1 RETURNING ConnectingInteriorSite, AccessPoint", [lid]);
+        })
         if (result.rowCount == 1) {
             connectingSite = result.rows[0].connectinginteriorsite;
             accessPoint    = result.rows[0].accesspoint;
         }
-        await client.query("COMMIT");
+        
         res.status(returnStatus).end();
 
         //
@@ -584,20 +629,20 @@ const deleteBackboneLink = async function(req, res) {
 }
 
 const listBackbones = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const bid = req.params.bid;
     const client = await ClientFromPool();
     try {
-        var result;
-        if (bid) {
-            if (!IsValidUuid(bid)) {
-                throw(Error('Backbone-Id is not a valid uuid'));
-            }
 
-            result = await client.query("SELECT Id, Name, Lifecycle, Failure FROM Backbones WHERE Id = $1", [bid]);
-        } else {
-            result = await client.query("SELECT Id, Name, Lifecycle, Failure FROM Backbones");
-        }
+        const result = await queryWithContext(req, client, async (client) => {
+            if (bid) {
+                if (!IsValidUuid(bid)) {
+                    throw new Error('Backbone-Id is not a valid uuid');
+                }
+                return await client.query("SELECT Id, Name, Lifecycle, Failure FROM Backbones WHERE Id = $1", [bid]);
+            }
+            return await client.query("SELECT Id, Name, Lifecycle, Failure FROM Backbones");
+        });
 
         if (bid) {
             if (result.rowCount < 1) {
@@ -618,39 +663,41 @@ const listBackbones = async function(req, res) {
 }
 
 const listBackboneSites = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const bid = req.params.bid;
     const sid = req.params.sid;
-    var byBackbone;
-    var id;
+    let byBackbone;
+    let id;
     const client = await ClientFromPool();
     try {
         if (bid) {
             if (!IsValidUuid(bid)) {
-                throw(Error('Id is not a valid uuid'));
+                throw new Error('Id is not a valid uuid');
             }
             byBackbone = true;
             id = bid;
         } else if (sid) {
             if (!IsValidUuid(sid)) {
-                throw(Error('Id is not a valid uuid'));
+                throw new Error('Id is not a valid uuid');
             }
             byBackbone = false;
             id = sid;
         }
 
-        const result = await client.query("SELECT InteriorSites.Id, Name, Lifecycle, Failure, Metadata, DeploymentState, TargetPlatform, FirstActiveTime, LastHeartbeat, " +
-                                          "TlsCertificates.expiration as tlsexpiration, TlsCertificates.renewalTime as tlsrenewal, TargetPlatforms.LongName as PlatformLong " +
-                                          "FROM InteriorSites " +
-                                          "LEFT OUTER JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
-                                          "JOIN TargetPlatforms ON TargetPlatforms.ShortName = TargetPlatform " +
-                                          `WHERE ${byBackbone ? 'Backbone' : 'InteriorSites.Id'} = $1`, [id]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT InteriorSites.Id, Name, Lifecycle, Failure, Metadata, DeploymentState, TargetPlatform, FirstActiveTime, LastHeartbeat, " +
+                                      "TlsCertificates.expiration as tlsexpiration, TlsCertificates.renewalTime as tlsrenewal, TargetPlatforms.LongName as PlatformLong " +
+                                      "FROM InteriorSites " +
+                                      "LEFT OUTER JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
+                                      "JOIN TargetPlatforms ON TargetPlatforms.ShortName = TargetPlatform " +
+                                      `WHERE ${byBackbone ? 'Backbone' : 'InteriorSites.Id'} = $1`, [id]);
+        })
 
         if (byBackbone) {
             res.json(result.rows);
         } else {
             if (result.rowCount == 0) {
-                throw(Error('Not found'));
+                throw new Error('Not found');
             }
             res.json(result.rows[0]);
         }
@@ -666,22 +713,21 @@ const listBackboneSites = async function(req, res) {
 }
 
 const listAccessPointsBackbone = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const bid = req.params.bid;
     const client = await ClientFromPool();
     try {
         if (!IsValidUuid(bid)) {
-            throw(Error('Id is not a valid uuid'));
+            throw new Error('Id is not a valid uuid');
         }
-
-        const result = await client.query("SELECT BackboneAccessPoints.Id, BackboneAccessPoints.Name, BackboneAccessPoints.Lifecycle, BackboneAccessPoints.Failure, Hostname, Port, Kind, Bindhost, InteriorSite, InteriorSites.Name as sitename FROM BackboneAccessPoints " +
-                                          "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
-                                          "WHERE InteriorSites.Backbone = $1", [bid]);
-        var list = [];
-        result.rows.forEach(row => {
-            list.push(row);
-        });
-        res.json(list);
+        
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT BackboneAccessPoints.Id, BackboneAccessPoints.Name, BackboneAccessPoints.Lifecycle, BackboneAccessPoints.Failure, Hostname, Port, Kind, Bindhost, InteriorSite, InteriorSites.Name as sitename FROM BackboneAccessPoints " +
+                                      "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
+                                      "WHERE InteriorSites.Backbone = $1", [bid]);
+        })
+        
+        res.json(result.rows);
         res.status(returnStatus).end();
     } catch (error) {
         returnStatus = 400;
@@ -694,21 +740,20 @@ const listAccessPointsBackbone = async function(req, res) {
 }
 
 const listAccessPointsSite = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const sid = req.params.sid;
     const client = await ClientFromPool();
     try {
         if (!IsValidUuid(sid)) {
-            throw(Error('Id is not a valid uuid'));
+            throw new Error('Id is not a valid uuid');
         }
 
-        const result = await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost FROM BackboneAccessPoints " +
-                                          "WHERE InteriorSite = $1", [sid]);
-        var list = [];
-        result.rows.forEach(row => {
-            list.push(row);
-        });
-        res.json(list);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost FROM BackboneAccessPoints " +
+                                      "WHERE InteriorSite = $1", [sid]);
+        })
+        
+        res.json(result.rows);
         res.status(returnStatus).end();
     } catch (error) {
         returnStatus = 400;
@@ -721,18 +766,21 @@ const listAccessPointsSite = async function(req, res) {
 }
 
 const readAccessPoint = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const apid = req.params.apid;
     const client = await ClientFromPool();
     try {
         if (!IsValidUuid(apid)) {
-            throw(Error('Id is not a valid uuid'));
+            throw new Error('Id is not a valid uuid');
         }
 
-        const result = await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost, InteriorSite FROM BackboneAccessPoints " +
-                                          "WHERE Id = $1", [apid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost, InteriorSite FROM BackboneAccessPoints " +
+                                      "WHERE Id = $1", [apid]);
+        })
+
         if (result.rowCount == 0) {
-            throw(Error("Not found"));
+            throw new Error("Not found");
         }
 
         res.json(result.rows[0]);
@@ -748,43 +796,20 @@ const readAccessPoint = async function(req, res) {
 }
 
 const listBackboneLinks = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const bid = req.params.bid;
     const client = await ClientFromPool();
     try {
         if (!IsValidUuid(bid)) {
-            throw(Error('Backbone-Id is not a valid uuid'));
+            throw new Error('Backbone-Id is not a valid uuid');
         }
 
-        const result = await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks " +
-                                          "JOIN InteriorSites ON InterRouterLinks.ConnectingInteriorSite = InteriorSites.Id " +
-                                          "WHERE InteriorSites.Backbone = $1", [bid]);
-        var list = [];
-        result.rows.forEach(row => {
-            list.push(row);
-        });
-        res.json(list);
-        res.status(returnStatus).end();
-    } catch (error) {
-        returnStatus = 400;
-        res.status(returnStatus).send(error.message);
-    } finally {
-        client.release();
-    }
-
-    return returnStatus;
-}
-
-const listBackboneLinksForSite = async function(req, res) {
-    var returnStatus = 200;
-    const sid = req.params.sid;
-    const client = await ClientFromPool();
-    try {
-        if (!IsValidUuid(sid)) {
-            throw(Error('Site-Id is not a valid uuid'));
-        }
-
-        const result = await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks WHERE ConnectingInteriorSite = $1", [sid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks " +
+                                      "JOIN InteriorSites ON InterRouterLinks.ConnectingInteriorSite = InteriorSites.Id " +
+                                      "WHERE InteriorSites.Backbone = $1", [bid]);
+        })
+        
         res.json(result.rows);
         res.status(returnStatus).end();
     } catch (error) {
@@ -797,26 +822,20 @@ const listBackboneLinksForSite = async function(req, res) {
     return returnStatus;
 }
 
-const listSiteIngresses = async function(sid, res) {
-    var returnStatus = 200;
+const listBackboneLinksForSite = async function(req, res) {
+    let returnStatus = 200;
+    const sid = req.params.sid;
     const client = await ClientFromPool();
     try {
         if (!IsValidUuid(sid)) {
-            throw(Error('Site-Id is not a valid uuid'));
+            throw new Error('Site-Id is not a valid uuid');
         }
 
-        const sites = await client.query("SELECT ClaimAccess, PeerAccess, MemberAccess, ManageAccess FROM InteriorSites WHERE Id = $1", [sid]);
-        var list = [];
-        if (sites.rowCount == 1) {
-            const site = sites.rows[0];
-            const result = await client.query("SELECT Id, Name, Lifecycle, Failure, Kind, Hostname, Port FROM BackboneAccessPoints WHERE Id = $1 OR Id = $2 OR Id = $3 OR Id = $4",
-            [site.claimaccess, site.peeraccess, site.memberaccess, site.manageaccess]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks WHERE ConnectingInteriorSite = $1", [sid]);
+        })
 
-            result.rows.forEach(row => {
-                list.push(row);
-            });
-        }
-        res.json(list);
+        res.json(result.rows);
         res.status(returnStatus).end();
     } catch (error) {
         returnStatus = 400;
@@ -828,15 +847,46 @@ const listSiteIngresses = async function(sid, res) {
     return returnStatus;
 }
 
-const listInvitations = async function(res) {
-    var returnStatus = 200;
+const listSiteIngresses = async function(req, res) {
+    let returnStatus = 200;
+    const sid = req.params.sid;
     const client = await ClientFromPool();
-    const result = await client.query("SELECT Id, Name, Lifecycle, Failure FROM MemberInvitations");
-    var list = [];
-    result.rows.forEach(row => {
-        list.push(row);
-    });
-    res.send(JSON.stringify(list));
+    try {
+        if (!IsValidUuid(sid)) {
+            throw new Error('Site-Id is not a valid uuid');
+        }
+
+        const result = await queryWithContext(req, client, async (client) => {
+            const sites = await client.query("SELECT ClaimAccess, PeerAccess, MemberAccess, ManageAccess FROM InteriorSites WHERE Id = $1", [sid]);
+            if (sites.rowCount == 1) {
+                const site = sites.rows[0];
+                return await client.query("SELECT Id, Name, Lifecycle, Failure, Kind, Hostname, Port FROM BackboneAccessPoints WHERE Id = $1 OR Id = $2 OR Id = $3 OR Id = $4",
+                [site.claimaccess, site.peeraccess, site.memberaccess, site.manageaccess]);
+            }
+            return []
+        })
+
+        res.json(result.rows);
+        res.status(returnStatus).end();
+    } catch (error) {
+        returnStatus = 400;
+        res.status(returnStatus).send(error.message);
+    } finally {
+        client.release();
+    }
+
+    return returnStatus;
+}
+
+const listInvitations = async function(req, res) {
+    let returnStatus = 200;
+    const client = await ClientFromPool();
+    
+    const result = await queryWithContext(req, client, async (client) => {
+        return await client.query("SELECT Id, Name, Lifecycle, Failure FROM MemberInvitations")
+    })
+
+    res.send(JSON.stringify(result.rows));
     res.status(returnStatus).end();
     client.release();
 
@@ -852,11 +902,11 @@ export async function Initialize(app, keycloak) {
 
     app.route(API_PREFIX + 'backbones')
     .post(keycloak.protect('realm:backbone-admin'), createBackbone)       // CREATE
-    .get(keycloak.protect('realm:backbone-admin'), listBackbones);        // LIST
+    .get(keycloak.protect(), listBackbones);                              // LIST
 
     app.route(API_PREFIX + 'backbones/:bid')
-    .get(listBackbones)         // READ
-    .delete(deleteBackbone);    // DELETE
+    .get(keycloak.protect('realm:backbone-admin'), listBackbones)         // READ
+    .delete(keycloak.protect('realm:backbone-admin'), deleteBackbone);    // DELETE
 
     //========================================
     // Backbone/Interior Sites
@@ -880,7 +930,7 @@ export async function Initialize(app, keycloak) {
     .get(keycloak.protect('realm:backbone-admin'), listAccessPointsSite);      // LIST for Site
 
     app.route(API_PREFIX + 'backbones/:bid/accesspoints')
-    .get(keycloak.protect('realm:backbone-admin'), listAccessPointsBackbone);  // LIST for Backbone
+    .get(keycloak.protect(), listAccessPointsBackbone);  // LIST for Backbone
 
     app.route(API_PREFIX + 'accesspoints/:apid')
     .get(keycloak.protect('realm:backbone-admin'), readAccessPoint)            // READ
@@ -907,10 +957,10 @@ export async function Initialize(app, keycloak) {
     // Backbone Access Points
     //========================================
     app.get(API_PREFIX + 'backbonesites/:sid/ingresses', keycloak.protect(), async (req, res) => {
-        await listSiteIngresses(req.params.sid, res);
+        await listSiteIngresses(req, res);
     });
 
     app.get(API_PREFIX + 'invitations', keycloak.protect(), async (req, res) => {
-        await listInvitations(res);
+        await listInvitations(req, res);
     });
 }

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -35,8 +35,8 @@ const createBackbone = async function(req, res) {
     try {
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
-            'name': { type: 'string', optional: false },
-            'ownerGroup': { type: 'string', optional: true },
+            'name' : {type: 'string', optional: false},
+            'ownerGroup': {type: 'string', optional: true},
         });
 
         const client = await ClientFromPool();
@@ -83,6 +83,9 @@ const createBackboneSite = async function(req, res) {
             let extraVals = "";
 
             const siteId = await queryWithContext(req, client, async (client) => {
+                 //
+                // If the name is not unique within the backbone, modify it to be unique.
+                //
                 const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1", [bid]);
 
                 let existingNames = [];
@@ -221,6 +224,9 @@ const createAccessPoint = async function(req, res) {
                     extraVals += `, '${norm.bindhost}'`;
                 }
                 
+                //
+                // Create the access point
+                //
                 return await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`, [name, norm.kind, sid]);
             })
             

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -872,66 +872,66 @@ export async function Initialize(app, keycloak) {
     //========================================
 
     app.route(API_PREFIX + 'backbones')
-    .post(keycloak.protect('realm:can-create-backbone'), createBackbone)       // CREATE
+    .post(keycloak.protect('realm:backbone-owner'), createBackbone)       // CREATE
     .get(keycloak.protect('realm:can-list-backbones'), listBackbones);        // LIST
 
     app.route(API_PREFIX + 'backbones/:bid')
     .get(keycloak.protect('realm:can-list-backbones'), listBackbones)         // READ
-    .delete(keycloak.protect('realm:can-delete-backbone'), deleteBackbone);    // DELETE
+    .delete(keycloak.protect('realm:backbone-owner'), deleteBackbone);    // DELETE
 
     //========================================
     // Backbone/Interior Sites
     //========================================
 
     app.route(API_PREFIX + 'backbones/:bid/sites')
-    .post(keycloak.protect('realm:can-create-backbone-site'), createBackboneSite)     // CREATE
-    .get(keycloak.protect('realm:can-list-backbone-sites'), listBackboneSites);      // LIST
+    .post(keycloak.protect('realm:backbone-owner'), createBackboneSite)     // CREATE
+    .get(keycloak.protect('realm:backbone-owner'), listBackboneSites);      // LIST
 
     app.route(API_PREFIX + 'backbonesites/:sid')
-    .get(keycloak.protect('realm:can-list-backbone-sites'), listBackboneSites)       // READ
-    .put(keycloak.protect('realm:can-update-backbone-site'), updateBackboneSite)      // UPDATE
-    .delete(keycloak.protect('realm:can-delete-backbone-site'), deleteBackboneSite);  // DELETE
+    .get(keycloak.protect('realm:backbone-owner'), listBackboneSites)       // READ
+    .put(keycloak.protect('realm:backbone-owner'), updateBackboneSite)      // UPDATE
+    .delete(keycloak.protect('realm:backbone-owner'), deleteBackboneSite);  // DELETE
 
     //========================================
     // Interior Access Points
     //========================================
 
     app.route(API_PREFIX + 'backbonesites/:sid/accesspoints')
-    .post(keycloak.protect('realm:can-create-access-point'), createAccessPoint)         // CREATE
-    .get(keycloak.protect('realm:can-list-access-points-site'), listAccessPointsSite);      // LIST for Site
+    .post(keycloak.protect('realm:backbone-owner'), createAccessPoint)         // CREATE
+    .get(keycloak.protect('realm:backbone-owner'), listAccessPointsSite);      // LIST for Site
 
     app.route(API_PREFIX + 'backbones/:bid/accesspoints')
-    .get(keycloak.protect('realm:can-list-access-points-backbone'), listAccessPointsBackbone);  // LIST for Backbone
+    .get(keycloak.protect('realm:backbone-owner'), listAccessPointsBackbone);  // LIST for Backbone
 
     app.route(API_PREFIX + 'accesspoints/:apid')
-    .get(keycloak.protect('realm:can-read-access-point'), readAccessPoint)            // READ
-    .delete(keycloak.protect('realm:can-delete-access-point'), deleteAccessPoint);      // DELETE
+    .get(keycloak.protect('realm:backbone-owner'), readAccessPoint)            // READ
+    .delete(keycloak.protect('realm:backbone-owner'), deleteAccessPoint);      // DELETE
 
     //========================================
     // Interior Site Links
     //========================================
 
     app.route(API_PREFIX + 'accesspoints/:apid/links')
-    .post(keycloak.protect('realm:can-create-backbone-link'), createBackboneLink);
+    .post(keycloak.protect('realm:backbone-owner'), createBackboneLink);
 
     app.route(API_PREFIX + 'backbones/:bid/links')
-    .get(keycloak.protect('realm:can-list-backbone-links'), listBackboneLinks);
+    .get(keycloak.protect('realm:backbone-owner'), listBackboneLinks);
 
     app.route(API_PREFIX + 'backbonesites/:sid/links')
-    .get(keycloak.protect('realm:can-list-backbone-links-for-site'), listBackboneLinksForSite);
+    .get(keycloak.protect('realm:backbone-owner'), listBackboneLinksForSite);
 
     app.route(API_PREFIX + 'backbonelinks/:lid')
-    .put(keycloak.protect('realm:can-update-backbone-link'), updateBackboneLink)
-    .delete(keycloak.protect('realm:can-delete-backbone-link'), deleteBackboneLink);
+    .put(keycloak.protect('realm:backbone-owner'), updateBackboneLink)
+    .delete(keycloak.protect('realm:backbone-owner'), deleteBackboneLink);
 
     //========================================
     // Backbone Access Points
     //========================================
-    app.get(API_PREFIX + 'backbonesites/:sid/ingresses', keycloak.protect('realm:can-list-site-ingresses'), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesites/:sid/ingresses', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         await listSiteIngresses(req, res);
     });
 
-    app.get(API_PREFIX + 'invitations', keycloak.protect('realm:can-list-invitations'), async (req, res) => {
+    app.get(API_PREFIX + 'invitations', keycloak.protect('realm:van-owner'), async (req, res) => {
         await listInvitations(req, res);
     });
 }

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -41,9 +41,8 @@ const createBackbone = async function(req, res) {
 
         const client = await ClientFromPool();
         try {
-            const result = await queryWithContext(req, client, async (client, credentials) => {
-                const ownerId = credentials.userId;
-                return await client.query("INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroup) VALUES ($1, 'new', $2, $3) RETURNING Id", [norm.name, ownerId, norm.ownerGroup]);
+            const result = await queryWithContext(req, client, async (client, userInfo) => {
+                return await client.query("INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroup) VALUES ($1, 'new', $2, $3) RETURNING Id", [norm.name, userInfo.userId, norm.ownerGroup]);
             });
 
             returnStatus = 201;
@@ -408,8 +407,10 @@ const deleteBackbone = async function(req, res) {
             throw new Error('Backbone-Id is not a valid uuid');
         }
 
-        await queryWithContext(req, client, async (client) => {
-            const vanResult = await client.query("SELECT Id FROM ApplicationNetworks WHERE Backbone = $1 and LifeCycle = 'ready' LIMIT 1", [bid]);
+        await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups;
+            const vanResult = await client.query("SELECT Id FROM ApplicationNetworks WHERE Backbone = $1 and LifeCycle = 'ready' and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) LIMIT 1", [bid, userId, userGroups]);
             if (vanResult.rowCount > 0) {
                 throw new Error('Cannot delete a backbone with active application networks');
             }
@@ -417,7 +418,7 @@ const deleteBackbone = async function(req, res) {
             if (siteResult.rowCount > 0) {
                 throw new Error('Cannot delete a backbone with interior sites');
             }
-            const bbResult = await client.query("DELETE FROM Backbones WHERE Id = $1 RETURNING Certificate", [bid]);
+            const bbResult = await client.query("DELETE FROM Backbones WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING Certificate", [bid, userId, userGroups]);
             if (bbResult.rowCount == 1) {
                 const row = bbResult.rows[0];
                 if (row.certificate) {
@@ -582,14 +583,16 @@ const listBackbones = async function(req, res) {
     const client = await ClientFromPool();
     try {
 
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups;
             if (bid) {
                 if (!IsValidUuid(bid)) {
                     throw new Error('Backbone-Id is not a valid uuid');
                 }
-                return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE Id = $1", [bid]);
+                return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userId, userGroups]);
             }
-            return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones");
+            return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE (Owner = $1 or OwnerGroup = Any($2) or is_admin())", [userId, userGroups]);
         });
 
         if (bid) {

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -20,7 +20,7 @@
 "use strict";
 
 import { IncomingForm } from 'formidable';
-import { ClientFromPool, queryWithContext, convertArrayLiteral } from './db.js';
+import { ClientFromPool, queryWithContext } from './db.js';
 import { SiteIngressChanged, LinkChanged } from './sync-management.js';
 import { Log } from '@skupperx/modules/log'
 import { ManageIngressAdded, LinkAddedOrDeleted, ManageIngressDeleted } from './site-deployment-state.js';
@@ -35,15 +35,15 @@ const createBackbone = async function(req, res) {
     try {
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
-            'name' : {type: 'string', optional: false},
+            'name': { type: 'string', optional: false },
+            'ownerGroup': { type: 'string', optional: true },
         });
 
         const client = await ClientFromPool();
         try {
             const result = await queryWithContext(req, client, async (client, credentials) => {
                 const ownerId = credentials.userId;
-                const ownerGroups = credentials.userGroups;
-                return await client.query("INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroups) VALUES ($1, 'new', $2, $3) RETURNING Id", [norm.name, ownerId, ownerGroups]);
+                return await client.query("INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroup) VALUES ($1, 'new', $2, $3) RETURNING Id", [norm.name, ownerId, norm.ownerGroup]);
             });
 
             returnStatus = 201;
@@ -276,49 +276,6 @@ const createBackboneLink = async function(req, res) {
 
         const client = await ClientFromPool();
         try {
-            // await client.query("BEGIN");
-
-            // //
-            // // Get the referenced access point for validation
-            // //
-            // const accessResult = await client.query("SELECT Kind, InteriorSite, InteriorSites.Id as siteId, InteriorSites.Backbone FROM BackboneAccessPoints " +
-            //                                         "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
-            //                                         "WHERE BackboneAccessPoints.Id = $1", [apid]);
-
-            // //
-            // // Validate that the referenced access point exists
-            // //
-            // if (accessResult.rowCount == 0) {
-            //     throw(Error(`Referenced access point not found: ${apid}`));
-            // }
-            // const accessPoint = accessResult.rows[0];
-
-            // //
-            // // Validate that the referenced access point is of kind 'peer'
-            // //
-            // if (accessPoint.kind != 'peer') {
-            //     throw(Error(`Referenced access point must be 'peer', found '${accessPoint.kind}'`));
-            // }
-
-            // //
-            // // Validate that the referenced site is in the specified backbone network
-            // //
-            // const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1", [norm.connectingsite]);
-            // if (siteResult.rowCount == 0) {
-            //     throw(Error(`Referenced connecting site not found: ${norm.connectingsite}`));
-            // }
-
-            // if (siteResult.rows[0].backbone != accessPoint.backbone) {
-            //     throw(Error(`Referenced connecting site is not in the same backbone network as the access-point`));
-            // }
-
-            // //
-            // // Create the new link
-            // //
-            // const linkResult = await client.query("INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost) VALUES ($1, $2, $3) RETURNING Id", [apid, norm.connectingsite, norm.cost]);
-            // const linkId = linkResult.rows[0].id;
-
-            // await client.query("COMMIT");
 
             const linkResult = await queryWithContext(req, client, async (client) => {
                 //
@@ -476,6 +433,7 @@ const deleteBackbone = async function(req, res) {
         });
         res.status(returnStatus).end();
     } catch (error) {
+        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -639,9 +597,9 @@ const listBackbones = async function(req, res) {
                 if (!IsValidUuid(bid)) {
                     throw new Error('Backbone-Id is not a valid uuid');
                 }
-                return await client.query("SELECT Id, Name, Lifecycle, Failure FROM Backbones WHERE Id = $1", [bid]);
+                return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE Id = $1", [bid]);
             }
-            return await client.query("SELECT Id, Name, Lifecycle, Failure FROM Backbones");
+            return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones");
         });
 
         if (bid) {

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -87,7 +87,7 @@ const createBackboneSite = async function(req, res) {
                  //
                 // If the name is not unique within the backbone, modify it to be unique.
                 //
-                const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
+                const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1", [bid]);
 
                 let existingNames = [];
                 for (const row of namesResult.rows) {
@@ -148,10 +148,8 @@ const updateBackboneSite = async function(req, res) {
         try {
             let nameChanged   = false;
 
-            await queryWithContext(req, client, async (client, userInfo) => {
-                const userId = userInfo.userId;
-                const userGroups = userInfo.userGroups;
-                const siteResult = await client.query("SELECT * FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
+            await queryWithContext(req, client, async (client) => {
+                const siteResult = await client.query("SELECT * FROM InteriorSites WHERE Id = $1", [sid]);
                 if (siteResult.rowCount == 1) {
                     const site = siteResult.rows[0];
                     let siteName = site.name;
@@ -161,7 +159,7 @@ const updateBackboneSite = async function(req, res) {
                     //
                     if (norm.name != null && norm.name != site.name) {
                         nameChanged = true;
-                        await client.query("UPDATE InteriorSites SET Name = $1 WHERE Id = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [norm.name, sid, userId, userGroups]);
+                        await client.query("UPDATE InteriorSites SET Name = $1 WHERE Id = $2", [norm.name, sid]);
                         siteName = norm.name;
                     }
 
@@ -169,7 +167,7 @@ const updateBackboneSite = async function(req, res) {
                     // Update the metadata if needed
                     //
                     if (norm.metadata != null && norm.metadata != site.metadata) {
-                        await client.query("UPDATE InteriorSites SET Metadata = $1 WHERE Id = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [norm.metadata, sid, userId, userGroups]);
+                        await client.query("UPDATE InteriorSites SET Metadata = $1 WHERE Id = $2", [norm.metadata, sid]);
                     }
                 }
             })
@@ -210,8 +208,7 @@ const createAccessPoint = async function(req, res) {
         try {
             const result = await queryWithContext(req, client, async (client, userInfo) => {
                 const userId = userInfo.userId;
-                const userGroups = userInfo.userGroups;
-                const siteResult = await client.query("SELECT Name from InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
+                const siteResult = await client.query("SELECT Name from InteriorSites WHERE Id = $1", [sid]);
                 if (siteResult.rowCount == 0) {
                     throw new Error(`Referenced interior site not found: ${sid}`);
                 }
@@ -287,13 +284,12 @@ const createBackboneLink = async function(req, res) {
 
             const linkResult = await queryWithContext(req, client, async (client, userInfo) => {
                 const userId = userInfo.userId;
-                const userGroups = userInfo.userGroups;
                 //
                 // Get the referenced access point for validation
                 //
                 const accessResult = await client.query("SELECT Kind, InteriorSite, InteriorSites.Id as siteId, InteriorSites.Backbone FROM BackboneAccessPoints " +
                                                         "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
-                                                        "WHERE BackboneAccessPoints.Id = $1 and (BackboneAccessPoints.Owner = $2 or BackboneAccessPoints.OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]);
+                                                        "WHERE BackboneAccessPoints.Id = $1", [apid]);
 
                 //
                 // Validate that the referenced access point exists
@@ -313,7 +309,7 @@ const createBackboneLink = async function(req, res) {
                 //
                 // Validate that the referenced site is in the specified backbone network
                 //
-                const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.connectingsite, userId, userGroups]);
+                const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1", [norm.connectingsite]);
                 if (siteResult.rowCount == 0) {
                     throw(Error(`Referenced connecting site not found: ${norm.connectingsite}`));
                 }
@@ -374,10 +370,8 @@ const updateBackboneLink = async function(req, res) {
         try {
             let linkChanged = null;
 
-            await queryWithContext(req, client, async (client, userInfo) => {
-                const userId = userInfo.userId;
-                const userGroups = userInfo.userGroups;
-                const linkResult = await client.query("SELECT * FROM InterRouterLinks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [lid, userId, userGroups]);
+            await queryWithContext(req, client, async (client) => {
+                const linkResult = await client.query("SELECT * FROM InterRouterLinks WHERE Id = $1", [lid]);
                 if (linkResult.rowCount == 1) {
                     const link = linkResult.rows[0];
 
@@ -385,7 +379,7 @@ const updateBackboneLink = async function(req, res) {
                     // If the cost has been changed, update the link record in the database
                     //
                     if (norm.cost != null && norm.cost != link.cost) {
-                        await client.query("UPDATE InterRouterLinks SET Cost = $1 WHERE Id = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [norm.cost, lid, userId, userGroups]);
+                        await client.query("UPDATE InterRouterLinks SET Cost = $1 WHERE Id = $2", [norm.cost, lid]);
                         returnStatus = 200;
                         linkChanged = link.connectinginteriorsite;
                     }
@@ -424,18 +418,16 @@ const deleteBackbone = async function(req, res) {
             throw new Error('Backbone-Id is not a valid uuid');
         }
 
-        await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId
-            const userGroups = userInfo.userGroups;
-            const vanResult = await client.query("SELECT Id FROM ApplicationNetworks WHERE Backbone = $1 and LifeCycle = 'ready' and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) LIMIT 1", [bid, userId, userGroups]);
+        await queryWithContext(req, client, async (client) => {
+            const vanResult = await client.query("SELECT Id FROM ApplicationNetworks WHERE Backbone = $1 and LifeCycle = 'ready' LIMIT 1", [bid]);
             if (vanResult.rowCount > 0) {
                 throw new Error('Cannot delete a backbone with active application networks');
             }
-            const siteResult = await client.query("SELECT Id FROM InteriorSites WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) LIMIT 1", [bid, userId, userGroups]);
+            const siteResult = await client.query("SELECT Id FROM InteriorSites WHERE Backbone = $1 LIMIT 1", [bid]);
             if (siteResult.rowCount > 0) {
                 throw new Error('Cannot delete a backbone with interior sites');
             }
-            const bbResult = await client.query("DELETE FROM Backbones WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING Certificate", [bid, userId, userGroups]);
+            const bbResult = await client.query("DELETE FROM Backbones WHERE Id = $1 RETURNING Certificate", [bid]);
             if (bbResult.rowCount == 1) {
                 const row = bbResult.rows[0];
                 if (row.certificate) {
@@ -463,29 +455,27 @@ const deleteBackboneSite = async function(req, res) {
             throw new Error('Site-Id is not a valid uuid');
         }
 
-        await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId
-            const userGroups = userInfo.userGroups;
-            const result = await client.query("SELECT Certificate FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query("SELECT Certificate FROM InteriorSites WHERE Id = $1", [sid]);
             if (result.rowCount == 1) {
                 const row = result.rows[0];
 
             //
             // Delete all of the site's access points
             //
-            const apResult = await client.query("SELECT Id, Certificate FROM BackboneAccessPoints WHERE InteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
+            const apResult = await client.query("SELECT Id, Certificate FROM BackboneAccessPoints WHERE InteriorSite = $1", [sid]);
             for (const row of apResult.rows) {
                 if (row.certificate) {
-                    await client.query("UPDATE BackboneAccessPoints SET Certificate = NULL WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [row.id, userId, userGroups]);
+                    await client.query("UPDATE BackboneAccessPoints SET Certificate = NULL WHERE Id = $1", [row.id]);
                     await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
                 }
-                await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [row.id, userId, userGroups]);
+                await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1", [row.id]);
             }
 
                 //
                 // Delete the site.  Note that involved inter-router links will be automatically deleted by the database.
                 //
-                await client.query("DELETE FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
+                await client.query("DELETE FROM InteriorSites WHERE Id = $1", [sid]);
 
                 //
                 // Delete the TLS certificate
@@ -518,8 +508,8 @@ const deleteAccessPoint = async function(req, res) {
             throw new Error('AccessPoint-Id is not a valid uuid');
         }
 
-        await queryWithContext(req, client, async (client, userInfo) => {
-            const apResult = await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) Returning Certificate, Kind, InteriorSite", [apid, userInfo.userId, userInfo.userGroups]);
+        await queryWithContext(req, client, async (client) => {
+            const apResult = await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 Returning Certificate, Kind, InteriorSite", [apid]);
             if (apResult.rowCount == 1) {
                 const row = apResult.rows[0];
                 if (row.certificate) {
@@ -564,8 +554,8 @@ const deleteBackboneLink = async function(req, res) {
             throw new Error('Link-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query("DELETE FROM InterRouterLinks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING ConnectingInteriorSite, AccessPoint", [lid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("DELETE FROM InterRouterLinks WHERE Id = $1 RETURNING ConnectingInteriorSite, AccessPoint", [lid]);
         })
         if (result.rowCount == 1) {
             connectingSite = result.rows[0].connectinginteriorsite;
@@ -602,16 +592,14 @@ const listBackbones = async function(req, res) {
     const client = await ClientFromPool();
     try {
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId
-            const userGroups = userInfo.userGroups;
+        const result = await queryWithContext(req, client, async (client) => {
             if (bid) {
                 if (!IsValidUuid(bid)) {
                     throw new Error('Backbone-Id is not a valid uuid');
                 }
-                return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userId, userGroups]);
+                return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE Id = $1", [bid]);
             }
-            return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE (Owner = $1 or OwnerGroup = Any($2) or is_admin())", [userId, userGroups]);
+            return await client.query("SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones");
         });
 
         if (bid) {
@@ -654,13 +642,13 @@ const listBackboneSites = async function(req, res) {
             id = sid;
         }
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT InteriorSites.Id, Name, Lifecycle, Failure, Metadata, DeploymentState, TargetPlatform, FirstActiveTime, LastHeartbeat, " +
                                       "TlsCertificates.expiration as tlsexpiration, TlsCertificates.renewalTime as tlsrenewal, TargetPlatforms.LongName as PlatformLong " +
                                       "FROM InteriorSites " +
                                       "LEFT OUTER JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
                                       "JOIN TargetPlatforms ON TargetPlatforms.ShortName = TargetPlatform " +
-                                      `WHERE ${byBackbone ? 'Backbone' : 'InteriorSites.Id'} = $1 and (InteriorSites.Owner = $2 or InteriorSites.OwnerGroup = Any($3) or is_admin())`, [id, userInfo.userId, userInfo.userGroups]);
+                                      `WHERE ${byBackbone ? 'Backbone' : 'InteriorSites.Id'} = $1`, [id]);
         })
 
         if (byBackbone) {
@@ -691,10 +679,10 @@ const listAccessPointsBackbone = async function(req, res) {
             throw new Error('Id is not a valid uuid');
         }
         
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT BackboneAccessPoints.Id, BackboneAccessPoints.Name, BackboneAccessPoints.Lifecycle, BackboneAccessPoints.Failure, Hostname, Port, Kind, Bindhost, InteriorSite, InteriorSites.Name as sitename FROM BackboneAccessPoints " +
                                       "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
-                                      "WHERE InteriorSites.Backbone = $1 and (BackboneAccessPoints.Owner = $2 or BackboneAccessPoints.OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
+                                      "WHERE InteriorSites.Backbone = $1", [bid]);
         })
         
         res.json(result.rows);
@@ -718,9 +706,9 @@ const listAccessPointsSite = async function(req, res) {
             throw new Error('Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost FROM BackboneAccessPoints " +
-                                      "WHERE InteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userInfo.userId, userInfo.userGroups]);
+                                      "WHERE InteriorSite = $1", [sid]);
         })
         
         res.json(result.rows);
@@ -744,9 +732,9 @@ const readAccessPoint = async function(req, res) {
             throw new Error('Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost, InteriorSite FROM BackboneAccessPoints " +
-                                      "WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userInfo.userId, userInfo.userGroups]);
+                                      "WHERE Id = $1", [apid]);
         })
 
         if (result.rowCount == 0) {
@@ -774,10 +762,10 @@ const listBackboneLinks = async function(req, res) {
             throw new Error('Backbone-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks " +
                                       "JOIN InteriorSites ON InterRouterLinks.ConnectingInteriorSite = InteriorSites.Id " +
-                                      "WHERE InteriorSites.Backbone = $1 and (InterRouterLinks.Owner = $2 or InterRouterLinks.OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
+                                      "WHERE InteriorSites.Backbone = $1", [bid]);
         })
         
         res.json(result.rows);
@@ -801,8 +789,8 @@ const listBackboneLinksForSite = async function(req, res) {
             throw new Error('Site-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks WHERE ConnectingInteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks WHERE ConnectingInteriorSite = $1", [sid]);
         })
 
         res.json(result.rows);
@@ -826,12 +814,12 @@ const listSiteIngresses = async function(req, res) {
             throw new Error('Site-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            const sites = await client.query("SELECT ClaimAccess, PeerAccess, MemberAccess, ManageAccess FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            const sites = await client.query("SELECT ClaimAccess, PeerAccess, MemberAccess, ManageAccess FROM InteriorSites WHERE Id = $1", [sid]);
             if (sites.rowCount == 1) {
                 const site = sites.rows[0];
-                return await client.query("SELECT Id, Name, Lifecycle, Failure, Kind, Hostname, Port FROM BackboneAccessPoints WHERE (Id = $1 OR Id = $2 OR Id = $3 OR Id = $4) and (Owner = $5 or OwnerGroup = Any($6) or is_admin())",
-                [site.claimaccess, site.peeraccess, site.memberaccess, site.manageaccess, userInfo.userId, userInfo.userGroups]);
+                return await client.query("SELECT Id, Name, Lifecycle, Failure, Kind, Hostname, Port FROM BackboneAccessPoints WHERE (Id = $1 OR Id = $2 OR Id = $3 OR Id = $4)",
+                [site.claimaccess, site.peeraccess, site.memberaccess, site.manageaccess]);
             }
             // Return empty result object with rows array
             return { rows: [] };

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -75,6 +75,7 @@ const createBackboneSite = async function(req, res) {
             'name'     : {type: 'dnsname', optional: false},
             'platform' : {type: 'dnsname', optional: false},
             'metadata' : {type: 'string',  optional: true, default: null},
+            'ownerGroup': {type: 'string', optional: true, default: ''},
         });
 
         const client = await ClientFromPool();
@@ -82,11 +83,11 @@ const createBackboneSite = async function(req, res) {
             let extraCols = "";
             let extraVals = "";
 
-            const siteId = await queryWithContext(req, client, async (client) => {
+            const siteId = await queryWithContext(req, client, async (client, userInfo) => {
                  //
                 // If the name is not unique within the backbone, modify it to be unique.
                 //
-                const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1", [bid]);
+                const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
 
                 let existingNames = [];
                 for (const row of namesResult.rows) {
@@ -105,8 +106,8 @@ const createBackboneSite = async function(req, res) {
                 //
                 // Create the site
                 //
-                const result = await client.query(`INSERT INTO InteriorSites(Name, TargetPlatform, Backbone${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`,
-                                                [uniqueName, norm.platform, bid]);
+                const result = await client.query(`INSERT INTO InteriorSites(Name, TargetPlatform, Backbone${extraCols}, Owner, OwnerGroup) VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`,
+                                                [uniqueName, norm.platform, bid, userInfo.userId, norm.ownerGroup]);
                 const site_id = result.rows[0].id;
 
                 return site_id
@@ -147,8 +148,10 @@ const updateBackboneSite = async function(req, res) {
         try {
             let nameChanged   = false;
 
-            await queryWithContext(req, client, async (client) => {
-                const siteResult = await client.query("SELECT * FROM InteriorSites WHERE Id = $1", [sid]);
+            await queryWithContext(req, client, async (client, userInfo) => {
+                const userId = userInfo.userId;
+                const userGroups = userInfo.userGroups;
+                const siteResult = await client.query("SELECT * FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
                 if (siteResult.rowCount == 1) {
                     const site = siteResult.rows[0];
                     let siteName = site.name;
@@ -158,7 +161,7 @@ const updateBackboneSite = async function(req, res) {
                     //
                     if (norm.name != null && norm.name != site.name) {
                         nameChanged = true;
-                        await client.query("UPDATE InteriorSites SET Name = $1 WHERE Id = $2", [norm.name, sid]);
+                        await client.query("UPDATE InteriorSites SET Name = $1 WHERE Id = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [norm.name, sid, userId, userGroups]);
                         siteName = norm.name;
                     }
 
@@ -166,7 +169,7 @@ const updateBackboneSite = async function(req, res) {
                     // Update the metadata if needed
                     //
                     if (norm.metadata != null && norm.metadata != site.metadata) {
-                        await client.query("UPDATE InteriorSites SET Metadata = $1 WHERE Id = $2", [norm.metadata, sid]);
+                        await client.query("UPDATE InteriorSites SET Metadata = $1 WHERE Id = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [norm.metadata, sid, userId, userGroups]);
                     }
                 }
             })
@@ -200,12 +203,15 @@ const createAccessPoint = async function(req, res) {
             'name'     : {type: 'dnsname',    optional: true, default: null},
             'kind'     : {type: 'accesskind', optional: false},
             'bindhost' : {type: 'string',     optional: true, default: null},
+            'ownerGroup': {type: 'string', optional: true, default: ''},
         });
 
         const client = await ClientFromPool();
         try {
-            const result = await queryWithContext(req, client, async (client) => {
-                const siteResult = await client.query("SELECT Name from InteriorSites WHERE Id = $1", [sid]);
+            const result = await queryWithContext(req, client, async (client, userInfo) => {
+                const userId = userInfo.userId;
+                const userGroups = userInfo.userGroups;
+                const siteResult = await client.query("SELECT Name from InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
                 if (siteResult.rowCount == 0) {
                     throw new Error(`Referenced interior site not found: ${sid}`);
                 }
@@ -227,7 +233,7 @@ const createAccessPoint = async function(req, res) {
                 //
                 // Create the access point
                 //
-                return await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`, [name, norm.kind, sid]);
+                return await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite${extraCols}, Owner, OwnerGroup) VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`, [name, norm.kind, sid, userId, norm.ownerGroup]);
             })
             
             const apId = result.rows[0].id;
@@ -273,18 +279,21 @@ const createBackboneLink = async function(req, res) {
         const norm = ValidateAndNormalizeFields(fields, {
             'connectingsite' : {type: 'uuid',   optional: false},
             'cost'           : {type: 'number', optional: true, default: 1},
+            'ownerGroup'     : {type: 'string', optional: true, default: ''},
         });
 
         const client = await ClientFromPool();
         try {
 
-            const linkResult = await queryWithContext(req, client, async (client) => {
+            const linkResult = await queryWithContext(req, client, async (client, userInfo) => {
+                const userId = userInfo.userId;
+                const userGroups = userInfo.userGroups;
                 //
                 // Get the referenced access point for validation
                 //
                 const accessResult = await client.query("SELECT Kind, InteriorSite, InteriorSites.Id as siteId, InteriorSites.Backbone FROM BackboneAccessPoints " +
                                                         "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
-                                                        "WHERE BackboneAccessPoints.Id = $1", [apid]);
+                                                        "WHERE BackboneAccessPoints.Id = $1 and (BackboneAccessPoints.Owner = $2 or BackboneAccessPoints.OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]);
 
                 //
                 // Validate that the referenced access point exists
@@ -304,7 +313,7 @@ const createBackboneLink = async function(req, res) {
                 //
                 // Validate that the referenced site is in the specified backbone network
                 //
-                const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1", [norm.connectingsite]);
+                const siteResult = await client.query("SELECT Backbone FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.connectingsite, userId, userGroups]);
                 if (siteResult.rowCount == 0) {
                     throw(Error(`Referenced connecting site not found: ${norm.connectingsite}`));
                 }
@@ -316,7 +325,7 @@ const createBackboneLink = async function(req, res) {
                 //
                 // Create the new link
                 //
-                return await client.query("INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost) VALUES ($1, $2, $3) RETURNING Id", [apid, norm.connectingsite, norm.cost]);
+                return await client.query("INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost, Owner, OwnerGroup) VALUES ($1, $2, $3, $4, $5) RETURNING Id", [apid, norm.connectingsite, norm.cost, userId, norm.ownerGroup]);
             })
 
             const linkId = linkResult.rows[0].id;
@@ -365,8 +374,10 @@ const updateBackboneLink = async function(req, res) {
         try {
             let linkChanged = null;
 
-            await queryWithContext(req, client, async (client) => {
-                const linkResult = await client.query("SELECT * FROM InterRouterLinks WHERE Id = $1", [lid]);
+            await queryWithContext(req, client, async (client, userInfo) => {
+                const userId = userInfo.userId;
+                const userGroups = userInfo.userGroups;
+                const linkResult = await client.query("SELECT * FROM InterRouterLinks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [lid, userId, userGroups]);
                 if (linkResult.rowCount == 1) {
                     const link = linkResult.rows[0];
 
@@ -374,7 +385,7 @@ const updateBackboneLink = async function(req, res) {
                     // If the cost has been changed, update the link record in the database
                     //
                     if (norm.cost != null && norm.cost != link.cost) {
-                        await client.query("UPDATE InterRouterLinks SET Cost = $1 WHERE Id = $2", [norm.cost, lid]);
+                        await client.query("UPDATE InterRouterLinks SET Cost = $1 WHERE Id = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [norm.cost, lid, userId, userGroups]);
                         returnStatus = 200;
                         linkChanged = link.connectinginteriorsite;
                     }
@@ -420,7 +431,7 @@ const deleteBackbone = async function(req, res) {
             if (vanResult.rowCount > 0) {
                 throw new Error('Cannot delete a backbone with active application networks');
             }
-            const siteResult = await client.query("SELECT Id FROM InteriorSites WHERE Backbone = $1 LIMIT 1", [bid]);
+            const siteResult = await client.query("SELECT Id FROM InteriorSites WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) LIMIT 1", [bid, userId, userGroups]);
             if (siteResult.rowCount > 0) {
                 throw new Error('Cannot delete a backbone with interior sites');
             }
@@ -452,27 +463,29 @@ const deleteBackboneSite = async function(req, res) {
             throw new Error('Site-Id is not a valid uuid');
         }
 
-        await queryWithContext(req, client, async (client) => {
-            const result = await client.query("SELECT Certificate FROM InteriorSites WHERE Id = $1", [sid]);
+        await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups;
+            const result = await client.query("SELECT Certificate FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
             if (result.rowCount == 1) {
                 const row = result.rows[0];
 
             //
             // Delete all of the site's access points
             //
-            const apResult = await client.query("SELECT Id, Certificate FROM BackboneAccessPoints WHERE InteriorSite = $1", [sid]);
+            const apResult = await client.query("SELECT Id, Certificate FROM BackboneAccessPoints WHERE InteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
             for (const row of apResult.rows) {
                 if (row.certificate) {
-                    await client.query("UPDATE BackboneAccessPoints SET Certificate = NULL WHERE Id = $1", [row.id]);
+                    await client.query("UPDATE BackboneAccessPoints SET Certificate = NULL WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [row.id, userId, userGroups]);
                     await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
                 }
-                await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1", [row.id]);
+                await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [row.id, userId, userGroups]);
             }
 
                 //
                 // Delete the site.  Note that involved inter-router links will be automatically deleted by the database.
                 //
-                await client.query("DELETE FROM InteriorSites WHERE Id = $1", [sid]);
+                await client.query("DELETE FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userId, userGroups]);
 
                 //
                 // Delete the TLS certificate
@@ -505,8 +518,8 @@ const deleteAccessPoint = async function(req, res) {
             throw new Error('AccessPoint-Id is not a valid uuid');
         }
 
-        await queryWithContext(req, client, async (client) => {
-            const apResult = await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 Returning Certificate, Kind, InteriorSite", [apid]);
+        await queryWithContext(req, client, async (client, userInfo) => {
+            const apResult = await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) Returning Certificate, Kind, InteriorSite", [apid, userInfo.userId, userInfo.userGroups]);
             if (apResult.rowCount == 1) {
                 const row = apResult.rows[0];
                 if (row.certificate) {
@@ -551,8 +564,8 @@ const deleteBackboneLink = async function(req, res) {
             throw new Error('Link-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("DELETE FROM InterRouterLinks WHERE Id = $1 RETURNING ConnectingInteriorSite, AccessPoint", [lid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("DELETE FROM InterRouterLinks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING ConnectingInteriorSite, AccessPoint", [lid, userInfo.userId, userInfo.userGroups]);
         })
         if (result.rowCount == 1) {
             connectingSite = result.rows[0].connectinginteriorsite;
@@ -641,13 +654,13 @@ const listBackboneSites = async function(req, res) {
             id = sid;
         }
 
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT InteriorSites.Id, Name, Lifecycle, Failure, Metadata, DeploymentState, TargetPlatform, FirstActiveTime, LastHeartbeat, " +
                                       "TlsCertificates.expiration as tlsexpiration, TlsCertificates.renewalTime as tlsrenewal, TargetPlatforms.LongName as PlatformLong " +
                                       "FROM InteriorSites " +
                                       "LEFT OUTER JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
                                       "JOIN TargetPlatforms ON TargetPlatforms.ShortName = TargetPlatform " +
-                                      `WHERE ${byBackbone ? 'Backbone' : 'InteriorSites.Id'} = $1`, [id]);
+                                      `WHERE ${byBackbone ? 'Backbone' : 'InteriorSites.Id'} = $1 and (InteriorSites.Owner = $2 or InteriorSites.OwnerGroup = Any($3) or is_admin())`, [id, userInfo.userId, userInfo.userGroups]);
         })
 
         if (byBackbone) {
@@ -678,10 +691,10 @@ const listAccessPointsBackbone = async function(req, res) {
             throw new Error('Id is not a valid uuid');
         }
         
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT BackboneAccessPoints.Id, BackboneAccessPoints.Name, BackboneAccessPoints.Lifecycle, BackboneAccessPoints.Failure, Hostname, Port, Kind, Bindhost, InteriorSite, InteriorSites.Name as sitename FROM BackboneAccessPoints " +
                                       "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " +
-                                      "WHERE InteriorSites.Backbone = $1", [bid]);
+                                      "WHERE InteriorSites.Backbone = $1 and (BackboneAccessPoints.Owner = $2 or BackboneAccessPoints.OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
         })
         
         res.json(result.rows);
@@ -705,9 +718,9 @@ const listAccessPointsSite = async function(req, res) {
             throw new Error('Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost FROM BackboneAccessPoints " +
-                                      "WHERE InteriorSite = $1", [sid]);
+                                      "WHERE InteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userInfo.userId, userInfo.userGroups]);
         })
         
         res.json(result.rows);
@@ -731,9 +744,9 @@ const readAccessPoint = async function(req, res) {
             throw new Error('Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT Id, Name, Lifecycle, Failure, Hostname, Port, Kind, Bindhost, InteriorSite FROM BackboneAccessPoints " +
-                                      "WHERE Id = $1", [apid]);
+                                      "WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userInfo.userId, userInfo.userGroups]);
         })
 
         if (result.rowCount == 0) {
@@ -761,10 +774,10 @@ const listBackboneLinks = async function(req, res) {
             throw new Error('Backbone-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks " +
                                       "JOIN InteriorSites ON InterRouterLinks.ConnectingInteriorSite = InteriorSites.Id " +
-                                      "WHERE InteriorSites.Backbone = $1", [bid]);
+                                      "WHERE InteriorSites.Backbone = $1 and (InterRouterLinks.Owner = $2 or InterRouterLinks.OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
         })
         
         res.json(result.rows);
@@ -788,8 +801,8 @@ const listBackboneLinksForSite = async function(req, res) {
             throw new Error('Site-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks WHERE ConnectingInteriorSite = $1", [sid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("SELECT InterRouterLinks.* FROM InterRouterLinks WHERE ConnectingInteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userInfo.userId, userInfo.userGroups]);
         })
 
         res.json(result.rows);
@@ -813,12 +826,12 @@ const listSiteIngresses = async function(req, res) {
             throw new Error('Site-Id is not a valid uuid');
         }
 
-        const result = await queryWithContext(req, client, async (client) => {
-            const sites = await client.query("SELECT ClaimAccess, PeerAccess, MemberAccess, ManageAccess FROM InteriorSites WHERE Id = $1", [sid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            const sites = await client.query("SELECT ClaimAccess, PeerAccess, MemberAccess, ManageAccess FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [sid, userInfo.userId, userInfo.userGroups]);
             if (sites.rowCount == 1) {
                 const site = sites.rows[0];
-                return await client.query("SELECT Id, Name, Lifecycle, Failure, Kind, Hostname, Port FROM BackboneAccessPoints WHERE Id = $1 OR Id = $2 OR Id = $3 OR Id = $4",
-                [site.claimaccess, site.peeraccess, site.memberaccess, site.manageaccess]);
+                return await client.query("SELECT Id, Name, Lifecycle, Failure, Kind, Hostname, Port FROM BackboneAccessPoints WHERE (Id = $1 OR Id = $2 OR Id = $3 OR Id = $4) and (Owner = $5 or OwnerGroup = Any($6) or is_admin())",
+                [site.claimaccess, site.peeraccess, site.memberaccess, site.manageaccess, userInfo.userId, userInfo.userGroups]);
             }
             // Return empty result object with rows array
             return { rows: [] };

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -859,66 +859,66 @@ export async function Initialize(app, keycloak) {
     //========================================
 
     app.route(API_PREFIX + 'backbones')
-    .post(keycloak.protect('realm:backbone-admin'), createBackbone)       // CREATE
-    .get(keycloak.protect(), listBackbones);                              // LIST
+    .post(keycloak.protect('realm:can-create-backbone'), createBackbone)       // CREATE
+    .get(keycloak.protect('realm:can-list-backbones'), listBackbones);        // LIST
 
     app.route(API_PREFIX + 'backbones/:bid')
-    .get(keycloak.protect('realm:backbone-admin'), listBackbones)         // READ
-    .delete(keycloak.protect('realm:backbone-admin'), deleteBackbone);    // DELETE
+    .get(keycloak.protect('realm:can-list-backbones'), listBackbones)         // READ
+    .delete(keycloak.protect('realm:can-delete-backbone'), deleteBackbone);    // DELETE
 
     //========================================
     // Backbone/Interior Sites
     //========================================
 
     app.route(API_PREFIX + 'backbones/:bid/sites')
-    .post(keycloak.protect('realm:backbone-admin'), createBackboneSite)     // CREATE
-    .get(keycloak.protect('realm:backbone-admin'), listBackboneSites);      // LIST
+    .post(keycloak.protect('realm:can-create-backbone-site'), createBackboneSite)     // CREATE
+    .get(keycloak.protect('realm:can-list-backbone-sites'), listBackboneSites);      // LIST
 
     app.route(API_PREFIX + 'backbonesites/:sid')
-    .get(keycloak.protect('realm:backbone-admin'), listBackboneSites)       // READ
-    .put(keycloak.protect('realm:backbone-admin'), updateBackboneSite)      // UPDATE
-    .delete(keycloak.protect('realm:backbone-admin'), deleteBackboneSite);  // DELETE
+    .get(keycloak.protect('realm:can-list-backbone-sites'), listBackboneSites)       // READ
+    .put(keycloak.protect('realm:can-update-backbone-site'), updateBackboneSite)      // UPDATE
+    .delete(keycloak.protect('realm:can-delete-backbone-site'), deleteBackboneSite);  // DELETE
 
     //========================================
     // Interior Access Points
     //========================================
 
     app.route(API_PREFIX + 'backbonesites/:sid/accesspoints')
-    .post(keycloak.protect('realm:backbone-admin'), createAccessPoint)         // CREATE
-    .get(keycloak.protect('realm:backbone-admin'), listAccessPointsSite);      // LIST for Site
+    .post(keycloak.protect('realm:can-create-access-point'), createAccessPoint)         // CREATE
+    .get(keycloak.protect('realm:can-list-access-points-site'), listAccessPointsSite);      // LIST for Site
 
     app.route(API_PREFIX + 'backbones/:bid/accesspoints')
-    .get(keycloak.protect(), listAccessPointsBackbone);  // LIST for Backbone
+    .get(keycloak.protect('realm:can-list-access-points-backbone'), listAccessPointsBackbone);  // LIST for Backbone
 
     app.route(API_PREFIX + 'accesspoints/:apid')
-    .get(keycloak.protect('realm:backbone-admin'), readAccessPoint)            // READ
-    .delete(keycloak.protect('realm:backbone-admin'), deleteAccessPoint);      // DELETE
+    .get(keycloak.protect('realm:can-read-access-point'), readAccessPoint)            // READ
+    .delete(keycloak.protect('realm:can-delete-access-point'), deleteAccessPoint);      // DELETE
 
     //========================================
     // Interior Site Links
     //========================================
 
     app.route(API_PREFIX + 'accesspoints/:apid/links')
-    .post(keycloak.protect('realm:backbone-admin'), createBackboneLink);
+    .post(keycloak.protect('realm:can-create-backbone-link'), createBackboneLink);
 
     app.route(API_PREFIX + 'backbones/:bid/links')
-    .get(keycloak.protect('realm:backbone-admin'), listBackboneLinks);
+    .get(keycloak.protect('realm:can-list-backbone-links'), listBackboneLinks);
 
     app.route(API_PREFIX + 'backbonesites/:sid/links')
-    .get(keycloak.protect('realm:backbone-admin'), listBackboneLinksForSite);
+    .get(keycloak.protect('realm:can-list-backbone-links-for-site'), listBackboneLinksForSite);
 
     app.route(API_PREFIX + 'backbonelinks/:lid')
-    .put(keycloak.protect('realm:backbone-admin'), updateBackboneLink)
-    .delete(keycloak.protect('realm:backbone-admin'), deleteBackboneLink);
+    .put(keycloak.protect('realm:can-update-backbone-link'), updateBackboneLink)
+    .delete(keycloak.protect('realm:can-delete-backbone-link'), deleteBackboneLink);
 
     //========================================
     // Backbone Access Points
     //========================================
-    app.get(API_PREFIX + 'backbonesites/:sid/ingresses', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesites/:sid/ingresses', keycloak.protect('realm:can-list-site-ingresses'), async (req, res) => {
         await listSiteIngresses(req, res);
     });
 
-    app.get(API_PREFIX + 'invitations', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'invitations', keycloak.protect('realm:can-list-invitations'), async (req, res) => {
         await listInvitations(req, res);
     });
 }

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -534,32 +534,32 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // CREATE
-    api.post(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:can-create-van'), async (req, res) => {
+    api.post(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:van-owner'), async (req, res) => {
         await createVan(req, res);
     });
 
     // READ
-    api.get(API_PREFIX + 'vans/:vid', keycloak.protect('realm:can-read-van'), async (req, res) => {
+    api.get(API_PREFIX + 'vans/:vid', keycloak.protect('realm:van-owner'), async (req, res) => {
         await readVan(req, res);
     });
 
     // LIST
-    api.get(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:can-list-vans'), async (req, res) => {
+    api.get(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:van-owner'), async (req, res) => {
         await listVans(req, res);
     });
 
     // LIST ALL
-    api.get(API_PREFIX + 'vans', keycloak.protect('realm:can-list-all-vans'), async (req, res) => {
+    api.get(API_PREFIX + 'vans', keycloak.protect('realm:can-list-vans'), async (req, res) => {
         await listAllVans(req, res);
     });
 
     // DELETE
-    api.delete(API_PREFIX + 'vans/:vid', keycloak.protect('realm:can-delete-van'), async (req, res) => {
+    api.delete(API_PREFIX + 'vans/:vid', keycloak.protect('realm:van-owner'), async (req, res) => {
         await deleteVan(req, res);
     });
 
     // COMMANDS
-    api.put(API_PREFIX + 'vans/:vid/evict', keycloak.protect('realm:can-evict-van'), async (req, res) => {
+    api.put(API_PREFIX + 'vans/:vid/evict', keycloak.protect('realm:van-owner'), async (req, res) => {
         await evictVan(req, res);
     });
 
@@ -568,27 +568,27 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // CREATE
-    api.post(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:can-create-invitation'), async (req, res) => {
+    api.post(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:van-owner'), async (req, res) => {
         await createInvitation(req, res);
     });
 
     // READ
-    api.get(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:can-read-invitation'), async (req, res) => {
+    api.get(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:van-owner'), async (req, res) => {
         await readInvitation(req, res);
     });
 
     // LIST
-    api.get(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:can-list-invitations'), async (req, res) => {
+    api.get(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:van-owner'), async (req, res) => {
         await listInvitations(req, res);
     });
 
     // DELETE
-    api.delete(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:can-delete-invitation'), async (req, res) => {
+    api.delete(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:van-owner'), async (req, res) => {
         await deleteInvitation(req, res);
     });
 
     // COMMANDS
-    api.put(API_PREFIX + 'invitations/:iid/expire', keycloak.protect('realm:can-expire-invitation'), async (req, res) => {
+    api.put(API_PREFIX + 'invitations/:iid/expire', keycloak.protect('realm:van-owner'), async (req, res) => {
         await expireInvitation(req, res);
     })
 
@@ -597,24 +597,24 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // READ
-    api.get(API_PREFIX + 'members/:mid', keycloak.protect('realm:can-read-van-member'), async (req, res) => {
+    api.get(API_PREFIX + 'members/:mid', keycloak.protect('realm:van-owner'), async (req, res) => {
         await readVanMember(req, res);
     });
 
     // LIST
-    api.get(API_PREFIX + 'vans/:vid/members', keycloak.protect('realm:can-list-van-members'), async (req, res) => {
+    api.get(API_PREFIX + 'vans/:vid/members', keycloak.protect('realm:van-owner'), async (req, res) => {
         await listVanMembers(req, res);
     });
 
     // COMMANDS
-    api.put(API_PREFIX + 'members/:mid/evict', keycloak.protect('realm:can-evict-member'), async (req, res) => {
+    api.put(API_PREFIX + 'members/:mid/evict', keycloak.protect('realm:van-owner'), async (req, res) => {
         await evictMember(req, res);
     });
 
     //========================================
     // TLS Certificates
     //========================================
-    api.get(API_PREFIX + 'tls-certificates/:cid', keycloak.protect('realm:can-read-certificate'), async (req, res) => {
+    api.get(API_PREFIX + 'tls-certificates/:cid', keycloak.protect('realm:certificate-manager'), async (req, res) => {
         await readCertificate(req, res);
     });
 
@@ -623,12 +623,12 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // Claim Access Points
-    api.get(API_PREFIX + 'backbones/:bid/access/claim', keycloak.protect('realm:can-list-claim-access-points'), async (req, res) => {
+    api.get(API_PREFIX + 'backbones/:bid/access/claim', keycloak.protect('realm:van-owner'), async (req, res) => {
         await listClaimAccessPoints(req, res, 'ClaimAccess');
     });
 
     // Member Access Points
-    api.get(API_PREFIX + 'backbones/:bid/access/member', keycloak.protect('realm:can-list-member-access-points'), async (req, res) => {
+    api.get(API_PREFIX + 'backbones/:bid/access/member', keycloak.protect('realm:van-owner'), async (req, res) => {
         await listClaimAccessPoints(req, res, 'MemberAccess');
     });
 }

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -20,18 +20,19 @@
 "use strict";
 
 import { IncomingForm } from 'formidable';
-import { ClientFromPool } from './db.js';
+import { ClientFromPool, queryWithContext } from './db.js';
 import { Log } from '@skupperx/modules/log'
 import { IsValidUuid, ValidateAndNormalizeFields, UniquifyName } from '@skupperx/modules/util'
 
 const API_PREFIX = '/api/v1alpha1/';
 
-const createVan = async function(bid, req, res) {
-    var returnStatus;
+const createVan = async function(req, res) {
+    const bid = req.params.bid;
+    let returnStatus;
     const form = new IncomingForm();
     try {
         if (!IsValidUuid(bid)) {
-            throw(Error('Backbone-Id is not a valid uuid'));
+            throw new Error('Backbone-Id is not a valid uuid');
         }
 
         const [fields, files] = await form.parse(req);
@@ -46,54 +47,58 @@ const createVan = async function(bid, req, res) {
         const client = await ClientFromPool();
         try {
             returnStatus = 500;
-            await client.query("BEGIN");
 
-            //
-            // If the name is not unique within the backbone, modify it to be unique.
-            //
-            const namesResult = await client.query("SELECT Name FROM ApplicationNetworks WHERE Backbone = $1", [bid]);
-            var existingNames = [];
-            for (const row of namesResult.rows) {
-                existingNames.push(row.name);
-            }
-            const uniqueName = UniquifyName(norm.name, existingNames);
+            const vanId = await queryWithContext(req, client, async (client, credentials) => {
+                //
+                // If the name is not unique within the backbone, modify it to be unique.
+                //
+                const namesResult = await client.query("SELECT Name FROM ApplicationNetworks WHERE Backbone = $1", [bid]);
+                let existingNames = [];
+                for (const row of namesResult.rows) {
+                    existingNames.push(row.name);
+                }
+                const uniqueName = UniquifyName(norm.name, existingNames);
 
-            var extraCols = "";
-            var extraVals = "";
+                let extraCols = "";
+                let extraVals = "";
 
-            //
-            // Handle the optional fields
-            //
-            if (norm.starttime) {
-                extraCols += ', StartTime';
-                extraVals += `, '${norm.starttime}'`;
-            }
+                //
+                // Handle the optional fields
+                //
+                if (norm.starttime) {
+                    extraCols += ', StartTime';
+                    extraVals += `, '${norm.starttime}'`;
+                }
 
-            if (norm.endtime) {
-                extraCols += ', EndTime';
-                extraVals += `, '${norm.endtime}'`;
-            }
+                if (norm.endtime) {
+                    extraCols += ', EndTime';
+                    extraVals += `, '${norm.endtime}'`;
+                }
 
-            if (norm.deletedelay) {
-                extraCols += ', DeleteDelay';
-                extraVals += `, '${norm.deletedelay}'`;
-            }
+                if (norm.deletedelay) {
+                    extraCols += ', DeleteDelay';
+                    extraVals += `, '${norm.deletedelay}'`;
+                }
 
-            //
-            // Create the application network
-            //
-            const result = await client.query(
-                `INSERT INTO ApplicationNetworks(Name, NetworkType, Backbone${extraCols}) VALUES ($1, $2, $3${extraVals}) RETURNING Id`,
-                [uniqueName, norm.nettype, bid]
-            );
-            const vanId = result.rows[0].id;
+                //
+                // Create the application network
+                //
+                const ownerId = credentials.userId;
+                const ownerGroups = credentials.userGroups;
+                const result = await client.query(
+                    `INSERT INTO ApplicationNetworks(Name, NetworkType, Backbone${extraCols}, Owner, OwnerGroups) VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`,
+                    [uniqueName, norm.nettype, bid, ownerId, ownerGroups]
+                );
+                const vanId = result.rows[0].id;
+                
+                //
+                // Create network credentials for the VAN.
+                //
+                await client.query("INSERT INTO NetworkCredentials (Name, MemberOf) VALUES ($1, $2)", [uniqueName, vanId]);
 
-            //
-            // Create network credentials for the VAN.
-            //
-            await client.query("INSERT INTO NetworkCredentials (Name, MemberOf) VALUES ($1, $2)", [uniqueName, vanId]);
+                return vanId
+            })
 
-            await client.query("COMMIT");
             returnStatus = 201;
             res.status(returnStatus).json({id: vanId});
         } catch (error) {
@@ -111,12 +116,13 @@ const createVan = async function(bid, req, res) {
     return returnStatus;
 }
 
-const createInvitation = async function(vid, req, res) {
-    var returnStatus;
+const createInvitation = async function(req, res) {
+    const vid = req.params.vid;
+    let returnStatus;
     const form = new IncomingForm();
     try {
         if (!IsValidUuid(vid)) {
-            throw(Error('VAN-Id is not a valid uuid'));
+            throw new Error('VAN-Id is not a valid uuid');
         }
 
         const [fields, files] = await form.parse(req)
@@ -134,57 +140,59 @@ const createInvitation = async function(vid, req, res) {
 
         const client = await ClientFromPool();
         try {
-            await client.query("BEGIN");
 
-            //
-            // If the name is not unique within the backbone, modify it to be unique.
-            //
-            const namesResult = await client.query("SELECT Name FROM MemberInvitations WHERE MemberOf = $1", [vid]);
-            var existingNames = [];
-            for (const row of namesResult.rows) {
-                existingNames.push(row.name);
-            }
-            const uniqueName = UniquifyName(norm.name, existingNames);
+            const invitationId = await queryWithContext(req, client, async (client) => {
+                //
+                // If the name is not unique within the backbone, modify it to be unique.
+                //
+                const namesResult = await client.query("SELECT Name FROM MemberInvitations WHERE MemberOf = $1", [vid]);
+                let existingNames = [];
+                for (const row of namesResult.rows) {
+                    existingNames.push(row.name);
+                }
+                const uniqueName = UniquifyName(norm.name, existingNames);
 
-            var extraCols = "";
-            var extraVals = "";
+                let extraCols = "";
+                let extraVals = "";
 
-            //
-            // Handle the optional fields
-            //
-            if (norm.siteclass) {
-                extraCols += ', MemberClasses';
-                extraVals += `, ARRAY['${norm.siteclass}']`;
-            }
+                //
+                // Handle the optional fields
+                //
+                if (norm.siteclass) {
+                    extraCols += ', MemberClasses';
+                    extraVals += `, ARRAY['${norm.siteclass}']`;
+                }
 
-            if (norm.instancelimit) {
-                extraCols += ', InstanceLimit';
-                extraVals += `, ${norm.instancelimit}`;
-            }
+                if (norm.instancelimit) {
+                    extraCols += ', InstanceLimit';
+                    extraVals += `, ${norm.instancelimit}`;
+                }
 
-            if (norm.joindeadline) {
-                extraCols += ', JoinDeadline';
-                extraVals += `, '${norm.joindeadline}'`;
-            }
+                if (norm.joindeadline) {
+                    extraCols += ', JoinDeadline';
+                    extraVals += `, '${norm.joindeadline}'`;
+                }
 
-            if (norm.prefix) {
-                extraCols += ', MemberNamePrefix';
-                extraVals += `, '${norm.prefix}'`;
-            }
+                if (norm.prefix) {
+                    extraCols += ', MemberNamePrefix';
+                    extraVals += `, '${norm.prefix}'`;
+                }
 
-            //
-            // Create the application network
-            //
-            const result = await client.query(`INSERT INTO MemberInvitations(Name, MemberOf, ClaimAccess, InteractiveClaim${extraCols}) ` +
-                                              `VALUES ($1, $2, $3, $4${extraVals}) RETURNING Id`, [uniqueName, vid, norm.claimaccess, norm.interactive]);
-            const invitationId = result.rows[0].id;
+                //
+                // Create the application network
+                //
+                const result = await client.query(`INSERT INTO MemberInvitations(Name, MemberOf, ClaimAccess, InteractiveClaim${extraCols}) ` +
+                                                `VALUES ($1, $2, $3, $4${extraVals}) RETURNING Id`, [uniqueName, vid, norm.claimaccess, norm.interactive]);
+                const invitationId = result.rows[0].id;
 
-            await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 1)", [norm.primaryaccess, invitationId]);
+                await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 1)", [norm.primaryaccess, invitationId]);
 
-            if (norm.secondaryaccess) {
-                await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 2)", [norm.secondaryaccess, invitationId]);
-            }
-            await client.query("COMMIT");
+                if (norm.secondaryaccess) {
+                    await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 2)", [norm.secondaryaccess, invitationId]);
+                }
+
+                return invitationId
+            })
 
             returnStatus = 201;
             res.status(returnStatus).json({id: invitationId});
@@ -203,15 +211,19 @@ const createInvitation = async function(vid, req, res) {
     return returnStatus;
 }
 
-const readVan = async function(res, vid) {
-    var returnStatus = 200;
+const readVan = async function(req, res) {
+    let returnStatus = 200;
+    const vid = req.params.vid;
     const client = await ClientFromPool();
     try {
-        const result = await client.query(
-            "SELECT ApplicationNetworks.*, Backbones.Id as backboneid, Backbones.Name as backbonename " +
-            "FROM ApplicationNetworks " +
-            "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id WHERE ApplicationNetworks.Id = $1", [vid]
-        );
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                "SELECT ApplicationNetworks.*, Backbones.Id as backboneid, Backbones.Name as backbonename " +
+                "FROM ApplicationNetworks " +
+                "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id WHERE ApplicationNetworks.Id = $1", [vid]
+            );
+        })
+
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
         } else {
@@ -227,12 +239,17 @@ const readVan = async function(res, vid) {
     return returnStatus;
 }
 
-const readInvitation = async function(res, iid) {
-    var returnStatus = 200;
+const readInvitation = async function(req, res) {
+    let returnStatus = 200;
+    const iid = req.params.iid;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT MemberInvitations.Name, MemberInvitations.LifeCycle, MemberInvitations.Failure, ApplicationNetworks.Name as vanname, JoinDeadline, InstanceLimit, InstanceCount, InteractiveClaim as interactive FROM MemberInvitations " +
-                                          "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberInvitations.MemberOf WHERE MemberInvitations.Id = $1", [iid]);
+        
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT MemberInvitations.Name, MemberInvitations.LifeCycle, MemberInvitations.Failure, ApplicationNetworks.Name as vanname, JoinDeadline, InstanceLimit, InstanceCount, InteractiveClaim as interactive FROM MemberInvitations " +
+                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberInvitations.MemberOf WHERE MemberInvitations.Id = $1", [iid]);
+        })
+        
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
         } else {
@@ -248,12 +265,16 @@ const readInvitation = async function(res, iid) {
     return returnStatus;
 }
 
-const readVanMember = async function(res, mid) {
-    var returnStatus = 200;
+const readVanMember = async function(req, res) {
+    let returnStatus = 200;
+    const mid = req.params.mid;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT MemberSites.*, ApplicationNetworks.Name as vanname FROM MemberSites " +
-                                          "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberSites.MemberOf WHERE MemberSites.Id = $1", [mid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT MemberSites.*, ApplicationNetworks.Name as vanname FROM MemberSites " +
+                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberSites.MemberOf WHERE MemberSites.Id = $1", [mid]);
+        })
+
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
         } else {
@@ -269,13 +290,15 @@ const readVanMember = async function(res, mid) {
     return returnStatus;
 }
 
-const listVans = async function(res, bid) {
-    var returnStatus = 200;
+const listVans = async function(req, res) {
+    const bid = req.params.bid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query(
-            "SELECT Id, Name, LifeCycle, Failure, StartTime, EndTime, DeleteDelay, NetworkType, Connected FROM ApplicationNetworks WHERE Backbone = $1", [bid]
-        );
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Name, LifeCycle, Failure, StartTime, EndTime, DeleteDelay, NetworkType, Connected FROM ApplicationNetworks WHERE Backbone = $1", [bid])
+        })
+
         res.status(returnStatus).json(result.rows);
     } catch (error) {
         returnStatus = 500
@@ -286,16 +309,18 @@ const listVans = async function(res, bid) {
     return returnStatus;
 }
 
-const listAllVans = async function(res, bid) {
-    var returnStatus = 200;
+const listAllVans = async function(req, res) {
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query(
-            "SELECT ApplicationNetworks.Id, Backbone, Backbones.Name as backbonename, ApplicationNetworks.Name, NetworkType, " +
-            "ApplicationNetworks.LifeCycle, ApplicationNetworks.Failure, StartTime, EndTime, DeleteDelay, Connected " +
-            "FROM ApplicationNetworks " +
-            "JOIN Backbones ON Backbones.Id = Backbone"
-        );
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                "SELECT ApplicationNetworks.Id, Backbone, Backbones.Name as backbonename, ApplicationNetworks.Name, NetworkType, " +
+                "ApplicationNetworks.LifeCycle, ApplicationNetworks.Failure, StartTime, EndTime, DeleteDelay, Connected " +
+                "FROM ApplicationNetworks " +
+                "JOIN Backbones ON Backbones.Id = Backbone"
+            )
+        })
         res.status(returnStatus).json(result.rows);
     } catch (error) {
         returnStatus = 500
@@ -306,11 +331,14 @@ const listAllVans = async function(res, bid) {
     return returnStatus;
 }
 
-const listInvitations = async function(res, vid) {
-    var returnStatus = 200;
+const listInvitations = async function(req, res) {
+    const vid = req.params.vid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT Id, Name, LifeCycle, Failure, JoinDeadline, MemberClasses, InstanceLimit, InstanceCount, FetchCount, InteractiveClaim as interactive FROM MemberInvitations WHERE MemberOf = $1", [vid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Name, LifeCycle, Failure, JoinDeadline, MemberClasses, InstanceLimit, InstanceCount, FetchCount, InteractiveClaim as interactive FROM MemberInvitations WHERE MemberOf = $1", [vid]);
+        })
         res.status(returnStatus).json(result.rows);
     } catch (error) {
         returnStatus = 500
@@ -321,14 +349,17 @@ const listInvitations = async function(res, vid) {
     return returnStatus;
 }
 
-const listVanMembers = async function(res, vid) {
-    var returnStatus = 200;
+const listVanMembers = async function(req, res) {
+    const vid = req.params.vid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT MemberSites.*, MemberInvitations.name as invitationname " +
-                                          "FROM MemberSites " +
-                                          "JOIN MemberInvitations ON MemberInvitations.Id = Invitation " +
-                                          "WHERE MemberSites.MemberOf = $1", [vid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT MemberSites.*, MemberInvitations.name as invitationname " +
+                                      "FROM MemberSites " +
+                                      "JOIN MemberInvitations ON MemberInvitations.Id = Invitation " +
+                                      "WHERE MemberSites.MemberOf = $1", [vid]);
+        })
         res.status(returnStatus).json(result.rows);
     } catch (error) {
         returnStatus = 500
@@ -339,30 +370,31 @@ const listVanMembers = async function(res, vid) {
     return returnStatus;
 }
 
-const deleteVan = async function(res, vid) {
-    var returnStatus = 204;
+const deleteVan = async function(req, res) {
+    const vid = req.params.vid;
+    let returnStatus = 204;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT Id FROM MemberSites WHERE MemberOf = $1 LIMIT 1", [vid]);
-        if (result.rowCount == 0) {
-            const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 RETURNING Certificate", [vid]);
-            if (delResult.rowCount == 1) {
-                if (delResult.certificate) {
-                    await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.certificate]);
+        await queryWithContext(req, client, async (client) => {
+            const memberSiteId = await client.query("SELECT Id FROM MemberSites WHERE MemberOf = $1 LIMIT 1", [vid]);
+            if (memberSiteId.rowCount == 0) {
+                const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 RETURNING Certificate", [vid]);
+                if (delResult.rowCount == 1) {
+                    if (delResult.certificate) {
+                        await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.certificate]);
+                    }
+                    res.status(returnStatus).send("Application network deleted");
+                } else {
+                    await client.query("ROLLBACK");
+                    returnStatus = 404;
+                    res.status(returnStatus).send("Application network not found");
                 }
-                await client.query("COMMIT");
-                res.status(returnStatus).send("Application network deleted");
             } else {
                 await client.query("ROLLBACK");
-                returnStatus = 404;
-                res.status(returnStatus).send("Application network not found");
+                returnStatus = 400;
+                res.status(returnStatus).send('Cannot delete application network because is still has members');
             }
-        } else {
-            await client.query("ROLLBACK");
-            returnStatus = 400;
-            res.status(returnStatus).send('Cannot delete application network because is still has members');
-        }
+        })
     } catch (error) {
         await client.query("ROLLBACK");
         returnStatus = 500;
@@ -373,8 +405,9 @@ const deleteVan = async function(res, vid) {
     return returnStatus;
 }
 
-const deleteInvitation = async function(res, iid) {
-    var returnStatus = 204;
+const deleteInvitation = async function(req, res) {
+    const iid = req.params.iid;
+    let returnStatus = 204;
     const client = await ClientFromPool();
     try {
         await client.query("BEGIN");
@@ -393,6 +426,23 @@ const deleteInvitation = async function(res, iid) {
             res.status(returnStatus).send('Cannot delete invitation because members still exist that use the invitation');
         }
         await client.query("COMMIT");
+
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query("SELECT id FROM MemberSites WHERE Invitation = $1 LIMIT 1", [iid]);
+            if (result.rowCount == 0) {
+                const invResult = await client.query("DELETE FROM MemberInvitations WHERE Id = $1 RETURNING Certificate", [iid]);
+                if (invResult.rowCount == 1) {
+                    const row = invResult.rows[0];
+                    if (row.certificate) {
+                        await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                    }
+                }
+                res.status(returnStatus).end();
+            } else {
+                returnStatus = 400;
+                res.status(returnStatus).send('Cannot delete invitation because members still exist that use the invitation');
+            }
+        })
     } catch (error) {
         await client.query("ROLLBACK");
         returnStatus = 500
@@ -403,11 +453,14 @@ const deleteInvitation = async function(res, iid) {
     return returnStatus;
 }
 
-const expireInvitation = async function(res, iid) {
-    var returnStatus = 200;
+const expireInvitation = async function(req, res) {
+    const iid = req.params.iid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("UPDATE MemberInvitations SET Lifecycle = 'expired', Failure = 'Expired via API' WHERE Id = $1 RETURNING Id", [iid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("UPDATE MemberInvitations SET Lifecycle = 'expired', Failure = 'Expired via API' WHERE Id = $1 RETURNING Id", [iid]);
+        })
         if (result.rowCount == 0) {
             returnStatus = 404;
         }
@@ -423,10 +476,12 @@ const expireInvitation = async function(res, iid) {
 
 const readCertificate = async function(req, res) {
     const cid = req.params.cid;
-    var returnStatus = 200;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT * FROM TlsCertificates WHERE Id = $1", [cid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT * FROM TlsCertificates WHERE Id = $1", [cid]);
+        })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
         } else {
@@ -442,25 +497,30 @@ const readCertificate = async function(req, res) {
     return returnStatus;
 }
 
-const evictMember = async function(mid, req, res) {
-    var returnStatus = 501;
+const evictMember = async function(req, res) {
+    const mid = req.params.mid;
+    let returnStatus = 501;
     res.status(returnStatus).send("Member eviction not implemented");
     return returnStatus;
 }
 
-const evictVan = async function(vid, req, res) {
-    var returnStatus = 501;
+const evictVan = async function(req, res) {
+    const vid = req.params.vid;
+    let returnStatus = 501;
     res.status(returnStatus).send("Network eviction not implemented");
     return returnStatus;
 }
 
-const listClaimAccessPoints = async function(res, bid, ref) {
-    var returnStatus = 200;
+const listClaimAccessPoints = async function(req, res, ref) {
+    const bid = req.params.bid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT BackboneAccessPoints.Name as accessname, BackboneAccessPoints.Id as accessid FROM InteriorSites " +
-                                          `JOIN BackboneAccessPoints ON BackboneAccessPoints.Id = InteriorSites.${ref} ` +
-                                          "WHERE InteriorSites.Backbone = $1", [bid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT BackboneAccessPoints.Name as accessname, BackboneAccessPoints.Id as accessid FROM InteriorSites " +
+                                      `JOIN BackboneAccessPoints ON BackboneAccessPoints.Id = InteriorSites.${ref} ` +
+                                      "WHERE InteriorSites.Backbone = $1", [bid]);
+        })
         let data = [];
         for (const row of result.rows) {
             data.push({
@@ -487,32 +547,32 @@ export async function Initialize(api, keycloak) {
 
     // CREATE
     api.post(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await createVan(req.params.bid, req, res);
+        await createVan(req, res);
     });
 
     // READ
     api.get(API_PREFIX + 'vans/:vid', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await readVan(res, req.params.vid);
+        await readVan(req, res);
     });
 
     // LIST
     api.get(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await listVans(res, req.params.bid);
+        await listVans(req, res);
     });
 
     // LIST ALL
     api.get(API_PREFIX + 'vans', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await listAllVans(res);
+        await listAllVans(req, res);
     });
 
     // DELETE
     api.delete(API_PREFIX + 'vans/:vid', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await deleteVan(res, req.params.vid);
+        await deleteVan(req, res);
     });
 
     // COMMANDS
     api.put(API_PREFIX + 'vans/:vid/evict', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await evictVan(req.params.vid, req, res);
+        await evictVan(req, res);
     });
 
     //========================================
@@ -521,27 +581,27 @@ export async function Initialize(api, keycloak) {
 
     // CREATE
     api.post(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await createInvitation(req.params.vid, req, res);
+        await createInvitation(req, res);
     });
 
     // READ
     api.get(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await readInvitation(res, req.params.iid);
+        await readInvitation(req, res);
     });
 
     // LIST
     api.get(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await listInvitations(res, req.params.vid);
+        await listInvitations(req, res);
     });
 
     // DELETE
     api.delete(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await deleteInvitation(res, req.params.iid);
+        await deleteInvitation(req, res);
     });
 
     // COMMANDS
     api.put(API_PREFIX + 'invitations/:iid/expire', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await expireInvitation(res, req.params.iid);
+        await expireInvitation(req, res);
     })
 
     //========================================
@@ -550,17 +610,17 @@ export async function Initialize(api, keycloak) {
 
     // READ
     api.get(API_PREFIX + 'members/:mid', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await readVanMember(res, req.params.mid);
+        await readVanMember(req, res);
     });
 
     // LIST
     api.get(API_PREFIX + 'vans/:vid/members', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await listVanMembers(res, req.params.vid);
+        await listVanMembers(req, res);
     });
 
     // COMMANDS
     api.put(API_PREFIX + 'members/:mid/evict', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await evictMember(req.params.mid, req, res);
+        await evictMember(req, res);
     });
 
     //========================================
@@ -576,11 +636,11 @@ export async function Initialize(api, keycloak) {
 
     // Claim Access Points
     api.get(API_PREFIX + 'backbones/:bid/access/claim', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await listClaimAccessPoints(res, req.params.bid, 'ClaimAccess');
+        await listClaimAccessPoints(req, res, 'ClaimAccess');
     });
 
     // Member Access Points
     api.get(API_PREFIX + 'backbones/:bid/access/member', keycloak.protect('realm:van-owner'), async (req, res) => {
-        await listClaimAccessPoints(res, req.params.bid, 'MemberAccess');
+        await listClaimAccessPoints(req, res, 'MemberAccess');
     });
 }

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -504,10 +504,10 @@ const listClaimAccessPoints = async function(req, res, ref) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT BackboneAccessPoints.Name as accessname, BackboneAccessPoints.Id as accessid FROM InteriorSites " +
                                       `JOIN BackboneAccessPoints ON BackboneAccessPoints.Id = InteriorSites.${ref} ` +
-                                      "WHERE InteriorSites.Backbone = $1", [bid]);
+                                      "WHERE InteriorSites.Backbone = $1 and (InteriorSites.Owner = $2 or InteriorSites.OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
         })
         let data = [];
         for (const row of result.rows) {

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -48,12 +48,12 @@ const createVan = async function(req, res) {
         const client = await ClientFromPool();
         try {
             returnStatus = 500;
-
-            const vanId = await queryWithContext(req, client, async (client, credentials) => {
+            
+            const vanId = await queryWithContext(req, client, async (client, userInfo) => {
                 //
                 // If the name is not unique within the backbone, modify it to be unique.
                 //
-                const namesResult = await client.query("SELECT Name FROM ApplicationNetworks WHERE Backbone = $1", [bid]);
+                const namesResult = await client.query("SELECT Name FROM ApplicationNetworks WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
                 let existingNames = [];
                 for (const row of namesResult.rows) {
                     existingNames.push(row.name);
@@ -89,10 +89,9 @@ const createVan = async function(req, res) {
                 //
                 // Create the application network
                 //
-                const ownerId = credentials.userId;
                 const result = await client.query(
                     `INSERT INTO ApplicationNetworks(Name, NetworkType, Backbone${extraCols}, Owner) VALUES ($1, $2, $3${extraVals}, $4) RETURNING Id`,
-                    [uniqueName, norm.nettype, bid, ownerId]
+                    [uniqueName, norm.nettype, bid, userInfo.userId]
                 );
                 const vanId = result.rows[0].id;
                 
@@ -219,11 +218,11 @@ const readVan = async function(req, res) {
     const vid = req.params.vid;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query(
                 "SELECT ApplicationNetworks.*, Backbones.Id as backboneid, Backbones.Name as backbonename " +
                 "FROM ApplicationNetworks " +
-                "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id WHERE ApplicationNetworks.Id = $1", [vid]
+                "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id WHERE ApplicationNetworks.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [vid, userInfo.userId, userInfo.userGroups]
             );
         })
 
@@ -248,9 +247,9 @@ const readInvitation = async function(req, res) {
     const client = await ClientFromPool();
     try {
         
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT MemberInvitations.Name, MemberInvitations.LifeCycle, MemberInvitations.Failure, ApplicationNetworks.Name as vanname, JoinDeadline, InstanceLimit, InstanceCount, InteractiveClaim as interactive FROM MemberInvitations " +
-                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberInvitations.MemberOf WHERE MemberInvitations.Id = $1", [iid]);
+                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberInvitations.MemberOf WHERE MemberInvitations.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [iid, userInfo.userId, userInfo.userGroups]);
         })
         
         if (result.rowCount == 1) {
@@ -273,9 +272,9 @@ const readVanMember = async function(req, res) {
     const mid = req.params.mid;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("SELECT MemberSites.*, ApplicationNetworks.Name as vanname FROM MemberSites " +
-                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberSites.MemberOf WHERE MemberSites.Id = $1", [mid]);
+                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberSites.MemberOf WHERE MemberSites.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [mid, userInfo.userId, userInfo.userGroups]);
         })
 
         if (result.rowCount == 1) {
@@ -298,8 +297,8 @@ const listVans = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("SELECT Id, Name, LifeCycle, Failure, StartTime, EndTime, DeleteDelay, NetworkType, Connected FROM ApplicationNetworks WHERE Backbone = $1", [bid])
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("SELECT Id, Name, LifeCycle, Failure, StartTime, EndTime, DeleteDelay, NetworkType, Connected FROM ApplicationNetworks WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups])
         })
 
         res.status(returnStatus).json(result.rows);
@@ -316,13 +315,13 @@ const listAllVans = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query(
                 "SELECT ApplicationNetworks.Id, Backbone, Backbones.Name as backbonename, ApplicationNetworks.Name, NetworkType, " +
                 "ApplicationNetworks.LifeCycle, ApplicationNetworks.Failure, StartTime, EndTime, DeleteDelay, Connected " +
                 "FROM ApplicationNetworks " +
-                "JOIN Backbones ON Backbones.Id = Backbone"
-            )
+                "JOIN Backbones ON Backbones.Id = Backbone " +
+                "WHERE(ApplicationNetworks.Owner = $1 or ApplicationNetworks.OwnerGroup = Any($2) or is_admin())", [userInfo.userId, userInfo.userGroups])
         })
         res.status(returnStatus).json(result.rows);
     } catch (error) {
@@ -378,10 +377,10 @@ const deleteVan = async function(req, res) {
     let returnStatus = 204;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             const memberSiteId = await client.query("SELECT Id FROM MemberSites WHERE MemberOf = $1 LIMIT 1", [vid]);
             if (memberSiteId.rowCount == 0) {
-                const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 RETURNING Certificate", [vid]);
+                const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING Certificate", [vid, userInfo.userId, userInfo.userGroups]);
                 if (delResult.rowCount == 1) {
                     if (delResult.rows[0].certificate) {
                         await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.rows[0].certificate]);
@@ -615,7 +614,7 @@ export async function Initialize(api, keycloak) {
     //========================================
     // TLS Certificates
     //========================================
-    api.get(API_PREFIX + 'tls-certificates/:cid', async (req, res) => {
+    api.get(API_PREFIX + 'tls-certificates/:cid', keycloak.protect(), async (req, res) => {
         await readCertificate(req, res);
     });
 

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -53,7 +53,7 @@ const createVan = async function(req, res) {
                 //
                 // If the name is not unique within the backbone, modify it to be unique.
                 //
-                const namesResult = await client.query("SELECT Name FROM ApplicationNetworks WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
+                const namesResult = await client.query("SELECT Name FROM ApplicationNetworks WHERE Backbone = $1", [bid]);
                 let existingNames = [];
                 for (const row of namesResult.rows) {
                     existingNames.push(row.name);
@@ -222,7 +222,7 @@ const readVan = async function(req, res) {
             return await client.query(
                 "SELECT ApplicationNetworks.*, Backbones.Id as backboneid, Backbones.Name as backbonename " +
                 "FROM ApplicationNetworks " +
-                "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id WHERE ApplicationNetworks.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [vid, userInfo.userId, userInfo.userGroups]
+                "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id WHERE ApplicationNetworks.Id = $1", [vid]
             );
         })
 
@@ -247,9 +247,9 @@ const readInvitation = async function(req, res) {
     const client = await ClientFromPool();
     try {
         
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT MemberInvitations.Name, MemberInvitations.LifeCycle, MemberInvitations.Failure, ApplicationNetworks.Name as vanname, JoinDeadline, InstanceLimit, InstanceCount, InteractiveClaim as interactive FROM MemberInvitations " +
-                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberInvitations.MemberOf WHERE MemberInvitations.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [iid, userInfo.userId, userInfo.userGroups]);
+                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberInvitations.MemberOf WHERE MemberInvitations.Id = $1", [iid]);
         })
         
         if (result.rowCount == 1) {
@@ -272,9 +272,9 @@ const readVanMember = async function(req, res) {
     const mid = req.params.mid;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT MemberSites.*, ApplicationNetworks.Name as vanname FROM MemberSites " +
-                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberSites.MemberOf WHERE MemberSites.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [mid, userInfo.userId, userInfo.userGroups]);
+                                      "JOIN ApplicationNetworks ON ApplicationNetworks.Id = MemberSites.MemberOf WHERE MemberSites.Id = $1", [mid]);
         })
 
         if (result.rowCount == 1) {
@@ -297,8 +297,8 @@ const listVans = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query("SELECT Id, Name, LifeCycle, Failure, StartTime, EndTime, DeleteDelay, NetworkType, Connected FROM ApplicationNetworks WHERE Backbone = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups])
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Name, LifeCycle, Failure, StartTime, EndTime, DeleteDelay, NetworkType, Connected FROM ApplicationNetworks WHERE Backbone = $1", [bid])
         })
 
         res.status(returnStatus).json(result.rows);
@@ -315,13 +315,12 @@ const listAllVans = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query(
                 "SELECT ApplicationNetworks.Id, Backbone, Backbones.Name as backbonename, ApplicationNetworks.Name, NetworkType, " +
                 "ApplicationNetworks.LifeCycle, ApplicationNetworks.Failure, StartTime, EndTime, DeleteDelay, Connected " +
                 "FROM ApplicationNetworks " +
-                "JOIN Backbones ON Backbones.Id = Backbone " +
-                "WHERE(ApplicationNetworks.Owner = $1 or ApplicationNetworks.OwnerGroup = Any($2) or is_admin())", [userInfo.userId, userInfo.userGroups])
+                "JOIN Backbones ON Backbones.Id = Backbone")
         })
         res.status(returnStatus).json(result.rows);
     } catch (error) {
@@ -377,10 +376,10 @@ const deleteVan = async function(req, res) {
     let returnStatus = 204;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             const memberSiteId = await client.query("SELECT Id FROM MemberSites WHERE MemberOf = $1 LIMIT 1", [vid]);
             if (memberSiteId.rowCount == 0) {
-                const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING Certificate", [vid, userInfo.userId, userInfo.userGroups]);
+                const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 RETURNING Certificate", [vid]);
                 if (delResult.rowCount == 1) {
                     if (delResult.rows[0].certificate) {
                         await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.rows[0].certificate]);
@@ -504,10 +503,10 @@ const listClaimAccessPoints = async function(req, res, ref) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT BackboneAccessPoints.Name as accessname, BackboneAccessPoints.Id as accessid FROM InteriorSites " +
                                       `JOIN BackboneAccessPoints ON BackboneAccessPoints.Id = InteriorSites.${ref} ` +
-                                      "WHERE InteriorSites.Backbone = $1 and (InteriorSites.Owner = $2 or InteriorSites.OwnerGroup = Any($3) or is_admin())", [bid, userInfo.userId, userInfo.userGroups]);
+                                      "WHERE InteriorSites.Backbone = $1", [bid]);
         })
         let data = [];
         for (const row of result.rows) {

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -39,7 +39,7 @@ const createVan = async function(req, res) {
         const norm = ValidateAndNormalizeFields(fields, {
             'name'        : {type: 'dnsname',    optional: false},
             'nettype'     : {type: 'dnsname',    optional: false},
-            'ownerGroup'  : {type: 'string',     optional: true, default: null},
+            'ownerGroup'  : {type: 'string',     optional: true, default: ''},
             'starttime'   : {type: 'timestampz', optional: true, default: null},
             'endtime'     : {type: 'timestampz', optional: true, default: null},
             'deletedelay' : {type: 'interval',   optional: true, default: null},

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -38,8 +38,8 @@ const createVan = async function(req, res) {
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
             'name'        : {type: 'dnsname',    optional: false},
-            'nettype'     : { type: 'dnsname', optional: false },
-            'ownerGroup'  : { type: 'string', optional: true, default: null },
+            'nettype'     : {type: 'dnsname',    optional: false},
+            'ownerGroup'  : {type: 'string',     optional: true, default: null},
             'starttime'   : {type: 'timestampz', optional: true, default: null},
             'endtime'     : {type: 'timestampz', optional: true, default: null},
             'deletedelay' : {type: 'interval',   optional: true, default: null},

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -378,7 +378,7 @@ const deleteVan = async function(req, res) {
     let returnStatus = 204;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client) => {
             const memberSiteId = await client.query("SELECT Id FROM MemberSites WHERE MemberOf = $1 LIMIT 1", [vid]);
             if (memberSiteId.rowCount == 0) {
                 const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 RETURNING Certificate", [vid]);
@@ -386,7 +386,7 @@ const deleteVan = async function(req, res) {
                     if (delResult.rows[0].certificate) {
                         await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.rows[0].certificate]);
                     }
-                    res.status(returnStatus).send("Application network deleted");
+                    return { status: returnStatus, message: "Application network deleted" };
                 } else {
                     returnStatus = 404;
                     throw new Error("Application network not found");
@@ -396,6 +396,7 @@ const deleteVan = async function(req, res) {
                 throw new Error('Cannot delete application network because is still has members');
             }
         })
+        res.status(result.status).send(result.message);
     } catch (error) {
         // Only set 500 if returnStatus is still at default (204), preserving specific error codes
         if (returnStatus === 204) {
@@ -423,12 +424,12 @@ const deleteInvitation = async function(req, res) {
                         await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
                     }
                 }
-                res.status(returnStatus).end();
             } else {
                 returnStatus = 400;
                 throw new Error('Cannot delete invitation because members still exist that use the invitation');
             }
         })
+        res.status(returnStatus).end();
     } catch (error) {
         // Only set 500 if returnStatus is still at default (204), preserving specific error codes
         if (returnStatus === 204) {

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -39,7 +39,7 @@ const createVan = async function(req, res) {
         const norm = ValidateAndNormalizeFields(fields, {
             'name'        : {type: 'dnsname',    optional: false},
             'nettype'     : { type: 'dnsname', optional: false },
-            'ownerGroup'  : { type: 'string', optional: false },
+            'ownerGroup'  : { type: 'string', optional: true, default: null },
             'starttime'   : {type: 'timestampz', optional: true, default: null},
             'endtime'     : {type: 'timestampz', optional: true, default: null},
             'deletedelay' : {type: 'interval',   optional: true, default: null},
@@ -107,7 +107,6 @@ const createVan = async function(req, res) {
             returnStatus = 201;
             res.status(returnStatus).json({id: vanId});
         } catch (error) {
-            await client.query("ROLLBACK");
             res.status(returnStatus).send(error.stack);
         } finally {
             client.release();
@@ -202,7 +201,6 @@ const createInvitation = async function(req, res) {
             returnStatus = 201;
             res.status(returnStatus).json({id: invitationId});
         } catch (error) {
-            await client.query("ROLLBACK");
             returnStatus = 500
             res.status(returnStatus).send(error.message);
         } finally {
@@ -385,24 +383,24 @@ const deleteVan = async function(req, res) {
             if (memberSiteId.rowCount == 0) {
                 const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 RETURNING Certificate", [vid]);
                 if (delResult.rowCount == 1) {
-                    if (delResult.certificate) {
-                        await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.certificate]);
+                    if (delResult.rows[0].certificate) {
+                        await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.rows[0].certificate]);
                     }
                     res.status(returnStatus).send("Application network deleted");
                 } else {
-                    await client.query("ROLLBACK");
                     returnStatus = 404;
-                    res.status(returnStatus).send("Application network not found");
+                    throw new Error("Application network not found");
                 }
             } else {
-                await client.query("ROLLBACK");
                 returnStatus = 400;
-                res.status(returnStatus).send('Cannot delete application network because is still has members');
+                throw new Error('Cannot delete application network because is still has members');
             }
         })
     } catch (error) {
-        await client.query("ROLLBACK");
-        returnStatus = 500;
+        // Only set 500 if returnStatus is still at default (204), preserving specific error codes
+        if (returnStatus === 204) {
+            returnStatus = 500;
+        }
         res.status(returnStatus).send(error.message);
     } finally {
         client.release();
@@ -415,23 +413,6 @@ const deleteInvitation = async function(req, res) {
     let returnStatus = 204;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT id FROM MemberSites WHERE Invitation = $1 LIMIT 1", [iid]);
-        if (result.rowCount == 0) {
-            const invResult = await client.query("DELETE FROM MemberInvitations WHERE Id = $1 RETURNING Certificate", [iid]);
-            if (invResult.rowCount == 1) {
-                const row = invResult.rows[0];
-                if (row.certificate) {
-                    await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
-                }
-            }
-            res.status(returnStatus).end();
-        } else {
-            returnStatus = 400;
-            res.status(returnStatus).send('Cannot delete invitation because members still exist that use the invitation');
-        }
-        await client.query("COMMIT");
-
         await queryWithContext(req, client, async (client) => {
             const result = await client.query("SELECT id FROM MemberSites WHERE Invitation = $1 LIMIT 1", [iid]);
             if (result.rowCount == 0) {
@@ -445,12 +426,14 @@ const deleteInvitation = async function(req, res) {
                 res.status(returnStatus).end();
             } else {
                 returnStatus = 400;
-                res.status(returnStatus).send('Cannot delete invitation because members still exist that use the invitation');
+                throw new Error('Cannot delete invitation because members still exist that use the invitation');
             }
         })
     } catch (error) {
-        await client.query("ROLLBACK");
-        returnStatus = 500
+        // Only set 500 if returnStatus is still at default (204), preserving specific error codes
+        if (returnStatus === 204) {
+            returnStatus = 500;
+        }
         res.status(returnStatus).send(error.message);
     } finally {
         client.release();

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -38,7 +38,8 @@ const createVan = async function(req, res) {
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
             'name'        : {type: 'dnsname',    optional: false},
-            'nettype'     : {type: 'dnsname',    optional: false},
+            'nettype'     : { type: 'dnsname', optional: false },
+            'ownerGroup'  : { type: 'string', optional: false },
             'starttime'   : {type: 'timestampz', optional: true, default: null},
             'endtime'     : {type: 'timestampz', optional: true, default: null},
             'deletedelay' : {type: 'interval',   optional: true, default: null},
@@ -80,14 +81,18 @@ const createVan = async function(req, res) {
                     extraVals += `, '${norm.deletedelay}'`;
                 }
 
+                if (norm.ownerGroup) {
+                    extraCols += ', OwnerGroup';
+                    extraVals += `, '${norm.ownerGroup}'`;
+                }
+
                 //
                 // Create the application network
                 //
                 const ownerId = credentials.userId;
-                const ownerGroups = credentials.userGroups;
                 const result = await client.query(
-                    `INSERT INTO ApplicationNetworks(Name, NetworkType, Backbone${extraCols}, Owner, OwnerGroups) VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`,
-                    [uniqueName, norm.nettype, bid, ownerId, ownerGroups]
+                    `INSERT INTO ApplicationNetworks(Name, NetworkType, Backbone${extraCols}, Owner) VALUES ($1, $2, $3${extraVals}, $4) RETURNING Id`,
+                    [uniqueName, norm.nettype, bid, ownerId]
                 );
                 const vanId = result.rows[0].id;
                 

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -534,32 +534,32 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // CREATE
-    api.post(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.post(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:can-create-van'), async (req, res) => {
         await createVan(req, res);
     });
 
     // READ
-    api.get(API_PREFIX + 'vans/:vid', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'vans/:vid', keycloak.protect('realm:can-read-van'), async (req, res) => {
         await readVan(req, res);
     });
 
     // LIST
-    api.get(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'backbones/:bid/vans', keycloak.protect('realm:can-list-vans'), async (req, res) => {
         await listVans(req, res);
     });
 
     // LIST ALL
-    api.get(API_PREFIX + 'vans', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'vans', keycloak.protect('realm:can-list-all-vans'), async (req, res) => {
         await listAllVans(req, res);
     });
 
     // DELETE
-    api.delete(API_PREFIX + 'vans/:vid', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.delete(API_PREFIX + 'vans/:vid', keycloak.protect('realm:can-delete-van'), async (req, res) => {
         await deleteVan(req, res);
     });
 
     // COMMANDS
-    api.put(API_PREFIX + 'vans/:vid/evict', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.put(API_PREFIX + 'vans/:vid/evict', keycloak.protect('realm:can-evict-van'), async (req, res) => {
         await evictVan(req, res);
     });
 
@@ -568,27 +568,27 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // CREATE
-    api.post(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.post(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:can-create-invitation'), async (req, res) => {
         await createInvitation(req, res);
     });
 
     // READ
-    api.get(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:can-read-invitation'), async (req, res) => {
         await readInvitation(req, res);
     });
 
     // LIST
-    api.get(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'vans/:vid/invitations', keycloak.protect('realm:can-list-invitations'), async (req, res) => {
         await listInvitations(req, res);
     });
 
     // DELETE
-    api.delete(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.delete(API_PREFIX + 'invitations/:iid', keycloak.protect('realm:can-delete-invitation'), async (req, res) => {
         await deleteInvitation(req, res);
     });
 
     // COMMANDS
-    api.put(API_PREFIX + 'invitations/:iid/expire', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.put(API_PREFIX + 'invitations/:iid/expire', keycloak.protect('realm:can-expire-invitation'), async (req, res) => {
         await expireInvitation(req, res);
     })
 
@@ -597,24 +597,24 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // READ
-    api.get(API_PREFIX + 'members/:mid', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'members/:mid', keycloak.protect('realm:can-read-van-member'), async (req, res) => {
         await readVanMember(req, res);
     });
 
     // LIST
-    api.get(API_PREFIX + 'vans/:vid/members', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'vans/:vid/members', keycloak.protect('realm:can-list-van-members'), async (req, res) => {
         await listVanMembers(req, res);
     });
 
     // COMMANDS
-    api.put(API_PREFIX + 'members/:mid/evict', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.put(API_PREFIX + 'members/:mid/evict', keycloak.protect('realm:can-evict-member'), async (req, res) => {
         await evictMember(req, res);
     });
 
     //========================================
     // TLS Certificates
     //========================================
-    api.get(API_PREFIX + 'tls-certificates/:cid', keycloak.protect(), async (req, res) => {
+    api.get(API_PREFIX + 'tls-certificates/:cid', keycloak.protect('realm:can-read-certificate'), async (req, res) => {
         await readCertificate(req, res);
     });
 
@@ -623,12 +623,12 @@ export async function Initialize(api, keycloak) {
     //========================================
 
     // Claim Access Points
-    api.get(API_PREFIX + 'backbones/:bid/access/claim', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'backbones/:bid/access/claim', keycloak.protect('realm:can-list-claim-access-points'), async (req, res) => {
         await listClaimAccessPoints(req, res, 'ClaimAccess');
     });
 
     // Member Access Points
-    api.get(API_PREFIX + 'backbones/:bid/access/member', keycloak.protect('realm:van-owner'), async (req, res) => {
+    api.get(API_PREFIX + 'backbones/:bid/access/member', keycloak.protect('realm:can-list-member-access-points'), async (req, res) => {
         await listClaimAccessPoints(req, res, 'MemberAccess');
     });
 }

--- a/components/management-controller/src/backbone-links.js
+++ b/components/management-controller/src/backbone-links.js
@@ -105,8 +105,7 @@ const reconcileBackboneConnections = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back reconcile-backbone-connections transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in reconcile-backbone-connections transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -150,8 +149,7 @@ const resolveTLSData = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back resolveTLSData transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in resolveTLSData transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -170,14 +168,13 @@ const resolveControllerRecord = async function() {
             if (result.rowCount == 1) {
                 setTimeout(resolveTLSData, 0);
             } else {
-                client.query("INSERT INTO ManagementControllers (Name) VALUES ($1)", [controller_name]);
+                await client.query("INSERT INTO ManagementControllers (Name) VALUES ($1)", [controller_name]);
                 setTimeout(resolveTLSData, 1000);
                 Log(`No management controller found for '${controller_name}', created new record`);
             }
         })
     } catch (err) {
-        Log(`Rolling back resolveControllerRecord transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in resolveControllerRecord transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();

--- a/components/management-controller/src/backbone-links.js
+++ b/components/management-controller/src/backbone-links.js
@@ -25,7 +25,7 @@
 
 import { LoadSecret } from '@skupperx/modules/kube'
 import { Log } from '@skupperx/modules/log'
-import { ClientFromPool, queryWithContext, SYSTEM_USER_ID } from './db.js';
+import { ClientFromPool, queryWithContext } from './db.js';
 import { OpenConnection, CloseConnection } from '@skupperx/modules/amqp'
 
 let controller_name;
@@ -69,10 +69,10 @@ const deleteConnection = async function(bbid) {
 
 const reconcileBackboneConnections = async function() {
     let reschedule_delay = 30000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query(
                 "SELECT BackboneAccessPoints.*, InteriorSites.Backbone " +
                 "FROM BackboneAccessPoints " +
@@ -116,9 +116,9 @@ const reconcileBackboneConnections = async function() {
 
 const resolveTLSData = async function() {
     let reschedule_delay = 1000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query("SELECT * FROM ManagementControllers WHERE Name = $1 and LifeCycle = 'ready'", [controller_name]);
             if (result.rowCount == 1) {
                 const tls_result = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [result.rows[0].certificate]);
@@ -163,9 +163,9 @@ const resolveTLSData = async function() {
 
 const resolveControllerRecord = async function() {
     let reschedule_delay = -1;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query("SELECT * FROM ManagementControllers WHERE Name = $1", [controller_name]);
             if (result.rowCount == 1) {
                 setTimeout(resolveTLSData, 0);

--- a/components/management-controller/src/backbone-links.js
+++ b/components/management-controller/src/backbone-links.js
@@ -25,7 +25,7 @@
 
 import { LoadSecret } from '@skupperx/modules/kube'
 import { Log } from '@skupperx/modules/log'
-import { ClientFromPool, queryWithContext } from './db.js';
+import { ClientFromPool } from './db.js';
 import { OpenConnection, CloseConnection } from '@skupperx/modules/amqp'
 
 let controller_name;
@@ -71,41 +71,42 @@ const reconcileBackboneConnections = async function() {
     let reschedule_delay = 30000;
     const client = await ClientFromPool('system');
     try {
-        
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query(
-                "SELECT BackboneAccessPoints.*, InteriorSites.Backbone " +
-                "FROM BackboneAccessPoints " +
-                "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " + 
-                "JOIN Backbones ON Backbones.Id = InteriorSites.Backbone " +
-                "WHERE BackboneAccessPoints.Lifecycle = 'ready' and Kind = 'manage'");
-            let db_rows = {};
-            for (const row of result.rows) {
-                if (!db_rows[row.backbone]) {
-                    db_rows[row.backbone] = row;
-                }
+        await client.query('BEGIN');
+        const result = await client.query(
+            "SELECT BackboneAccessPoints.*, InteriorSites.Backbone " +
+            "FROM BackboneAccessPoints " +
+            "JOIN InteriorSites ON InteriorSites.Id = InteriorSite " + 
+            "JOIN Backbones ON Backbones.Id = InteriorSites.Backbone " +
+            "WHERE BackboneAccessPoints.Lifecycle = 'ready' and Kind = 'manage'");
+        let db_rows = {};
+        for (const row of result.rows) {
+            if (!db_rows[row.backbone]) {
+                db_rows[row.backbone] = row;
             }
-    
-            for (const bbid of Object.keys(bbConnections)) {
-                bbConnections[bbid].toDelete = true;
+        }
+
+        for (const bbid of Object.keys(bbConnections)) {
+            bbConnections[bbid].toDelete = true;
+        }
+
+        for (const [bbid, row] of Object.entries(db_rows)) {
+            if (bbConnections[bbid]) {
+                bbConnections[bbid].toDelete = false;
+            } else {
+                await createConnection(bbid, row);
             }
-    
-            for (const [bbid, row] of Object.entries(db_rows)) {
-                if (bbConnections[bbid]) {
-                    bbConnections[bbid].toDelete = false;
-                } else {
-                    await createConnection(bbid, row);
-                }
+        }
+
+        for (const bbid of Object.keys(bbConnections)) {
+            if (bbConnections[bbid].toDelete) {
+                await deleteConnection(bbid);
             }
-    
-            for (const bbid of Object.keys(bbConnections)) {
-                if (bbConnections[bbid].toDelete) {
-                    await deleteConnection(bbid);
-                }
-            }
-        })
+        }
+
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in reconcile-backbone-connections transaction: ${err.stack}`);
+        Log(`Rolling back reconcile-backbone-connections transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -117,39 +118,40 @@ const resolveTLSData = async function() {
     let reschedule_delay = 1000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query("SELECT * FROM ManagementControllers WHERE Name = $1 and LifeCycle = 'ready'", [controller_name]);
-            if (result.rowCount == 1) {
-                const tls_result = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [result.rows[0].certificate]);
-                if (tls_result.rowCount == 1) {
-                    const secret = await LoadSecret(tls_result.rows[0].objectname);
-                    let count = 0;
-                    for (const [key, value] of Object.entries(secret.data)) {
-                        if (key == 'ca.crt') {
-                            tls_ca = Buffer.from(value, 'base64');
-                            count += 1;
-                        } else if (key == 'tls.crt') {
-                            tls_cert = Buffer.from(value, 'base64');
-                            count += 1;
-                        } else if (key == 'tls.key') {
-                            tls_key = Buffer.from(value, 'base64');
-                            count += 1;
-                        }
+        await client.query('BEGIN');
+        const result = await client.query("SELECT * FROM ManagementControllers WHERE Name = $1 and LifeCycle = 'ready'", [controller_name]);
+        if (result.rowCount == 1) {
+            const tls_result = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [result.rows[0].certificate]);
+            if (tls_result.rowCount == 1) {
+                const secret = await LoadSecret(tls_result.rows[0].objectname);
+                let   count  = 0;
+                for (const [key, value] of Object.entries(secret.data)) {
+                    if (key == 'ca.crt') {
+                        tls_ca = Buffer.from(value, 'base64');
+                        count += 1;
+                    } else if (key == 'tls.crt') {
+                        tls_cert = Buffer.from(value, 'base64');
+                        count += 1;
+                    } else if (key == 'tls.key') {
+                        tls_key = Buffer.from(value, 'base64');
+                        count += 1;
                     }
-
-                    if (count != 3) {
-                        throw (Error(`Unexpected set of values from TLS secret data - expected 3, got ${count}`));
-                    }
-
-                    reschedule_delay = -1;
-                    setTimeout(reconcileBackboneConnections, 0);
-                } else {
-                    throw (Error(`Expected to find a TlsCertificate record for ready controller: ${result.rows[0].certificate}`));
                 }
+
+                if (count != 3) {
+                    throw(Error(`Unexpected set of values from TLS secret data - expected 3, got ${count}`));
+                }
+
+                reschedule_delay = -1;
+                setTimeout(reconcileBackboneConnections, 0);
+            } else {
+                throw(Error(`Expected to find a TlsCertificate record for ready controller: ${result.rows[0].certificate}`));
             }
-        })
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in resolveTLSData transaction: ${err.stack}`);
+        Log(`Rolling back resolveTLSData transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -163,18 +165,19 @@ const resolveControllerRecord = async function() {
     let reschedule_delay = -1;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query("SELECT * FROM ManagementControllers WHERE Name = $1", [controller_name]);
-            if (result.rowCount == 1) {
-                setTimeout(resolveTLSData, 0);
-            } else {
-                await client.query("INSERT INTO ManagementControllers (Name) VALUES ($1)", [controller_name]);
-                setTimeout(resolveTLSData, 1000);
-                Log(`No management controller found for '${controller_name}', created new record`);
-            }
-        })
+        await client.query('BEGIN');
+        const result = await client.query("SELECT * FROM ManagementControllers WHERE Name = $1", [controller_name]);
+        if (result.rowCount == 1) {
+            setTimeout(resolveTLSData, 0);
+        } else {
+            await client.query("INSERT INTO ManagementControllers (Name) VALUES ($1)", [controller_name]);
+            setTimeout(resolveTLSData, 1000);
+            Log(`No management controller found for '${controller_name}', created new record`);
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in resolveControllerRecord transaction: ${err.stack}`);
+        Log(`Rolling back resolveControllerRecord transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();

--- a/components/management-controller/src/certs.js
+++ b/components/management-controller/src/certs.js
@@ -21,7 +21,7 @@
 
 import { ApplyObject, LoadCertificate, WatchSecrets, WatchCertificates } from '@skupperx/modules/kube'
 import { Log } from '@skupperx/modules/log'
-import { ClientFromPool, IntervalMilliseconds } from './db.js';
+import { ClientFromPool, IntervalMilliseconds, queryWithContext, SYSTEM_USER_ID } from './db.js';
 import { BackboneExpiration, DefaultCaExpiration, DefaultCertExpiration, SiteDataplaneImage, SiteControllerImage, RootIssuer, CertOrganization } from './config.js';
 import { SiteCertificateChanged, AccessCertificateChanged } from './sync-management.js';
 import { CompleteMember } from './claim-server.js';
@@ -68,24 +68,26 @@ const processNewManagementControllers = async function() {
 // When new backbones are created, add a certificate request to begin the full setup of the network.
 //
 const processNewBackbones = async function() {
-    var reschedule_delay = 2000;
+    let reschedule_delay = 2000;
     const client = await ClientFromPool();
-    try {
-        await client.query('BEGIN');
-        const result = await client.query("SELECT * FROM Backbones WHERE Lifecycle = 'new' LIMIT 1");
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Backbone Network: ${row.name}`);
-            var duration_ms;
-            duration_ms = IntervalMilliseconds(BackboneExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Backbone) VALUES(gen_random_uuid(), 'backboneCA', now(), now(), $1, $2)",
-                [duration_ms / 3600000, row.id]
-                );
-            await client.query("UPDATE Backbones SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+    try {  
+        
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query("SELECT * FROM Backbones WHERE Lifecycle = 'new' LIMIT 1");
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Backbone Network: ${row.name}`);
+                let duration_ms;
+                duration_ms = IntervalMilliseconds(BackboneExpiration());
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Backbone) VALUES(gen_random_uuid(), 'backboneCA', now(), now(), $1, $2)",
+                    [duration_ms / 3600000, row.id]
+                    );
+                await client.query("UPDATE Backbones SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            }
+
+        })
     } catch (err) {
         Log(`Rolling back new-backbone transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -100,33 +102,33 @@ const processNewBackbones = async function() {
 //
 //
 const processNewAccessPoints = async function() {
-    var reschedule_delay = 2000;
+    let reschedule_delay = 2000;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            "SELECT BackboneAccessPoints.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM BackboneAccessPoints " +
-            "JOIN InteriorSites ON BackboneAccessPoints.InteriorSite = InteriorSites.Id " +
-            "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE BackboneAccessPoints.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
-        );
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Backbone Access Point: ${row.name}`);
-            var duration_ms;
-
-            if (row.endtime) {
-                duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
-            } else {
-                duration_ms = IntervalMilliseconds(DefaultCaExpiration());
-            }
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, AccessPoint, Issuer, Hostname) VALUES(gen_random_uuid(), 'accessPoint', now(), now(), $1, $2, $3, $4)",
-                [duration_ms / 3600000, row.id, row.bbca, row.hostname]
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
+                "SELECT BackboneAccessPoints.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM BackboneAccessPoints " +
+                "JOIN InteriorSites ON BackboneAccessPoints.InteriorSite = InteriorSites.Id " +
+                "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE BackboneAccessPoints.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
             );
-            await client.query("UPDATE BackboneAccessPoints SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Backbone Access Point: ${row.name}`);
+                let duration_ms;
+    
+                if (row.endtime) {
+                    duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
+                } else {
+                    duration_ms = IntervalMilliseconds(DefaultCaExpiration());
+                }
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, AccessPoint, Issuer, Hostname) VALUES(gen_random_uuid(), 'accessPoint', now(), now(), $1, $2, $3, $4)",
+                    [duration_ms / 3600000, row.id, row.bbca, row.hostname]
+                );
+                await client.query("UPDATE BackboneAccessPoints SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            } 
+        })
     } catch (err) {
         Log(`Rolling back new-access-point transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -143,35 +145,35 @@ const processNewAccessPoints = async function() {
 // When new networks are created, add a certificate request to begin the full setup of the network.
 //
 const processNewNetworks = async function() {
-    var reschedule_delay = 2000;
+    let reschedule_delay = 2000;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            "SELECT ApplicationNetworks.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM ApplicationNetworks " + 
-            "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id " +
-            "WHERE ApplicationNetworks.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
-        );
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Application Network: ${row.name}`);
-            const van_id = 'v' + row.id.substr(-5);
-            var   duration_ms;
-
-            if (row.endtime) {
-                duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
-                // TODO - if duration is greater than the default CA expiration, reduce it to the default.
-            } else {
-                duration_ms = IntervalMilliseconds(DefaultCaExpiration());
-            }
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ApplicationNetwork, Issuer) VALUES(gen_random_uuid(), 'vanCA', now(), $1, $2, $3, $4)",
-                [row.starttime, Math.trunc(duration_ms / 3600000), row.id, row.bbca]
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
+                "SELECT ApplicationNetworks.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM ApplicationNetworks " + 
+                "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id " +
+                "WHERE ApplicationNetworks.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
             );
-            await client.query("UPDATE ApplicationNetworks SET Lifecycle = 'skx_cr_created', VanId = $1 WHERE Id = $2", [van_id, row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Application Network: ${row.name}`);
+                const van_id = 'v' + row.id.substr(-5);
+                let duration_ms;
+    
+                if (row.endtime) {
+                    duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
+                    // TODO - if duration is greater than the default CA expiration, reduce it to the default.
+                } else {
+                    duration_ms = IntervalMilliseconds(DefaultCaExpiration());
+                }
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ApplicationNetwork, Issuer) VALUES(gen_random_uuid(), 'vanCA', now(), $1, $2, $3, $4)",
+                    [row.starttime, Math.trunc(duration_ms / 3600000), row.id, row.bbca]
+                );
+                await client.query("UPDATE ApplicationNetworks SET Lifecycle = 'skx_cr_created', VanId = $1 WHERE Id = $2", [van_id, row.id]);
+                reschedule_delay = 0;
+            }
+        })
     } catch (err) {
         Log(`Rolling back new-network transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -186,26 +188,27 @@ const processNewNetworks = async function() {
 // processNewInteriorSites
 //
 const processNewInteriorSites = async function() {
-    var reschedule_delay = 2000;
+    let reschedule_delay = 2000;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
+
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
             "SELECT InteriorSites.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM InteriorSites " + 
             "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE InteriorSites.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
-        );
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Interior Site: ${row.name}`);
-            var duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, InteriorSite, Issuer) VALUES(gen_random_uuid(), 'interiorRouter', now(), now(), $1, $2, $3)",
-                [duration_ms / 3600000, row.id, row.bbca]
             );
-            await client.query("UPDATE InteriorSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Interior Site: ${row.name}`);
+                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, InteriorSite, Issuer) VALUES(gen_random_uuid(), 'interiorRouter', now(), now(), $1, $2, $3)",
+                    [duration_ms / 3600000, row.id, row.bbca]
+                );
+                await client.query("UPDATE InteriorSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            }
+        })
     } catch (err) {
         Log(`Rolling back new-interior-site transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -220,26 +223,26 @@ const processNewInteriorSites = async function() {
 // processNewInvitations
 //
 const processNewInvitations = async function() {
-    var reschedule_delay = 2000;
+    let reschedule_delay = 2000;
     const client = await ClientFromPool();
-    try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            "SELECT MemberInvitations.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberInvitations " + 
-            "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id WHERE MemberInvitations.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
-        );
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Invitation: ${row.name}`);
-            var duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Invitation, Issuer) VALUES(gen_random_uuid(), 'memberClaim', now(), now(), $1, $2, $3)",
-                [duration_ms / 3600000, row.id, row.vanca]
+    try {  
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
+                "SELECT MemberInvitations.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberInvitations " + 
+                "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id WHERE MemberInvitations.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
             );
-            await client.query("UPDATE MemberInvitations SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Invitation: ${row.name}`);
+                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Invitation, Issuer) VALUES(gen_random_uuid(), 'memberClaim', now(), now(), $1, $2, $3)",
+                    [duration_ms / 3600000, row.id, row.vanca]
+                );
+                await client.query("UPDATE MemberInvitations SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            }
+        })
     } catch (err) {
         Log(`Rolling back new-invitation transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -254,26 +257,26 @@ const processNewInvitations = async function() {
 // processNewMemberSites
 //
 const processNewMemberSites = async function() {
-    var reschedule_delay = 2000;
+    let reschedule_delay = 2000;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            "SELECT MemberSites.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberSites " + 
-            "JOIN ApplicationNetworks ON MemberSites.MemberOf = ApplicationNetworks.Id WHERE MemberSites.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
-        );
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Member Site: ${row.name}`);
-            var duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Site, Issuer) VALUES(gen_random_uuid(), 'vanSite', now(), now(), $1, $2, $3)",
-                [duration_ms / 3600000, row.id, row.vanca]
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
+                "SELECT MemberSites.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberSites " + 
+                "JOIN ApplicationNetworks ON MemberSites.MemberOf = ApplicationNetworks.Id WHERE MemberSites.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
             );
-            await client.query("UPDATE MemberSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Member Site: ${row.name}`);
+                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Site, Issuer) VALUES(gen_random_uuid(), 'vanSite', now(), now(), $1, $2, $3)",
+                    [duration_ms / 3600000, row.id, row.vanca]
+                );
+                await client.query("UPDATE MemberSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            }
+        })
     } catch (err) {
         Log(`Rolling back new-member-site transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -286,29 +289,30 @@ const processNewMemberSites = async function() {
 
 
 const processNewNetworkCredentials = async function() {
-    var reschedule_delay = 2000;
+    let reschedule_delay = 2000;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            "SELECT NetworkCredentials.*, ApplicationNetworks.Lifecycle as vanlc, Backbones.Certificate as vanca " +
-            "FROM NetworkCredentials " + 
-            "JOIN ApplicationNetworks ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
-            "JOIN Backbones ON Backbones.id = ApplicationNetworks.Backbone " +
-            "WHERE NetworkCredentials.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
-        );
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Network Credential: ${row.name}`);
-            var duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, NetworkCredential, Issuer) VALUES(gen_random_uuid(), 'vanCredential', now(), now(), $1, $2, $3)",
-                [duration_ms / 3600000, row.id, row.vanca]
+        
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
+                "SELECT NetworkCredentials.*, ApplicationNetworks.Lifecycle as vanlc, Backbones.Certificate as vanca " +
+                "FROM NetworkCredentials " + 
+                "JOIN ApplicationNetworks ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
+                "JOIN Backbones ON Backbones.id = ApplicationNetworks.Backbone " +
+                "WHERE NetworkCredentials.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
             );
-            await client.query("UPDATE NetworkCredentials SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Network Credential: ${row.name}`);
+                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, NetworkCredential, Issuer) VALUES(gen_random_uuid(), 'vanCredential', now(), now(), $1, $2, $3)",
+                    [duration_ms / 3600000, row.id, row.vanca]
+                );
+                await client.query("UPDATE NetworkCredentials SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            }      
+        })
     } catch (err) {
         Log(`Rolling back new-network-credential transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -425,120 +429,122 @@ const processNewCertificateRequests = async function() {
 const secretAdded = async function(dblink, secret) {
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query("SELECT * FROM CertificateRequests WHERE Id = $1", [dblink]);
-        var ref_table;
-        var ref_id;
-        var ref_label;
-        var is_ca = false;
-        var alertSiteCertChanged   = false;
-        var alertAccessCertChanged = false;
-        var alertMemberCompletion  = false;
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
 
-        if (result.rowCount == 1) {
-            const cert_request = result.rows[0];
+            const result = await client.query("SELECT * FROM CertificateRequests WHERE Id = $1", [dblink]);
+            var ref_table;
+            var ref_id;
+            var ref_label;
+            var is_ca = false;
+            var alertSiteCertChanged = false;
+            var alertAccessCertChanged = false;
+            var alertMemberCompletion = false;
 
-            if (cert_request.managementcontroller) {
-                ref_table  = 'ManagementControllers';
-                ref_id     = cert_request.managementcontroller;
-                ref_label  = 'Management Controller';
-            } else if (cert_request.backbone) {
-                ref_table  = 'Backbones';
-                ref_id     = cert_request.backbone;
-                is_ca      = true;
-                ref_label  = 'Backbone';
-            } else if (cert_request.interiorsite) {
-                ref_table  = 'InteriorSites';
-                ref_id     = cert_request.interiorsite;
-                ref_label  = 'Backbone Site';
-                alertSiteCertChanged = true;
-            } else if (cert_request.accesspoint) {
-                ref_table  = 'BackboneAccessPoints';
-                ref_id     = cert_request.accesspoint;
-                ref_label  = 'Access Point';
-                alertAccessCertChanged = true;
-            } else if (cert_request.applicationnetwork) {
-                ref_table  = 'ApplicationNetworks';
-                ref_id     = cert_request.applicationnetwork;
-                is_ca      = true;
-                ref_label  = 'VAN';
-            } else if (cert_request.networkcredential) {
-                ref_table  = 'NetworkCredentials';
-                ref_id     = cert_request.networkcredential;
-                is_ca      = false;
-                ref_label  = 'VAN Attach';
-            } else if (cert_request.invitation) {
-                ref_table  = 'MemberInvitations';
-                ref_id     = cert_request.invitation;
-                ref_label  = 'Member Invitation';
-            } else if (cert_request.site) {
-                ref_table  = 'MemberSites';
-                ref_id     = cert_request.site;
-                ref_label  = 'Member Site';
-                alertMemberCompletion = true;
-            } else {
-                throw new Error('Unknown Target');
-            }
-            const cert_object = await LoadCertificate(secret.metadata.name);
-            const expiration  = cert_object.status.notAfter    ? new Date(cert_object.status.notAfter) : undefined;
-            const renewal     = cert_object.status.renewalTime ? new Date(cert_object.status.renewalTime) : undefined;
-            const signed_by   = secret.metadata.annotations['skupper.io/skx-issuerlink'];
-            const get_name    = await client.query(
-                `SELECT name FROM ${ref_table} WHERE Id = $1`,
-                [ref_id]
-            );
-            const label = `${ref_label}: ${get_name.rows[0].name}`;
-            if (signed_by == 'root') {
-                await client.query(
-                    "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label) VALUES ($1, $2, $3, $4, $5, $6)",
-                    [dblink, is_ca, secret.metadata.name, expiration, renewal, label]
+            if (result.rowCount == 1) {
+                const cert_request = result.rows[0];
+
+                if (cert_request.managementcontroller) {
+                    ref_table = 'ManagementControllers';
+                    ref_id = cert_request.managementcontroller;
+                    ref_label = 'Management Controller';
+                } else if (cert_request.backbone) {
+                    ref_table = 'Backbones';
+                    ref_id = cert_request.backbone;
+                    is_ca = true;
+                    ref_label = 'Backbone';
+                } else if (cert_request.interiorsite) {
+                    ref_table = 'InteriorSites';
+                    ref_id = cert_request.interiorsite;
+                    ref_label = 'Backbone Site';
+                    alertSiteCertChanged = true;
+                } else if (cert_request.accesspoint) {
+                    ref_table = 'BackboneAccessPoints';
+                    ref_id = cert_request.accesspoint;
+                    ref_label = 'Access Point';
+                    alertAccessCertChanged = true;
+                } else if (cert_request.applicationnetwork) {
+                    ref_table = 'ApplicationNetworks';
+                    ref_id = cert_request.applicationnetwork;
+                    is_ca = true;
+                    ref_label = 'VAN';
+                } else if (cert_request.networkcredential) {
+                    ref_table = 'NetworkCredentials';
+                    ref_id = cert_request.networkcredential;
+                    is_ca = false;
+                    ref_label = 'VAN Attach';
+                } else if (cert_request.invitation) {
+                    ref_table = 'MemberInvitations';
+                    ref_id = cert_request.invitation;
+                    ref_label = 'Member Invitation';
+                } else if (cert_request.site) {
+                    ref_table = 'MemberSites';
+                    ref_id = cert_request.site;
+                    ref_label = 'Member Site';
+                    alertMemberCompletion = true;
+                } else {
+                    throw new Error('Unknown Target');
+                }
+                const cert_object = await LoadCertificate(secret.metadata.name);
+                const expiration = cert_object.status.notAfter ? new Date(cert_object.status.notAfter) : undefined;
+                const renewal = cert_object.status.renewalTime ? new Date(cert_object.status.renewalTime) : undefined;
+                const signed_by = secret.metadata.annotations['skupper.io/skx-issuerlink'];
+                const get_name = await client.query(
+                    `SELECT name FROM ${ref_table} WHERE Id = $1`,
+                    [ref_id]
                 );
+                const label = `${ref_label}: ${get_name.rows[0].name}`;
+                if (signed_by == 'root') {
+                    await client.query(
+                        "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label) VALUES ($1, $2, $3, $4, $5, $6)",
+                        [dblink, is_ca, secret.metadata.name, expiration, renewal, label]
+                    );
+                } else {
+                    await client.query(
+                        "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label, SignedBy) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                        [dblink, is_ca, secret.metadata.name, expiration, renewal, label, signed_by]
+                    );
+                }
+                await client.query(`UPDATE ${ref_table} SET Certificate = $1, Lifecycle = 'ready' WHERE Id = $2`, [dblink, ref_id]);
+                await client.query('DELETE FROM CertificateRequests WHERE Id = $1', [dblink]);
+                if (is_ca) {
+                    var issuer_obj = issuerObject(secret.metadata.name, secret.metadata.annotations['skupper.io/skx-dblink']);
+                    await ApplyObject(issuer_obj);
+                }
+                Log(`Certificate${is_ca ? ' Authority' : ''} created: ${secret.metadata.name}`)
+                if (alertSiteCertChanged) {
+                    await SiteLifecycleChanged_TX(client, ref_id, 'ready');
+                }
+                await client.query('COMMIT');
+
+                //
+                // Alert the sync module that changes have been made that require reconciliation with remote sites
+                //
+                if (alertSiteCertChanged) {
+                    await SiteCertificateChanged(dblink);
+                } else if (alertAccessCertChanged) {
+                    await AccessCertificateChanged(dblink);
+                }
+
+                //
+                // If we just updated a member site, there will be a claim-assertion that is awaiting completion.  Invoke the completion function.
+                //
+                if (alertMemberCompletion) {
+                    await CompleteMember(ref_id);
+                }
+    
+                //
+                // If this is an access point, ping the site-deployment-state module in case it needs to do anything.
+                //
+                if (ref_table == 'BackboneAccessPoints') {
+                    await AccessPointCertReady(ref_id);
+                }
             } else {
-                await client.query(
-                    "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label, SignedBy) VALUES ($1, $2, $3, $4, $5, $6, $7)",
-                    [dblink, is_ca, secret.metadata.name, expiration, renewal, label, signed_by]
-                );
+                    //
+                    // There's been no meaningful action taken.  Roll back the transaction.
+                    //
+                    await client.query('ROLLBACK');
             }
-            await client.query(`UPDATE ${ref_table} SET Certificate = $1, Lifecycle = 'ready' WHERE Id = $2`, [dblink, ref_id]);
-            await client.query('DELETE FROM CertificateRequests WHERE Id = $1', [dblink]);
-            if (is_ca) {
-                var issuer_obj = issuerObject(secret.metadata.name, secret.metadata.annotations['skupper.io/skx-dblink']);
-                await ApplyObject(issuer_obj);
-            }
-            Log(`Certificate${is_ca ? ' Authority' : ''} created: ${secret.metadata.name}`)
-            if (alertSiteCertChanged) {
-                await SiteLifecycleChanged_TX(client, ref_id, 'ready');
-            }
-            await client.query('COMMIT');
-
-            //
-            // Alert the sync module that changes have been made that require reconciliation with remote sites
-            //
-            if (alertSiteCertChanged) {
-                await SiteCertificateChanged(dblink);
-            } else if (alertAccessCertChanged) {
-                await AccessCertificateChanged(dblink);
-            }
-
-            //
-            // If we just updated a member site, there will be a claim-assertion that is awaiting completion.  Invoke the completion function.
-            //
-            if (alertMemberCompletion) {
-                await CompleteMember(ref_id);
-            }
-
-            //
-            // If this is an access point, ping the site-deployment-state module in case it needs to do anything.
-            //
-            if (ref_table == 'BackboneAccessPoints') {
-                await AccessPointCertReady(ref_id);
-            }
-        } else {
-            //
-            // There's been no meaningful action taken.  Roll back the transaction.
-            //
-            await client.query('ROLLBACK');
-        }
+        })
     } catch (err) {
         Log(`Rolling back secret-added transaction: ${err.stack}`);
         await client.query('ROLLBACK');

--- a/components/management-controller/src/certs.js
+++ b/components/management-controller/src/certs.js
@@ -53,8 +53,7 @@ const processNewManagementControllers = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back new-management-controller transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-management-controller transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -87,8 +86,7 @@ const processNewBackbones = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back new-backbone transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-backbone transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -128,8 +126,7 @@ const processNewAccessPoints = async function() {
             } 
         })
     } catch (err) {
-        Log(`Rolling back new-access-point transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-access-point transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -173,8 +170,7 @@ const processNewNetworks = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back new-network transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-network transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -207,8 +203,7 @@ const processNewInteriorSites = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back new-interior-site transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-interior-site transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -241,8 +236,7 @@ const processNewInvitations = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back new-invitation transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-invitation transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -275,8 +269,7 @@ const processNewMemberSites = async function() {
             }
         })
     } catch (err) {
-        Log(`Rolling back new-member-site transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-member-site transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -310,8 +303,7 @@ const processNewNetworkCredentials = async function() {
             }      
         })
     } catch (err) {
-        Log(`Rolling back new-network-credential transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Error in new-network-credential transaction: ${err.stack}`);
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -410,7 +402,6 @@ const processNewCertificateRequests = async function() {
         })
     } catch (err) {
         Log(`Rolling back cert-request transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -424,126 +415,126 @@ const processNewCertificateRequests = async function() {
 //
 const secretAdded = async function(dblink, secret) {
     const client = await ClientFromPool('system');
+    
     try {
-            await queryWithContext({ system: true }, client, async (client) => {
-
+        const alertInfo = await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query("SELECT * FROM CertificateRequests WHERE Id = $1", [dblink]);
             var ref_table;
             var ref_id;
             var ref_label;
             var is_ca = false;
-            var alertSiteCertChanged = false;
-            var alertAccessCertChanged = false;
-            var alertMemberCompletion = false;
+            let alertSiteCertChanged = false;
+            let alertAccessCertChanged = false;
+            let alertMemberCompletion = false;
+            let memberSiteId = null;
 
-            if (result.rowCount == 1) {
-                const cert_request = result.rows[0];
-
-                if (cert_request.managementcontroller) {
-                    ref_table = 'ManagementControllers';
-                    ref_id = cert_request.managementcontroller;
-                    ref_label = 'Management Controller';
-                } else if (cert_request.backbone) {
-                    ref_table = 'Backbones';
-                    ref_id = cert_request.backbone;
-                    is_ca = true;
-                    ref_label = 'Backbone';
-                } else if (cert_request.interiorsite) {
-                    ref_table = 'InteriorSites';
-                    ref_id = cert_request.interiorsite;
-                    ref_label = 'Backbone Site';
-                    alertSiteCertChanged = true;
-                } else if (cert_request.accesspoint) {
-                    ref_table = 'BackboneAccessPoints';
-                    ref_id = cert_request.accesspoint;
-                    ref_label = 'Access Point';
-                    alertAccessCertChanged = true;
-                } else if (cert_request.applicationnetwork) {
-                    ref_table = 'ApplicationNetworks';
-                    ref_id = cert_request.applicationnetwork;
-                    is_ca = true;
-                    ref_label = 'VAN';
-                } else if (cert_request.networkcredential) {
-                    ref_table = 'NetworkCredentials';
-                    ref_id = cert_request.networkcredential;
-                    is_ca = false;
-                    ref_label = 'VAN Attach';
-                } else if (cert_request.invitation) {
-                    ref_table = 'MemberInvitations';
-                    ref_id = cert_request.invitation;
-                    ref_label = 'Member Invitation';
-                } else if (cert_request.site) {
-                    ref_table = 'MemberSites';
-                    ref_id = cert_request.site;
-                    ref_label = 'Member Site';
-                    alertMemberCompletion = true;
-                } else {
-                    throw new Error('Unknown Target');
-                }
-                const cert_object = await LoadCertificate(secret.metadata.name);
-                const expiration = cert_object.status.notAfter ? new Date(cert_object.status.notAfter) : undefined;
-                const renewal = cert_object.status.renewalTime ? new Date(cert_object.status.renewalTime) : undefined;
-                const signed_by = secret.metadata.annotations['skupper.io/skx-issuerlink'];
-                const get_name = await client.query(
-                    `SELECT name FROM ${ref_table} WHERE Id = $1`,
-                    [ref_id]
-                );
-                const label = `${ref_label}: ${get_name.rows[0].name}`;
-                if (signed_by == 'root') {
-                    await client.query(
-                        "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label) VALUES ($1, $2, $3, $4, $5, $6)",
-                        [dblink, is_ca, secret.metadata.name, expiration, renewal, label]
-                    );
-                } else {
-                    await client.query(
-                        "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label, SignedBy) VALUES ($1, $2, $3, $4, $5, $6, $7)",
-                        [dblink, is_ca, secret.metadata.name, expiration, renewal, label, signed_by]
-                    );
-                }
-                await client.query(`UPDATE ${ref_table} SET Certificate = $1, Lifecycle = 'ready' WHERE Id = $2`, [dblink, ref_id]);
-                await client.query('DELETE FROM CertificateRequests WHERE Id = $1', [dblink]);
-                if (is_ca) {
-                    var issuer_obj = issuerObject(secret.metadata.name, secret.metadata.annotations['skupper.io/skx-dblink']);
-                    await ApplyObject(issuer_obj);
-                }
-                Log(`Certificate${is_ca ? ' Authority' : ''} created: ${secret.metadata.name}`)
-                if (alertSiteCertChanged) {
-                    await SiteLifecycleChanged_TX(client, ref_id, 'ready');
-                }
-                await client.query('COMMIT');
-
-                //
-                // Alert the sync module that changes have been made that require reconciliation with remote sites
-                //
-                if (alertSiteCertChanged) {
-                    await SiteCertificateChanged(dblink);
-                } else if (alertAccessCertChanged) {
-                    await AccessCertificateChanged(dblink);
-                }
-
-                //
-                // If we just updated a member site, there will be a claim-assertion that is awaiting completion.  Invoke the completion function.
-                //
-                if (alertMemberCompletion) {
-                    await CompleteMember(ref_id);
-                }
-    
-                //
-                // If this is an access point, ping the site-deployment-state module in case it needs to do anything.
-                //
-                if (ref_table == 'BackboneAccessPoints') {
-                    await AccessPointCertReady(ref_id);
-                }
-            } else {
-                    //
-                    // There's been no meaningful action taken.  Roll back the transaction.
-                    //
-                    await client.query('ROLLBACK');
+            if (result.rowCount != 1) {
+                // No certificate request found - throw error to trigger rollback
+                throw new Error('No certificate request found');
             }
+
+            const cert_request = result.rows[0];
+
+            if (cert_request.managementcontroller) {
+                ref_table = 'ManagementControllers';
+                ref_id = cert_request.managementcontroller;
+                ref_label = 'Management Controller';
+            } else if (cert_request.backbone) {
+                ref_table = 'Backbones';
+                ref_id = cert_request.backbone;
+                is_ca = true;
+                ref_label = 'Backbone';
+            } else if (cert_request.interiorsite) {
+                ref_table = 'InteriorSites';
+                ref_id = cert_request.interiorsite;
+                ref_label = 'Backbone Site';
+                alertSiteCertChanged = true;
+            } else if (cert_request.accesspoint) {
+                ref_table = 'BackboneAccessPoints';
+                ref_id = cert_request.accesspoint;
+                ref_label = 'Access Point';
+                alertAccessCertChanged = true;
+            } else if (cert_request.applicationnetwork) {
+                ref_table = 'ApplicationNetworks';
+                ref_id = cert_request.applicationnetwork;
+                is_ca = true;
+                ref_label = 'VAN';
+            } else if (cert_request.networkcredential) {
+                ref_table = 'NetworkCredentials';
+                ref_id = cert_request.networkcredential;
+                is_ca = false;
+                ref_label = 'VAN Attach';
+            } else if (cert_request.invitation) {
+                ref_table = 'MemberInvitations';
+                ref_id = cert_request.invitation;
+                ref_label = 'Member Invitation';
+            } else if (cert_request.site) {
+                ref_table = 'MemberSites';
+                ref_id = cert_request.site;
+                ref_label = 'Member Site';
+                alertMemberCompletion = true;
+                memberSiteId = ref_id;
+            } else {
+                throw new Error('Unknown Target');
+            }
+            const cert_object = await LoadCertificate(secret.metadata.name);
+            const expiration = cert_object.status.notAfter ? new Date(cert_object.status.notAfter) : undefined;
+            const renewal = cert_object.status.renewalTime ? new Date(cert_object.status.renewalTime) : undefined;
+            const signed_by = secret.metadata.annotations['skupper.io/skx-issuerlink'];
+            const get_name = await client.query(
+                `SELECT name FROM ${ref_table} WHERE Id = $1`,
+                [ref_id]
+            );
+            const label = `${ref_label}: ${get_name.rows[0].name}`;
+            if (signed_by == 'root') {
+                await client.query(
+                    "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label) VALUES ($1, $2, $3, $4, $5, $6)",
+                    [dblink, is_ca, secret.metadata.name, expiration, renewal, label]
+                );
+            } else {
+                await client.query(
+                    "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label, SignedBy) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                    [dblink, is_ca, secret.metadata.name, expiration, renewal, label, signed_by]
+                );
+            }
+            await client.query(`UPDATE ${ref_table} SET Certificate = $1, Lifecycle = 'ready' WHERE Id = $2`, [dblink, ref_id]);
+            await client.query('DELETE FROM CertificateRequests WHERE Id = $1', [dblink]);
+            if (is_ca) {
+                var issuer_obj = issuerObject(secret.metadata.name, secret.metadata.annotations['skupper.io/skx-dblink']);
+                await ApplyObject(issuer_obj);
+            }
+            Log(`Certificate${is_ca ? ' Authority' : ''} created: ${secret.metadata.name}`)
+            if (alertSiteCertChanged) {
+                await SiteLifecycleChanged_TX(client, ref_id, 'ready');
+            }
+            
+            // Return alert info only if transaction succeeds
+            return {
+                alertSiteCertChanged,
+                alertAccessCertChanged,
+                alertMemberCompletion,
+                memberSiteId
+            };
         })
+        
+        //
+        // Alert the sync module that changes have been made that require reconciliation with remote sites
+        // (These run after the transaction is committed)
+        //
+        if (alertInfo.alertSiteCertChanged) {
+            await SiteCertificateChanged(dblink);
+        } else if (alertInfo.alertAccessCertChanged) {
+            await AccessCertificateChanged(dblink);
+        }
+
+        //
+        // If we just updated a member site, there will be a claim-assertion that is awaiting completion.  Invoke the completion function.
+        //
+        if (alertInfo.alertMemberCompletion && alertInfo.memberSiteId) {
+            await CompleteMember(alertInfo.memberSiteId);
+        }
     } catch (err) {
-        Log(`Rolling back secret-added transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
+        Log(`Exception in secretAdded: ${err.stack}`);
     } finally {
         client.release();
     }

--- a/components/management-controller/src/certs.js
+++ b/components/management-controller/src/certs.js
@@ -21,7 +21,7 @@
 
 import { ApplyObject, LoadCertificate, WatchSecrets, WatchCertificates } from '@skupperx/modules/kube'
 import { Log } from '@skupperx/modules/log'
-import { IntervalMilliseconds, queryWithContext, ClientFromPool } from './db.js';
+import { ClientFromPool, IntervalMilliseconds } from './db.js';
 import { BackboneExpiration, DefaultCaExpiration, DefaultCertExpiration, SiteDataplaneImage, SiteControllerImage, RootIssuer, CertOrganization } from './config.js';
 import { SiteCertificateChanged, AccessCertificateChanged } from './sync-management.js';
 import { CompleteMember } from './claim-server.js';
@@ -37,23 +37,24 @@ const processNewManagementControllers = async function() {
     var reschedule_delay = 5000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query("SELECT * FROM ManagementControllers WHERE Lifecycle = 'new' LIMIT 1");
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Management Controller: ${row.name}`);
-                var duration_ms;
-                duration_ms = IntervalMilliseconds(BackboneExpiration());
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ManagementController) VALUES(gen_random_uuid(), 'mgmtController', now(), now(), $1, $2)",
-                    [duration_ms / 3600000, row.id]
-                    );
-                await client.query("UPDATE ManagementControllers SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
-            }
-        })
+        await client.query('BEGIN');
+        const result = await client.query("SELECT * FROM ManagementControllers WHERE Lifecycle = 'new' LIMIT 1");
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Management Controller: ${row.name}`);
+            var duration_ms;
+            duration_ms = IntervalMilliseconds(BackboneExpiration());
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ManagementController) VALUES(gen_random_uuid(), 'mgmtController', now(), now(), $1, $2)",
+                [duration_ms / 3600000, row.id]
+                );
+            await client.query("UPDATE ManagementControllers SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-management-controller transaction: ${err.stack}`);
+        Log(`Rolling back new-management-controller transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -70,23 +71,24 @@ const processNewBackbones = async function() {
     let reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {  
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query("SELECT * FROM Backbones WHERE Lifecycle = 'new' LIMIT 1");
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Backbone Network: ${row.name}`);
-                let duration_ms;
-                duration_ms = IntervalMilliseconds(BackboneExpiration());
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Backbone) VALUES(gen_random_uuid(), 'backboneCA', now(), now(), $1, $2)",
-                    [duration_ms / 3600000, row.id]
-                    );
-                await client.query("UPDATE Backbones SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
-            }
-        })
+        await client.query('BEGIN');
+        const result = await client.query("SELECT * FROM Backbones WHERE Lifecycle = 'new' LIMIT 1");
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Backbone Network: ${row.name}`);
+            let duration_ms;
+            duration_ms = IntervalMilliseconds(BackboneExpiration());
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Backbone) VALUES(gen_random_uuid(), 'backboneCA', now(), now(), $1, $2)",
+                [duration_ms / 3600000, row.id]
+                );
+            await client.query("UPDATE Backbones SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-backbone transaction: ${err.stack}`);
+        Log(`Rolling back new-backbone transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -101,32 +103,33 @@ const processNewAccessPoints = async function() {
     let reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query(
-                "SELECT BackboneAccessPoints.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM BackboneAccessPoints " +
-                "JOIN InteriorSites ON BackboneAccessPoints.InteriorSite = InteriorSites.Id " +
-                "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE BackboneAccessPoints.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+        await client.query('BEGIN');
+        const result = await client.query(
+            "SELECT BackboneAccessPoints.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM BackboneAccessPoints " +
+            "JOIN InteriorSites ON BackboneAccessPoints.InteriorSite = InteriorSites.Id " +
+            "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE BackboneAccessPoints.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+        );
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Backbone Access Point: ${row.name}`);
+            let duration_ms;
+
+            if (row.endtime) {
+                duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
+            } else {
+                duration_ms = IntervalMilliseconds(DefaultCaExpiration());
+            }
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, AccessPoint, Issuer, Hostname) VALUES(gen_random_uuid(), 'accessPoint', now(), now(), $1, $2, $3, $4)",
+                [duration_ms / 3600000, row.id, row.bbca, row.hostname]
             );
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Backbone Access Point: ${row.name}`);
-                let duration_ms;
-    
-                if (row.endtime) {
-                    duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
-                } else {
-                    duration_ms = IntervalMilliseconds(DefaultCaExpiration());
-                }
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, AccessPoint, Issuer, Hostname) VALUES(gen_random_uuid(), 'accessPoint', now(), now(), $1, $2, $3, $4)",
-                    [duration_ms / 3600000, row.id, row.bbca, row.hostname]
-                );
-                await client.query("UPDATE BackboneAccessPoints SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
-            } 
-        })
+            await client.query("UPDATE BackboneAccessPoints SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        } 
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-access-point transaction: ${err.stack}`);
+        Log(`Rolling back new-access-point transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -143,34 +146,35 @@ const processNewNetworks = async function() {
     let reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query(
-                "SELECT ApplicationNetworks.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM ApplicationNetworks " + 
-                "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id " +
-                "WHERE ApplicationNetworks.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
-            );
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Application Network: ${row.name}`);
-                const van_id = 'v' + row.id.substr(-5);
-                let duration_ms;
-    
-                if (row.endtime) {
-                    duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
-                    // TODO - if duration is greater than the default CA expiration, reduce it to the default.
-                } else {
-                    duration_ms = IntervalMilliseconds(DefaultCaExpiration());
-                }
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ApplicationNetwork, Issuer) VALUES(gen_random_uuid(), 'vanCA', now(), $1, $2, $3, $4)",
-                    [row.starttime, Math.trunc(duration_ms / 3600000), row.id, row.bbca]
-                );
-                await client.query("UPDATE ApplicationNetworks SET Lifecycle = 'skx_cr_created', VanId = $1 WHERE Id = $2", [van_id, row.id]);
-                reschedule_delay = 0;
+        await client.query('BEGIN');
+        const result = await client.query(
+            "SELECT ApplicationNetworks.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM ApplicationNetworks " + 
+            "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id " +
+            "WHERE ApplicationNetworks.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+        );
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Application Network: ${row.name}`);
+            const van_id = 'v' + row.id.substr(-5);
+            let   duration_ms;
+
+            if (row.endtime) {
+                duration_ms = row.endtime.getTime() - row.starttime.getTime() + IntervalMilliseconds(row.deletedelay);
+                // TODO - if duration is greater than the default CA expiration, reduce it to the default.
+            } else {
+                duration_ms = IntervalMilliseconds(DefaultCaExpiration());
             }
-        })
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ApplicationNetwork, Issuer) VALUES(gen_random_uuid(), 'vanCA', now(), $1, $2, $3, $4)",
+                [row.starttime, Math.trunc(duration_ms / 3600000), row.id, row.bbca]
+            );
+            await client.query("UPDATE ApplicationNetworks SET Lifecycle = 'skx_cr_created', VanId = $1 WHERE Id = $2", [van_id, row.id]);
+            reschedule_delay = 0;
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-network transaction: ${err.stack}`);
+        Log(`Rolling back new-network transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -185,25 +189,26 @@ const processNewInteriorSites = async function() {
     let reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query(
-            "SELECT InteriorSites.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM InteriorSites " + 
-            "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE InteriorSites.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+        await client.query('BEGIN');
+        const result = await client.query(
+        "SELECT InteriorSites.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM InteriorSites " + 
+        "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE InteriorSites.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+        );
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Interior Site: ${row.name}`);
+            let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, InteriorSite, Issuer) VALUES(gen_random_uuid(), 'interiorRouter', now(), now(), $1, $2, $3)",
+                [duration_ms / 3600000, row.id, row.bbca]
             );
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Interior Site: ${row.name}`);
-                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, InteriorSite, Issuer) VALUES(gen_random_uuid(), 'interiorRouter', now(), now(), $1, $2, $3)",
-                    [duration_ms / 3600000, row.id, row.bbca]
-                );
-                await client.query("UPDATE InteriorSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
-            }
-        })
+            await client.query("UPDATE InteriorSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-interior-site transaction: ${err.stack}`);
+        Log(`Rolling back new-interior-site transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -218,25 +223,26 @@ const processNewInvitations = async function() {
     let reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {  
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query(
-                "SELECT MemberInvitations.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberInvitations " + 
-                "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id WHERE MemberInvitations.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
+        await client.query('BEGIN');
+        const result = await client.query(
+            "SELECT MemberInvitations.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberInvitations " + 
+            "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id WHERE MemberInvitations.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
+        );
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Invitation: ${row.name}`);
+            let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Invitation, Issuer) VALUES(gen_random_uuid(), 'memberClaim', now(), now(), $1, $2, $3)",
+                [duration_ms / 3600000, row.id, row.vanca]
             );
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Invitation: ${row.name}`);
-                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Invitation, Issuer) VALUES(gen_random_uuid(), 'memberClaim', now(), now(), $1, $2, $3)",
-                    [duration_ms / 3600000, row.id, row.vanca]
-                );
-                await client.query("UPDATE MemberInvitations SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
-            }
-        })
+            await client.query("UPDATE MemberInvitations SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-invitation transaction: ${err.stack}`);
+        Log(`Rolling back new-invitation transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -251,25 +257,26 @@ const processNewMemberSites = async function() {
     let reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query(
-                "SELECT MemberSites.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberSites " + 
-                "JOIN ApplicationNetworks ON MemberSites.MemberOf = ApplicationNetworks.Id WHERE MemberSites.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
+        await client.query('BEGIN');
+        const result = await client.query(
+            "SELECT MemberSites.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberSites " + 
+            "JOIN ApplicationNetworks ON MemberSites.MemberOf = ApplicationNetworks.Id WHERE MemberSites.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
+        );
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Member Site: ${row.name}`);
+            let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Site, Issuer) VALUES(gen_random_uuid(), 'vanSite', now(), now(), $1, $2, $3)",
+                [duration_ms / 3600000, row.id, row.vanca]
             );
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Member Site: ${row.name}`);
-                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Site, Issuer) VALUES(gen_random_uuid(), 'vanSite', now(), now(), $1, $2, $3)",
-                    [duration_ms / 3600000, row.id, row.vanca]
-                );
-                await client.query("UPDATE MemberSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
-            }
-        })
+            await client.query("UPDATE MemberSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        }
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-member-site transaction: ${err.stack}`);
+        Log(`Rolling back new-member-site transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -282,28 +289,29 @@ const processNewNetworkCredentials = async function() {
     let reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query(
-                "SELECT NetworkCredentials.*, ApplicationNetworks.Lifecycle as vanlc, Backbones.Certificate as vanca " +
-                "FROM NetworkCredentials " + 
-                "JOIN ApplicationNetworks ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
-                "JOIN Backbones ON Backbones.id = ApplicationNetworks.Backbone " +
-                "WHERE NetworkCredentials.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
+        await client.query('BEGIN');
+        const result = await client.query(
+            "SELECT NetworkCredentials.*, ApplicationNetworks.Lifecycle as vanlc, Backbones.Certificate as vanca " +
+            "FROM NetworkCredentials " + 
+            "JOIN ApplicationNetworks ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
+            "JOIN Backbones ON Backbones.id = ApplicationNetworks.Backbone " +
+            "WHERE NetworkCredentials.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
+        );
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`New Network Credential: ${row.name}`);
+            let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
+            await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, NetworkCredential, Issuer) VALUES(gen_random_uuid(), 'vanCredential', now(), now(), $1, $2, $3)",
+                [duration_ms / 3600000, row.id, row.vanca]
             );
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`New Network Credential: ${row.name}`);
-                let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-                await client.query(
-                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, NetworkCredential, Issuer) VALUES(gen_random_uuid(), 'vanCredential', now(), now(), $1, $2, $3)",
-                    [duration_ms / 3600000, row.id, row.vanca]
-                );
-                await client.query("UPDATE NetworkCredentials SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
-            }      
-        })
+            await client.query("UPDATE NetworkCredentials SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        }      
+        await client.query('COMMIT');
     } catch (err) {
-        Log(`Error in new-network-credential transaction: ${err.stack}`);
+        Log(`Rolling back new-network-credential transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -320,88 +328,89 @@ const processNewCertificateRequests = async function() {
     var reschedule_delay = 2000;
     const client = await ClientFromPool('system');
     try {
-            await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query("SELECT * FROM CertificateRequests WHERE RequestTime <= now() and Lifecycle = 'new' ORDER BY CreatedTime LIMIT 1");
-            if (result.rowCount == 1) {
-                const row = result.rows[0];
-                Log(`Processing Certificate Request: ${row.id} (${row.requesttype})`);
-                var name;
-                var is_ca;
-                var issuer;
-                var extra_annotations = {};
-                var dns_name;
-                var usage;
-                switch (row.requesttype) {
-                    case 'mgmtController':
-                        name   = `skx-mgmt-controller-${row.id}`;
-                        usage  = 'client auth';
-                        break;
-                    case 'backboneCA':
-                        name   = `skx-bb-ca-${row.id}`;
-                        is_ca  = true;
-                        usage  = 'signing';
-                        break;
-                    case 'accessPoint':
-                        name     = `skx-access-${row.id}`;
-                        issuer   = row.issuer;
-                        usage    = 'server auth';
-                        dns_name = row.hostname;
-                        break;
-                    case 'vanCA':
-                        name   = `skx-van-ca-${row.id}`;
-                        is_ca  = true;
-                        issuer = row.issuer;
-                        usage  = 'signing';
-                        break;
-                    case 'vanCredential':
-                        name   = `skx-van-cred-${row.id}`;
-                        is_ca  = false;
-                        issuer = row.issuer;
-                        usage  = 'client auth';
-                        break;
-                    case 'interiorRouter':
-                        name   = `skx-interior-${row.id}`;
-                        is_ca  = false;
-                        issuer = row.issuer;
-                        usage  = 'client auth';
-                        break;
-                    case 'memberClaim':
-                        name   = `skx-claim-${row.id}`;
-                        is_ca  = false;
-                        issuer = row.issuer;
-                        usage  = 'client auth';
-                        extra_annotations['skupper.io/skx-dataplane-image']  = SiteDataplaneImage();
-                        extra_annotations['skupper.io/skx-controller-image'] = SiteControllerImage();
-                        // TODO - Add annotations for valid and expiration times for this claim
-                        break;
-                    case 'vanSite':
-                        name   = `skx-member-${row.id}`;
-                        is_ca  = false;
-                        issuer = row.issuer;
-                        usage  = 'client auth';
-                        break;
-                }
-
-                var issuer_name;
-                if (!issuer) {
-                    issuer_name = RootIssuer();
-                } else {
-                    const issuer_result = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [issuer]);
-                    if (issuer_result.rowCount == 1) {
-                        issuer_name = issuer_result.rows[0].objectname;
-                    } else {
-                        // TODO - Go to 'failed' state and store error
-                    }
-                }
-
-                var cert_obj = certificateObject(name, row.durationhours, is_ca, issuer_name, row.id, row.issuer ? row.issuer : 'root', extra_annotations, name, dns_name, usage);
-                await ApplyObject(cert_obj);
-                await client.query("UPDATE CertificateRequests SET Lifecycle = 'cm_cert_created' WHERE Id = $1", [row.id]);
-                reschedule_delay = 0;
+        await client.query('BEGIN');
+        const result = await client.query("SELECT * FROM CertificateRequests WHERE RequestTime <= now() and Lifecycle = 'new' ORDER BY CreatedTime LIMIT 1");
+        if (result.rowCount == 1) {
+            const row = result.rows[0];
+            Log(`Processing Certificate Request: ${row.id} (${row.requesttype})`);
+            var name;
+            var is_ca;
+            var issuer;
+            var extra_annotations = {};
+            var dns_name;
+            var usage;
+            switch (row.requesttype) {
+                case 'mgmtController':
+                    name   = `skx-mgmt-controller-${row.id}`;
+                    usage  = 'client auth';
+                    break;
+                case 'backboneCA':
+                    name   = `skx-bb-ca-${row.id}`;
+                    is_ca  = true;
+                    usage  = 'signing';
+                    break;
+                case 'accessPoint':
+                    name     = `skx-access-${row.id}`;
+                    issuer   = row.issuer;
+                    usage    = 'server auth';
+                    dns_name = row.hostname;
+                    break;
+                case 'vanCA':
+                    name   = `skx-van-ca-${row.id}`;
+                    is_ca  = true;
+                    issuer = row.issuer;
+                    usage  = 'signing';
+                    break;
+                case 'vanCredential':
+                    name   = `skx-van-cred-${row.id}`;
+                    is_ca  = false;
+                    issuer = row.issuer;
+                    usage  = 'client auth';
+                    break;
+                case 'interiorRouter':
+                    name   = `skx-interior-${row.id}`;
+                    is_ca  = false;
+                    issuer = row.issuer;
+                    usage  = 'client auth';
+                    break;
+                case 'memberClaim':
+                    name   = `skx-claim-${row.id}`;
+                    is_ca  = false;
+                    issuer = row.issuer;
+                    usage  = 'client auth';
+                    extra_annotations['skupper.io/skx-dataplane-image']  = SiteDataplaneImage();
+                    extra_annotations['skupper.io/skx-controller-image'] = SiteControllerImage();
+                    // TODO - Add annotations for valid and expiration times for this claim
+                    break;
+                case 'vanSite':
+                    name   = `skx-member-${row.id}`;
+                    is_ca  = false;
+                    issuer = row.issuer;
+                    usage  = 'client auth';
+                    break;
             }
-        })
+
+            var issuer_name;
+            if (!issuer) {
+                issuer_name = RootIssuer();
+            } else {
+                const issuer_result = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [issuer]);
+                if (issuer_result.rowCount == 1) {
+                    issuer_name = issuer_result.rows[0].objectname;
+                } else {
+                    // TODO - Go to 'failed' state and store error
+                }
+            }
+
+            var cert_obj = certificateObject(name, row.durationhours, is_ca, issuer_name, row.id, row.issuer ? row.issuer : 'root', extra_annotations, name, dns_name, usage);
+            await ApplyObject(cert_obj);
+            await client.query("UPDATE CertificateRequests SET Lifecycle = 'cm_cert_created' WHERE Id = $1", [row.id]);
+            reschedule_delay = 0;
+        }
+        await client.query('COMMIT');
     } catch (err) {
         Log(`Rolling back cert-request transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
         reschedule_delay = 10000;
     } finally {
         client.release();
@@ -415,73 +424,66 @@ const processNewCertificateRequests = async function() {
 //
 const secretAdded = async function(dblink, secret) {
     const client = await ClientFromPool('system');
-    
     try {
-        const alertInfo = await queryWithContext({ system: true }, client, async (client) => {
-            const result = await client.query("SELECT * FROM CertificateRequests WHERE Id = $1", [dblink]);
-            var ref_table;
-            var ref_id;
-            var ref_label;
-            var is_ca = false;
-            let alertSiteCertChanged = false;
-            let alertAccessCertChanged = false;
-            let alertMemberCompletion = false;
-            let memberSiteId = null;
+        await client.query('BEGIN');
+        const result = await client.query("SELECT * FROM CertificateRequests WHERE Id = $1", [dblink]);
+        var ref_table;
+        var ref_id;
+        var ref_label;
+        var is_ca = false;
+        var alertSiteCertChanged   = false;
+        var alertAccessCertChanged = false;
+        var alertMemberCompletion  = false;
 
-            if (result.rowCount != 1) {
-                // No certificate request found - throw error to trigger rollback
-                throw new Error('No certificate request found');
-            }
-
+        if (result.rowCount == 1) {
             const cert_request = result.rows[0];
 
             if (cert_request.managementcontroller) {
-                ref_table = 'ManagementControllers';
-                ref_id = cert_request.managementcontroller;
-                ref_label = 'Management Controller';
+                ref_table  = 'ManagementControllers';
+                ref_id     = cert_request.managementcontroller;
+                ref_label  = 'Management Controller';
             } else if (cert_request.backbone) {
-                ref_table = 'Backbones';
-                ref_id = cert_request.backbone;
-                is_ca = true;
-                ref_label = 'Backbone';
+                ref_table  = 'Backbones';
+                ref_id     = cert_request.backbone;
+                is_ca      = true;
+                ref_label  = 'Backbone';
             } else if (cert_request.interiorsite) {
-                ref_table = 'InteriorSites';
-                ref_id = cert_request.interiorsite;
-                ref_label = 'Backbone Site';
+                ref_table  = 'InteriorSites';
+                ref_id     = cert_request.interiorsite;
+                ref_label  = 'Backbone Site';
                 alertSiteCertChanged = true;
             } else if (cert_request.accesspoint) {
-                ref_table = 'BackboneAccessPoints';
-                ref_id = cert_request.accesspoint;
-                ref_label = 'Access Point';
+                ref_table  = 'BackboneAccessPoints';
+                ref_id     = cert_request.accesspoint;
+                ref_label  = 'Access Point';
                 alertAccessCertChanged = true;
             } else if (cert_request.applicationnetwork) {
-                ref_table = 'ApplicationNetworks';
-                ref_id = cert_request.applicationnetwork;
-                is_ca = true;
-                ref_label = 'VAN';
+                ref_table  = 'ApplicationNetworks';
+                ref_id     = cert_request.applicationnetwork;
+                is_ca      = true;
+                ref_label  = 'VAN';
             } else if (cert_request.networkcredential) {
-                ref_table = 'NetworkCredentials';
-                ref_id = cert_request.networkcredential;
-                is_ca = false;
-                ref_label = 'VAN Attach';
+                ref_table  = 'NetworkCredentials';
+                ref_id     = cert_request.networkcredential;
+                is_ca      = false;
+                ref_label  = 'VAN Attach';
             } else if (cert_request.invitation) {
-                ref_table = 'MemberInvitations';
-                ref_id = cert_request.invitation;
-                ref_label = 'Member Invitation';
+                ref_table  = 'MemberInvitations';
+                ref_id     = cert_request.invitation;
+                ref_label  = 'Member Invitation';
             } else if (cert_request.site) {
-                ref_table = 'MemberSites';
-                ref_id = cert_request.site;
-                ref_label = 'Member Site';
+                ref_table  = 'MemberSites';
+                ref_id     = cert_request.site;
+                ref_label  = 'Member Site';
                 alertMemberCompletion = true;
-                memberSiteId = ref_id;
             } else {
                 throw new Error('Unknown Target');
             }
             const cert_object = await LoadCertificate(secret.metadata.name);
-            const expiration = cert_object.status.notAfter ? new Date(cert_object.status.notAfter) : undefined;
-            const renewal = cert_object.status.renewalTime ? new Date(cert_object.status.renewalTime) : undefined;
-            const signed_by = secret.metadata.annotations['skupper.io/skx-issuerlink'];
-            const get_name = await client.query(
+            const expiration  = cert_object.status.notAfter    ? new Date(cert_object.status.notAfter) : undefined;
+            const renewal     = cert_object.status.renewalTime ? new Date(cert_object.status.renewalTime) : undefined;
+            const signed_by   = secret.metadata.annotations['skupper.io/skx-issuerlink'];
+            const get_name    = await client.query(
                 `SELECT name FROM ${ref_table} WHERE Id = $1`,
                 [ref_id]
             );
@@ -507,34 +509,32 @@ const secretAdded = async function(dblink, secret) {
             if (alertSiteCertChanged) {
                 await SiteLifecycleChanged_TX(client, ref_id, 'ready');
             }
-            
-            // Return alert info only if transaction succeeds
-            return {
-                alertSiteCertChanged,
-                alertAccessCertChanged,
-                alertMemberCompletion,
-                memberSiteId
-            };
-        })
-        
-        //
-        // Alert the sync module that changes have been made that require reconciliation with remote sites
-        // (These run after the transaction is committed)
-        //
-        if (alertInfo.alertSiteCertChanged) {
-            await SiteCertificateChanged(dblink);
-        } else if (alertInfo.alertAccessCertChanged) {
-            await AccessCertificateChanged(dblink);
-        }
+            await client.query('COMMIT');
 
-        //
-        // If we just updated a member site, there will be a claim-assertion that is awaiting completion.  Invoke the completion function.
-        //
-        if (alertInfo.alertMemberCompletion && alertInfo.memberSiteId) {
-            await CompleteMember(alertInfo.memberSiteId);
+            //
+            // Alert the sync module that changes have been made that require reconciliation with remote sites
+            //
+            if (alertSiteCertChanged) {
+                await SiteCertificateChanged(dblink);
+            } else if (alertAccessCertChanged) {
+                await AccessCertificateChanged(dblink);
+            }
+
+            //
+            // If we just updated a member site, there will be a claim-assertion that is awaiting completion.  Invoke the completion function.
+            //
+            if (alertMemberCompletion) {
+                await CompleteMember(ref_id);
+            }
+        } else {
+            //
+            // There's been no meaningful action taken.  Roll back the transaction.
+            //
+            await client.query('ROLLBACK');
         }
     } catch (err) {
-        Log(`Exception in secretAdded: ${err.stack}`);
+        Log(`Rolling back secret-added transaction: ${err.stack}`);
+        await client.query('ROLLBACK');
     } finally {
         client.release();
     }

--- a/components/management-controller/src/certs.js
+++ b/components/management-controller/src/certs.js
@@ -191,8 +191,8 @@ const processNewInteriorSites = async function() {
     try {
         await client.query('BEGIN');
         const result = await client.query(
-        "SELECT InteriorSites.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM InteriorSites " + 
-        "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE InteriorSites.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+            "SELECT InteriorSites.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM InteriorSites " + 
+            "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE InteriorSites.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
         );
         if (result.rowCount == 1) {
             const row = result.rows[0];
@@ -525,6 +525,13 @@ const secretAdded = async function(dblink, secret) {
             //
             if (alertMemberCompletion) {
                 await CompleteMember(ref_id);
+            }
+
+            //
+            // If this is an access point, ping the site-deployment-state module in case it needs to do anything.
+            //
+            if (ref_table == 'BackboneAccessPoints') {
+                await AccessPointCertReady(ref_id);
             }
         } else {
             //

--- a/components/management-controller/src/certs.js
+++ b/components/management-controller/src/certs.js
@@ -21,7 +21,7 @@
 
 import { ApplyObject, LoadCertificate, WatchSecrets, WatchCertificates } from '@skupperx/modules/kube'
 import { Log } from '@skupperx/modules/log'
-import { ClientFromPool, IntervalMilliseconds, queryWithContext, SYSTEM_USER_ID } from './db.js';
+import { IntervalMilliseconds, queryWithContext, ClientFromPool } from './db.js';
 import { BackboneExpiration, DefaultCaExpiration, DefaultCertExpiration, SiteDataplaneImage, SiteControllerImage, RootIssuer, CertOrganization } from './config.js';
 import { SiteCertificateChanged, AccessCertificateChanged } from './sync-management.js';
 import { CompleteMember } from './claim-server.js';
@@ -35,23 +35,23 @@ import { META_ANNOTATION_SKUPPERX_CONTROLLED } from '@skupperx/modules/common'
 //
 const processNewManagementControllers = async function() {
     var reschedule_delay = 5000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await client.query('BEGIN');
-        const result = await client.query("SELECT * FROM ManagementControllers WHERE Lifecycle = 'new' LIMIT 1");
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Management Controller: ${row.name}`);
-            var duration_ms;
-            duration_ms = IntervalMilliseconds(BackboneExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ManagementController) VALUES(gen_random_uuid(), 'mgmtController', now(), now(), $1, $2)",
-                [duration_ms / 3600000, row.id]
-                );
-            await client.query("UPDATE ManagementControllers SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+        await queryWithContext({ system: true }, client, async (client) => {
+            const result = await client.query("SELECT * FROM ManagementControllers WHERE Lifecycle = 'new' LIMIT 1");
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Management Controller: ${row.name}`);
+                var duration_ms;
+                duration_ms = IntervalMilliseconds(BackboneExpiration());
+                await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ManagementController) VALUES(gen_random_uuid(), 'mgmtController', now(), now(), $1, $2)",
+                    [duration_ms / 3600000, row.id]
+                    );
+                await client.query("UPDATE ManagementControllers SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            }
+        })
     } catch (err) {
         Log(`Rolling back new-management-controller transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -69,10 +69,9 @@ const processNewManagementControllers = async function() {
 //
 const processNewBackbones = async function() {
     let reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {  
-        
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query("SELECT * FROM Backbones WHERE Lifecycle = 'new' LIMIT 1");
             if (result.rowCount == 1) {
                 const row = result.rows[0];
@@ -86,7 +85,6 @@ const processNewBackbones = async function() {
                 await client.query("UPDATE Backbones SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
                 reschedule_delay = 0;
             }
-
         })
     } catch (err) {
         Log(`Rolling back new-backbone transaction: ${err.stack}`);
@@ -103,9 +101,9 @@ const processNewBackbones = async function() {
 //
 const processNewAccessPoints = async function() {
     let reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query(
                 "SELECT BackboneAccessPoints.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM BackboneAccessPoints " +
                 "JOIN InteriorSites ON BackboneAccessPoints.InteriorSite = InteriorSites.Id " +
@@ -146,9 +144,9 @@ const processNewAccessPoints = async function() {
 //
 const processNewNetworks = async function() {
     let reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query(
                 "SELECT ApplicationNetworks.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM ApplicationNetworks " + 
                 "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id " +
@@ -189,10 +187,9 @@ const processNewNetworks = async function() {
 //
 const processNewInteriorSites = async function() {
     let reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query(
             "SELECT InteriorSites.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM InteriorSites " + 
             "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE InteriorSites.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
@@ -224,9 +221,9 @@ const processNewInteriorSites = async function() {
 //
 const processNewInvitations = async function() {
     let reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {  
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query(
                 "SELECT MemberInvitations.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberInvitations " + 
                 "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id WHERE MemberInvitations.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
@@ -258,9 +255,9 @@ const processNewInvitations = async function() {
 //
 const processNewMemberSites = async function() {
     let reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query(
                 "SELECT MemberSites.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberSites " + 
                 "JOIN ApplicationNetworks ON MemberSites.MemberOf = ApplicationNetworks.Id WHERE MemberSites.Lifecycle = 'new' and ApplicationNetworks.Lifecycle = 'ready' LIMIT 1"
@@ -290,10 +287,9 @@ const processNewMemberSites = async function() {
 
 const processNewNetworkCredentials = async function() {
     let reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             const result = await client.query(
                 "SELECT NetworkCredentials.*, ApplicationNetworks.Lifecycle as vanlc, Backbones.Certificate as vanca " +
                 "FROM NetworkCredentials " + 
@@ -330,88 +326,88 @@ const processNewNetworkCredentials = async function() {
 //
 const processNewCertificateRequests = async function() {
     var reschedule_delay = 2000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await client.query('BEGIN');
-        const result = await client.query("SELECT * FROM CertificateRequests WHERE RequestTime <= now() and Lifecycle = 'new' ORDER BY CreatedTime LIMIT 1");
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`Processing Certificate Request: ${row.id} (${row.requesttype})`);
-            var name;
-            var is_ca;
-            var issuer;
-            var extra_annotations = {};
-            var dns_name;
-            var usage;
-            switch (row.requesttype) {
-                case 'mgmtController':
-                    name   = `skx-mgmt-controller-${row.id}`;
-                    usage  = 'client auth';
-                    break;
-                case 'backboneCA':
-                    name   = `skx-bb-ca-${row.id}`;
-                    is_ca  = true;
-                    usage  = 'signing';
-                    break;
-                case 'accessPoint':
-                    name     = `skx-access-${row.id}`;
-                    issuer   = row.issuer;
-                    usage    = 'server auth';
-                    dns_name = row.hostname;
-                    break;
-                case 'vanCA':
-                    name   = `skx-van-ca-${row.id}`;
-                    is_ca  = true;
-                    issuer = row.issuer;
-                    usage  = 'signing';
-                    break;
-                case 'vanCredential':
-                    name   = `skx-van-cred-${row.id}`;
-                    is_ca  = false;
-                    issuer = row.issuer;
-                    usage  = 'client auth';
-                    break;
-                case 'interiorRouter':
-                    name   = `skx-interior-${row.id}`;
-                    is_ca  = false;
-                    issuer = row.issuer;
-                    usage  = 'client auth';
-                    break;
-                case 'memberClaim':
-                    name   = `skx-claim-${row.id}`;
-                    is_ca  = false;
-                    issuer = row.issuer;
-                    usage  = 'client auth';
-                    extra_annotations['skupper.io/skx-dataplane-image']  = SiteDataplaneImage();
-                    extra_annotations['skupper.io/skx-controller-image'] = SiteControllerImage();
-                    // TODO - Add annotations for valid and expiration times for this claim
-                    break;
-                case 'vanSite':
-                    name   = `skx-member-${row.id}`;
-                    is_ca  = false;
-                    issuer = row.issuer;
-                    usage  = 'client auth';
-                    break;
-            }
-
-            var issuer_name;
-            if (!issuer) {
-                issuer_name = RootIssuer();
-            } else {
-                const issuer_result = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [issuer]);
-                if (issuer_result.rowCount == 1) {
-                    issuer_name = issuer_result.rows[0].objectname;
-                } else {
-                    // TODO - Go to 'failed' state and store error
+            await queryWithContext({ system: true }, client, async (client) => {
+            const result = await client.query("SELECT * FROM CertificateRequests WHERE RequestTime <= now() and Lifecycle = 'new' ORDER BY CreatedTime LIMIT 1");
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`Processing Certificate Request: ${row.id} (${row.requesttype})`);
+                var name;
+                var is_ca;
+                var issuer;
+                var extra_annotations = {};
+                var dns_name;
+                var usage;
+                switch (row.requesttype) {
+                    case 'mgmtController':
+                        name   = `skx-mgmt-controller-${row.id}`;
+                        usage  = 'client auth';
+                        break;
+                    case 'backboneCA':
+                        name   = `skx-bb-ca-${row.id}`;
+                        is_ca  = true;
+                        usage  = 'signing';
+                        break;
+                    case 'accessPoint':
+                        name     = `skx-access-${row.id}`;
+                        issuer   = row.issuer;
+                        usage    = 'server auth';
+                        dns_name = row.hostname;
+                        break;
+                    case 'vanCA':
+                        name   = `skx-van-ca-${row.id}`;
+                        is_ca  = true;
+                        issuer = row.issuer;
+                        usage  = 'signing';
+                        break;
+                    case 'vanCredential':
+                        name   = `skx-van-cred-${row.id}`;
+                        is_ca  = false;
+                        issuer = row.issuer;
+                        usage  = 'client auth';
+                        break;
+                    case 'interiorRouter':
+                        name   = `skx-interior-${row.id}`;
+                        is_ca  = false;
+                        issuer = row.issuer;
+                        usage  = 'client auth';
+                        break;
+                    case 'memberClaim':
+                        name   = `skx-claim-${row.id}`;
+                        is_ca  = false;
+                        issuer = row.issuer;
+                        usage  = 'client auth';
+                        extra_annotations['skupper.io/skx-dataplane-image']  = SiteDataplaneImage();
+                        extra_annotations['skupper.io/skx-controller-image'] = SiteControllerImage();
+                        // TODO - Add annotations for valid and expiration times for this claim
+                        break;
+                    case 'vanSite':
+                        name   = `skx-member-${row.id}`;
+                        is_ca  = false;
+                        issuer = row.issuer;
+                        usage  = 'client auth';
+                        break;
                 }
-            }
 
-            var cert_obj = certificateObject(name, row.durationhours, is_ca, issuer_name, row.id, row.issuer ? row.issuer : 'root', extra_annotations, name, dns_name, usage);
-            await ApplyObject(cert_obj);
-            await client.query("UPDATE CertificateRequests SET Lifecycle = 'cm_cert_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-        }
-        await client.query('COMMIT');
+                var issuer_name;
+                if (!issuer) {
+                    issuer_name = RootIssuer();
+                } else {
+                    const issuer_result = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [issuer]);
+                    if (issuer_result.rowCount == 1) {
+                        issuer_name = issuer_result.rows[0].objectname;
+                    } else {
+                        // TODO - Go to 'failed' state and store error
+                    }
+                }
+
+                var cert_obj = certificateObject(name, row.durationhours, is_ca, issuer_name, row.id, row.issuer ? row.issuer : 'root', extra_annotations, name, dns_name, usage);
+                await ApplyObject(cert_obj);
+                await client.query("UPDATE CertificateRequests SET Lifecycle = 'cm_cert_created' WHERE Id = $1", [row.id]);
+                reschedule_delay = 0;
+            }
+        })
     } catch (err) {
         Log(`Rolling back cert-request transaction: ${err.stack}`);
         await client.query('ROLLBACK');
@@ -427,9 +423,9 @@ const processNewCertificateRequests = async function() {
 // to register the completion of the creation of a certificate or a CA.
 //
 const secretAdded = async function(dblink, secret) {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            await queryWithContext({ system: true }, client, async (client) => {
 
             const result = await client.query("SELECT * FROM CertificateRequests WHERE Id = $1", [dblink]);
             var ref_table;
@@ -579,7 +575,7 @@ const onCertificateWatch = async function(action, cert) {
         && cert.status
         && cert.status.notAfter
         && cert.status.renewalTime) {
-        const client      = await ClientFromPool();
+        const client      = await ClientFromPool('system');
         const expiration  = new Date(cert.status.notAfter);
         const renewal     = new Date(cert.status.renewalTime);
         await client.query(

--- a/components/management-controller/src/claim-server.js
+++ b/components/management-controller/src/claim-server.js
@@ -52,7 +52,7 @@ var memberCompletions = {};   // memberId   => {handler: completion-function, re
 const memberCompletion = async function(memberId) { // => [outgoingLinks, siteClient]
     var outgoingLinks;
     var siteClient;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         //
@@ -157,7 +157,7 @@ const processClaim = async function(claimId, name) {
     var siteClient        = null;
     var memberId;
 
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT * FROM MemberInvitations WHERE Id = $1 and (JoinDeadline IS NULL OR JoinDeadline > now())", [claimId]);

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -2118,43 +2118,43 @@ const getInterfaceRoles = async function(req, res) {
 }
 
 export function ApiInit(app, keycloak) {
-    app.post(COMPOSE_PREFIX + 'library/blocks/import', keycloak.protect('realm:can-import-library-blocks'), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'library/blocks/import', keycloak.protect('realm:application-owner'), async (req, res) => {
         await postLibraryBlocks(req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'library/blocks', keycloak.protect('realm:can-create-library-block'), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'library/blocks', keycloak.protect('realm:application-owner'), async (req, res) => {
         await createLibraryBlock(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks', keycloak.protect('realm:can-list-library-blocks'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks', keycloak.protect('realm:application-owner'), async (req, res) => {
         await listLibraryBlocks(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocktypes', keycloak.protect('realm:can-list-block-types'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocktypes', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getBlockTypes(req, res);
     })
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect('realm:can-read-library-block'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getLibraryBlock(req.params.blockid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect('realm:can-read-library-block-config'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'Config', req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect('realm:can-read-library-block-interfaces'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'Interfaces', req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect('realm:can-read-library-block-body'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'SpecBody', req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect('realm:can-delete-library-block'), async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect('realm:application-owner'), async (req, res) => {
         await deleteLibraryBlock(req.params.blockid, req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'applications', keycloak.protect('realm:can-create-application'), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'applications', keycloak.protect('realm:application-owner'), async (req, res) => {
         await postApplication(req, res);
     });
 
@@ -2162,59 +2162,59 @@ export function ApiInit(app, keycloak) {
         await listApplications(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect('realm:can-read-application'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getApplication(req.params.apid, req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'applications/:apid/build', keycloak.protect('realm:can-build-application'), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'applications/:apid/build', keycloak.protect('realm:application-owner'), async (req, res) => {
         await buildApplication(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/log', keycloak.protect('realm:can-read-application-build-log'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/log', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getApplicationBuildLog(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/image', keycloak.protect('realm:can-read-application-image'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/image', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getApplicationImage(req.params.apid, req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect('realm:can-delete-application'), async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect('realm:application-owner'), async (req, res) => {
         await deleteApplication(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks', keycloak.protect('realm:can-list-application-blocks'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks', keycloak.protect('realm:application-owner'), async (req, res) => {
         await listApplicationBlocks(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks/:blockid', keycloak.protect('realm:can-read-application-block'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks/:blockid', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getApplicationBlock(req.params.blockid, req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'deployments', keycloak.protect('realm:can-create-deployment'), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'deployments', keycloak.protect('realm:application-deployer'), async (req, res) => {
         await postDeployment(req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'deployments/:depid/deploy', keycloak.protect('realm:can-deploy-deployment'), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'deployments/:depid/deploy', keycloak.protect('realm:application-deployer'), async (req, res) => {
         await deployDeployment(req.params.depid, req, res)
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/log', keycloak.protect('realm:can-read-deployment-log'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/log', keycloak.protect('realm:application-deployer'), async (req, res) => {
         await getDeploymentLog(req.params.depid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments', keycloak.protect('realm:can-list-deployments'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments', keycloak.protect('realm:application-deployer'), async (req, res) => {
         await listDeployments(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect('realm:can-read-deployment'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect('realm:application-deployer'), async (req, res) => {
         await getDeployment(req.params.depid, req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect('realm:can-delete-deployment'), async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect('realm:application-deployer'), async (req, res) => {
         await deleteDeployment(req.params.depid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata', keycloak.protect('realm:can-read-site-data'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         await getSiteData(req.params.depid, req.params.siteid, req, res);
     });
 
@@ -2223,32 +2223,32 @@ export function ApiInit(app, keycloak) {
     // the name of the file that is saved (rather than always downloading to 'sitedata').
     // We ignore the filename.  We are simply allowing it to be included on the API path.
     //
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata/:filename', keycloak.protect('realm:can-read-site-data'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata/:filename', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         await getSiteData(req.params.depid, req.params.siteid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'targetplatforms', keycloak.protect('realm:can-list-target-platforms'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'targetplatforms', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         await getTargetPlatforms(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'interfaceroles', keycloak.protect('realm:can-list-interface-roles'), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'interfaceroles', keycloak.protect('realm:application-owner'), async (req, res) => {
         await getInterfaceRoles(req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'template', keycloak.protect('realm:can-expand-template'), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'template', keycloak.protect('realm:application-owner'), async (req, res) => {
         await ExpandTemplate(req, res);
     })
 
     app.use(json());
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect('realm:can-update-library-block-config'), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect('realm:application-owner'), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'Config', req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect('realm:can-update-library-block-interfaces'), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect('realm:application-owner'), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'Interfaces', req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect('realm:can-update-library-block-body'), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect('realm:application-owner'), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'SpecBody', req, res);
     });
 

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -495,10 +495,10 @@ class Application {
 
     async buildFromDatabase(client, appid, req) {
         let buildLog = new ProcessLog(false);   // Disabled build log
-        const appResult = await queryWithContext(req, client, async (client, userInfo) => {
+        const appResult = await queryWithContext(req, client, async (client) => {
             return await client.query("SELECT Applications.name as apname, LibraryBlocks.name as lbname, LibraryBlocks.revision FROM Applications " +
                                              "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                                             "WHERE Applications.Id = $1 and (Applications.Owner = $2 or Applications.OwnerGroup = Any($3) or is_admin())", [appid, userInfo.userId, userInfo.userGroups]);
+                                             "WHERE Applications.Id = $1", [appid]);
         })
         if (appResult.rowCount == 0) {
             throw new Error(`Cannot find application with id ${appid}`);
@@ -820,7 +820,7 @@ const importBlock = async function(client, block, blockRevisions, req) {
         // Only insert a new revision into the database if it is different from the current revision.
         //
         if (newRevision > 1) {
-            const mostRecent = await client.query("SELECT Config, Interfaces, SpecBody FROM LibraryBlocks WHERE Name = $1 AND Revision = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [name, newRevision - 1, userId, userGroups]);
+            const mostRecent = await client.query("SELECT Config, Interfaces, SpecBody FROM LibraryBlocks WHERE Name = $1 AND Revision = $2", [name, newRevision - 1]);
             if (mostRecent.rowCount == 1
                 && config     == mostRecent.rows[0].config
                 && ifObject   == mostRecent.rows[0].interfaces
@@ -854,8 +854,8 @@ const loadLibraryBlock = async function(client, library, blockName, buildLog, re
     //
     // Fetch all revisions of this block from the database.
     //
-    const result = await queryWithContext(req, client, async (client, userInfo) => {
-        return await client.query("SELECT * FROM LibraryBlocks WHERE Name = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) ORDER BY Revision DESC", [elements[0], userInfo.userId, userInfo.userGroups]);
+    const result = await queryWithContext(req, client, async (client) => {
+        return await client.query("SELECT * FROM LibraryBlocks WHERE Name = $1 ORDER BY Revision DESC", [elements[0]]);
     })
     if (result.rowCount == 0) {
         buildLog.error(`Library block ${elements[0]} not found`)
@@ -1168,7 +1168,7 @@ const postLibraryBlocks = async function(req, res) {
         try {
             let items = loadAll(req.body);
 
-            const importCount = await queryWithContext(req, client, async (client, userInfo) => {
+            const importCount = await queryWithContext(req, client, async (client) => {
                 //
                 // Get the set of valid block types.
                 //
@@ -1194,7 +1194,7 @@ const postLibraryBlocks = async function(req, res) {
                 // Get a list of block names with their revision numbers
                 //
                 let blockRevisions = {};
-                const blockResult = await client.query("SELECT Name, Type, Revision FROM LibraryBlocks WHERE Owner = $1 or OwnerGroup = Any($2) or is_admin()", [userInfo.userId, userInfo.userGroups]);
+                const blockResult = await client.query("SELECT Name, Type, Revision FROM LibraryBlocks");
                 for (const br of blockResult.rows) {
                     if (!blockRevisions[br.name] || blockRevisions[br.name].revision < br.revision) {
                         blockRevisions[br.name] = {
@@ -1256,8 +1256,7 @@ const createLibraryBlock = async function(req, res) {
 
         const result = await queryWithContext(req, client, async (client, userInfo) => {
             const userId = userInfo.userId;
-            const userGroups = userInfo.userGroups
-            const checkResult = await client.query("SELECT Id FROM LibraryBlocks WHERE Name = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.name, userId, userGroups]);
+            const checkResult = await client.query("SELECT Id FROM LibraryBlocks WHERE Name = $1", [norm.name]);
             if (checkResult.rowCount > 0) {
                 // Return error indicator - will be handled after COMMIT
                 return { error: true, message: `Library block with name ${norm.name} already exists` };
@@ -1294,14 +1293,14 @@ const listLibraryBlocks = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             let where = "";
-            let whereData = [userInfo.userId, userInfo.userGroups];
+            let whereData = [];
             if (req.query.type) {
-                where = " and type = $3"
+                where = " WHERE type = $1"
                 whereData.push(req.query.type);
             }
-            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE (Owner = $1 or OwnerGroup = Any($2) or is_admin())" + where, whereData);
+            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks" + where, whereData);
         })
         res.status(returnStatus).json(result.rows);
     } catch (error) {
@@ -1345,8 +1344,8 @@ const getLibraryBlock = async function(blockid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [blockid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE Id = $1", [blockid]);
         })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
@@ -1368,8 +1367,8 @@ const getLibraryBlockSection = async function(blockid, section, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query(`SELECT ${section} as data FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())`, [blockid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(`SELECT ${section} as data FROM LibraryBlocks WHERE Id = $1`, [blockid]);
         })
         if (result.rowCount == 1) {
             const jdata = load(result.rows[0].data);
@@ -1393,8 +1392,8 @@ const putLibraryBlockSection = async function(blockid, section, req, res) {
     const data   = dump(req.body);
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client, userInfo) => {
-            await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())`, [blockid, data, userInfo.userId, userInfo.userGroups]);
+        await queryWithContext(req, client, async (client) => {
+            await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1`, [blockid, data]);
         })
         res.status(returnStatus).send('Updated');
     } catch (error) {
@@ -1411,8 +1410,8 @@ const deleteLibraryBlock = async function(blockid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query("DELETE FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [blockid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("DELETE FROM LibraryBlocks WHERE Id = $1", [blockid]);
         })
         if (result.rowCount != 1) {
             returnStatus = 404;
@@ -1467,10 +1466,10 @@ const buildApplication = async function(apid, req, res) {
     const client   = await ClientFromPool();
     let   buildLog = new ProcessLog(true, 'build');
     try {
-        const response = await queryWithContext(req, client, async (client, userInfo) => {
+        const response = await queryWithContext(req, client, async (client) => {
             const result = await client.query("SELECT LibraryBlocks.Name as lbname, LibraryBlocks.Revision, Applications.Name as appname, Lifecycle FROM Applications " +
                                               "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                                              "WHERE Applications.Id = $1 and (Applications.Owner = $2 or Applications.OwnerGroup = Any($3) or is_admin())", [apid, userInfo.userId, userInfo.userGroups]);
+                                              "WHERE Applications.Id = $1", [apid]);
             if (result.rowCount == 1) {
                 const app = result.rows[0];
     
@@ -1551,7 +1550,7 @@ const buildApplication = async function(apid, req, res) {
                 //
                 // Update the lifecycle of the application and add the build log.
                 //
-                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [apid, buildLog.getText(), buildLog.getResult(), userInfo.userId, userInfo.userGroups]);
+                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
                 return response;
             }
         })
@@ -1561,8 +1560,8 @@ const buildApplication = async function(apid, req, res) {
             //
             // If we got a build error, update the build log for user visibility after rolling back the current transaction.
             //
-            await queryWithContext(req, client, async (client, userInfo) => {
-                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [apid, buildLog.getText(), buildLog.getResult(), userInfo.userId, userInfo.userGroups]);
+            await queryWithContext(req, client, async (client) => {
+                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
             })
             returnStatus = 200;
             res.status(returnStatus).send("Build Failed - See build log for details");
@@ -1581,12 +1580,10 @@ const listApplications = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query(
                 "SELECT Applications.Id, Applications.Name, RootBlock, Lifecycle, LibraryBlocks.Name as rootname FROM Applications " +
-                "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                "WHERE Applications.Owner = $1 or Applications.OwnerGroup = Any($2) or is_admin()",
-                [userInfo.userId, userInfo.userGroups]
+                "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock "
             );
         })
         res.status(returnStatus).json(result.rows);
@@ -1604,12 +1601,12 @@ const getApplication = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query(
                 "SELECT Applications.*, LibraryBlocks.Name as rootname FROM Applications " +
                 "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                "WHERE Applications.Id = $1 and (Applications.Owner = $2 or Applications.OwnerGroup = Any($3) or is_admin())",
-                [apid, userInfo.userId, userInfo.userGroups]
+                "WHERE Applications.Id = $1",
+                [apid]
             );
         })
         if (result.rowCount == 1) {
@@ -1632,8 +1629,8 @@ const getApplicationBuildLog = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query("SELECT BuildLog FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT BuildLog FROM Applications WHERE Id = $1", [apid]);
         })
         if (result.rowCount == 1) {
             res.status(returnStatus).send(result.rows[0].buildlog);
@@ -1655,14 +1652,12 @@ const getApplicationImage = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const yamlDocument = await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId
-            const userGroups = userInfo.userGroups
+        const yamlDocument = await queryWithContext(req, client, async (client) => {
             //
             // Get the application and ensure that it is in build-complete state.
             //
             const appResult = await client.query(
-                "SELECT Lifecycle FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]
+                "SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]
             );
     
             if (appResult.rowCount == 0) {
@@ -1698,7 +1693,7 @@ const getApplicationImage = async function(apid, req, res) {
             let libraryBlocks = {};
             for (const lbid of Object.keys(libraryReferencers)) {
                 const lbResult = await client.query(
-                    "SELECT * FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [lbid, userId, userGroups]
+                    "SELECT * FROM LibraryBlocks WHERE Id = $1", [lbid]
                 );
                 if (lbResult.rowCount == 0) {
                     throw new Error(`Nonexistent library block (${lbid}) referenced by ${libraryReferencers[lbid]}`);
@@ -1775,17 +1770,15 @@ const deleteApplication = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId
-            const userGroups = userInfo.userGroups
-            const check = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            const check = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]);
             if (check.rowCount == 1 && check.rows[0].lifecycle == 'deployed') {
                 // Return error indicator - will be handled after COMMIT
                 return { error: true, status: 400, message: 'Cannot delete an Application that is deployed' };
             } else {
                 await client.query("DELETE FROM Bindings WHERE Application = $1", [apid]);
                 await client.query("DELETE FROM InstanceBlocks WHERE Application = $1", [apid]);
-                const deleteResult = await client.query("DELETE FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]);
+                const deleteResult = await client.query("DELETE FROM Applications WHERE Id = $1", [apid]);
                 return deleteResult;
             }
         })
@@ -1814,13 +1807,13 @@ const listApplicationBlocks = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             return await client.query(
                 "SELECT InstanceBlocks.Id, InstanceName, LibraryBlock, " +
                 "LibraryBlocks.Name as libname, LibraryBlocks.Revision FROM InstanceBlocks " +
                 "JOIN LibraryBlocks ON LibraryBlocks.Id = LibraryBlock " +
-                "WHERE Application = $1 and (LibraryBlocks.Owner = $2 or LibraryBlocks.OwnerGroup = Any($3) or is_admin())",
-                [apid, userInfo.userId, userInfo.userGroups]
+                "WHERE Application = $1",
+                [apid]
             );
         })
         res.status(returnStatus).json(result.rows);
@@ -1851,8 +1844,7 @@ const postDeployment = async function(req, res) {
 
         const result = await queryWithContext(req, client, async (client, userInfo) => {
             const userId = userInfo.userId
-            const userGroups = userInfo.userGroups
-            const checkResult = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.app, userId, userGroups]);
+            const checkResult = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [norm.app]);
             if (checkResult.rowCount == 0) {
                 throw new Error(`Application not found; ${norm.app}`);
             } else if (checkResult.rows[0].lifecycle == 'deployed') {
@@ -1862,8 +1854,8 @@ const postDeployment = async function(req, res) {
                                               [norm.app, norm.van, userId, norm.ownerGroup]);
         })
         if (result.rowCount == 1) {
-            await queryWithContext(req, client, async (client, userInfo) => {
-                await client.query("UPDATE Applications SET Lifecycle = 'deployed' WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.app, userInfo.userId, userInfo.userGroups]);
+            await queryWithContext(req, client, async (client) => {
+                await client.query("UPDATE Applications SET Lifecycle = 'deployed' WHERE Id = $1", [norm.app]);
             })
             res.status(returnStatus).json(result.rows[0]);
         } else {
@@ -1885,10 +1877,8 @@ const deployDeployment = async function(depid, req, res) {
     const client = await ClientFromPool();
     let   deployLog = new ProcessLog(true, 'deploy');
     try {
-        const response = await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId
-            const userGroups = userInfo.userGroups
-            const checkResult = await client.query("SELECT Id, Lifecycle, Application, Van FROM DeployedApplications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [depid, userId, userGroups]);
+        const response = await queryWithContext(req, client, async (client) => {
+            const checkResult = await client.query("SELECT Id, Lifecycle, Application, Van FROM DeployedApplications WHERE Id = $1", [depid]);
             if (checkResult.rowCount == 0) {
                 throw new Error(`Deployment not found; ${depid}`);
             } else if (checkResult.rows[0].lifecycle == 'deployed') {
@@ -1913,7 +1903,7 @@ const deployDeployment = async function(depid, req, res) {
             //
             // Update the lifecycle of the deployment and add the build log.
             //
-            await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [depid, deployLog.getText(), 'deployed', userId, userGroups]);
+            await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), 'deployed']);
             return response;
         })
         res.status(returnStatus).send(response);
@@ -1922,8 +1912,8 @@ const deployDeployment = async function(depid, req, res) {
             //
             // If we got a process error, update the deploy log for user visibility after rolling back the current transaction.
             //
-            await queryWithContext(req, client, async (client, userInfo) => {
-                await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [depid, deployLog.getText(), deployLog.getResult(), userInfo.userId, userInfo.userGroups]);
+            await queryWithContext(req, client, async (client) => {
+                await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), deployLog.getResult()]);
             })
             returnStatus = 200;
             res.status(returnStatus).send("Deploy Failed - See deployment log for details");
@@ -1942,8 +1932,8 @@ const getDeploymentLog = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
-            return await client.query("SELECT DeployLog FROM DeployedApplications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [depid, userInfo.userId, userInfo.userGroups]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT DeployLog FROM DeployedApplications WHERE Id = $1", [depid]);
         })
         if (result.rowCount == 1) {
             const reply = result.rows[0].deploylog || 'Deployment has not yet been deployed';
@@ -1966,13 +1956,11 @@ const listDeployments = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 "SELECT DeployedApplications.Id, DeployedApplications.Lifecycle, Application, Van, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
-                "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van " + 
-                "WHERE DeployedApplications.Owner = $1 or DeployedApplications.OwnerGroup = Any($2) or is_admin()",
-                [userInfo.userId, userInfo.userGroups]
+                "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van "
             );
             return result;
         })
@@ -1991,13 +1979,13 @@ const getDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client, userInfo) => {
+        const result = await queryWithContext(req, client, async (client) => {
             const deploymentResult = await client.query(
                 "SELECT DeployedApplications.*, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
                 "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van " +
-                "WHERE DeployedApplications.Id = $1 and (DeployedApplications.Owner = $2 or DeployedApplications.OwnerGroup = Any($3) or is_admin())",
-                [depid, userInfo.userId, userInfo.userGroups]
+                "WHERE DeployedApplications.Id = $1",
+                [depid]
             );
             return deploymentResult;
         })
@@ -2021,22 +2009,20 @@ const deleteDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const message = await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId
-            const userGroups = userInfo.userGroups
+        const message = await queryWithContext(req, client, async (client) => {
             await client.query("DELETE FROM SiteData WHERE DeployedApplication = $1", [depid]);
-            const result = await client.query("DELETE FROM DeployedApplications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING Application", [depid, userId, userGroups]);
+            const result = await client.query("DELETE FROM DeployedApplications WHERE Id = $1 RETURNING Application", [depid]);
             let message = 'Not Found';
             if (result.rowCount != 1) {
                 returnStatus = 404;
             } else {
                 const appid = result.rows[0].application;
-                const listResult = await client.query("SELECT Id FROM DeployedApplications WHERE Application = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [appid, userId, userGroups]);
+                const listResult = await client.query("SELECT Id FROM DeployedApplications WHERE Application = $1", [appid]);
                 if (listResult.rowCount == 0) {
                     //
                     // If we just deleted the last deployment of the application, move its lifecycle back to 'build-complete'.
                     //
-                    await client.query("UPDATE Applications SET LifeCycle = 'build-complete' WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [appid, userId, userGroups]);
+                    await client.query("UPDATE Applications SET LifeCycle = 'build-complete' WHERE Id = $1", [appid]);
                     message = 'Deleted';
                 }
             }

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -1942,8 +1942,8 @@ const getDeploymentLog = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("SELECT DeployLog FROM DeployedApplications WHERE Id = $1", [depid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("SELECT DeployLog FROM DeployedApplications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [depid, userInfo.userId, userInfo.userGroups]);
         })
         if (result.rowCount == 1) {
             const reply = result.rows[0].deploylog || 'Deployment has not yet been deployed';

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -1160,7 +1160,7 @@ const postLibraryBlocks = async function(req, res) {
         try {
             let items = loadAll(req.body);
 
-            let importCount = await queryWithContext(req, client, async (client) => {
+            const importCount = await queryWithContext(req, client, async (client) => {
                 //
                 // Get the set of valid block types.
                 //
@@ -1210,6 +1210,7 @@ const postLibraryBlocks = async function(req, res) {
                 //
                 // Import the validated blocks into the database
                 //
+                let importCount = 0;
                 for (const block of items) {
                     importCount += await importBlock(client, block, blockRevisions);
                 }

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -1948,7 +1948,6 @@ const listDeployments = async function(req, res) {
         })
     } catch (error) {
         Log(`Exception in listDeployments: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1978,7 +1977,6 @@ const getDeployment = async function(depid, req, res) {
         })
     } catch (error) {
         Log(`Exception in getDeployment: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -493,11 +493,13 @@ class Application {
         buildLog.log(`${this}`);
     }
 
-    async buildFromDatabase(client, appid) {
-        let   buildLog  = new ProcessLog(false);   // Disabled build log
-        const appResult = await client.query("SELECT Applications.name as apname, LibraryBlocks.name as lbname, LibraryBlocks.revision FROM Applications " +
+    async buildFromDatabase(client, appid, req) {
+        let buildLog = new ProcessLog(false);   // Disabled build log
+        const appResult = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("SELECT Applications.name as apname, LibraryBlocks.name as lbname, LibraryBlocks.revision FROM Applications " +
                                              "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                                             "WHERE Applications.Id = $1", [appid]);
+                                             "WHERE Applications.Id = $1 and (Applications.Owner = $2 or Applications.OwnerGroup = Any($3) or is_admin())", [appid, userInfo.userId, userInfo.userGroups]);
+        })
         if (appResult.rowCount == 0) {
             throw new Error(`Cannot find application with id ${appid}`);
         }
@@ -803,33 +805,37 @@ const validateBlock = async function(block, validTypes, validRoles, blockRevisio
     return undefined;
 }
 
-const importBlock = async function(client, block, blockRevisions) {
+const importBlock = async function(client, block, blockRevisions, req) {
     const name        = block.metadata.name;
     const newRevision = blockRevisions[name] ? blockRevisions[name].revision + 1 : 1;
     const config      = dump(block.spec.config);
     const ifObject    = dump(block.spec.interfaces);
     const bodyObject  = dump(block.spec.body);
 
-    //
-    // If there's an existing revision of this block, check to see if it is the same as the new one.
-    // Only insert a new revision into the database if it is different from the current revision.
-    //
-    if (newRevision > 1) {
-        const mostRecent = await client.query("SELECT Config, Interfaces, SpecBody FROM LibraryBlocks WHERE Name = $1 AND Revision = $2", [name, newRevision - 1]);
-        if (mostRecent.rowCount == 1
-            && config     == mostRecent.rows[0].config
-            && ifObject   == mostRecent.rows[0].interfaces
-            && bodyObject == mostRecent.rows[0].specbody) {
-            return 0;
+    return await queryWithContext(req, client, async (client, userInfo) => {
+        const userId = userInfo.userId
+        const userGroups = userInfo.userGroups
+        //
+        // If there's an existing revision of this block, check to see if it is the same as the new one.
+        // Only insert a new revision into the database if it is different from the current revision.
+        //
+        if (newRevision > 1) {
+            const mostRecent = await client.query("SELECT Config, Interfaces, SpecBody FROM LibraryBlocks WHERE Name = $1 AND Revision = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())", [name, newRevision - 1, userId, userGroups]);
+            if (mostRecent.rowCount == 1
+                && config     == mostRecent.rows[0].config
+                && ifObject   == mostRecent.rows[0].interfaces
+                && bodyObject == mostRecent.rows[0].specbody) {
+                return 0;
+            }
         }
-    }
-
-    await client.query(
-        "INSERT INTO LibraryBlocks " +
-        "(Type, Name, Revision, RevisionComment, BodyStyle, Format, Config, Interfaces, SpecBody) " +
-        "VALUES ($1, $2, $3, 'Imported via API', $4, 'application/yaml', $5, $6, $7)",
-        [block.type, name, newRevision, block.spec.bodyStyle, config, ifObject, bodyObject]);
-    return 1;
+    
+        await client.query(
+            "INSERT INTO LibraryBlocks " +
+            "(Type, Name, Revision, RevisionComment, BodyStyle, Format, Config, Interfaces, SpecBody, Owner) " +
+            "VALUES ($1, $2, $3, 'Imported via API', $4, 'application/yaml', $5, $6, $7)",
+            [block.type, name, newRevision, block.spec.bodyStyle, config, ifObject, bodyObject, userId]);
+        return 1;
+    })
 }
 
 //
@@ -837,7 +843,7 @@ const importBlock = async function(client, block, blockRevisions) {
 // Name syntax:  <blockname>         - latest revision
 //               <blockname>;<rev>   - specified revision
 //
-const loadLibraryBlock = async function(client, library, blockName, buildLog) {
+const loadLibraryBlock = async function(client, library, blockName, buildLog, req) {
     const elements = blockName.split(';');
     const latest   = elements.length == 1;
 
@@ -848,7 +854,9 @@ const loadLibraryBlock = async function(client, library, blockName, buildLog) {
     //
     // Fetch all revisions of this block from the database.
     //
-    const result = await client.query("SELECT * FROM LibraryBlocks WHERE Name = $1 ORDER BY Revision DESC", [elements[0]]);
+    const result = await queryWithContext(req, client, async (client, userInfo) => {
+        return await client.query("SELECT * FROM LibraryBlocks WHERE Name = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) ORDER BY Revision DESC", [elements[0], userInfo.userId, userInfo.userGroups]);
+    })
     if (result.rowCount == 0) {
         buildLog.error(`Library block ${elements[0]} not found`)
     }
@@ -1095,19 +1103,19 @@ const addMemberSite = async function(client, app, site, depid, deployLog) {
 const deleteMemberSite = async function(client, app, site, depid) {
 }
 
-const preLoadApplication = async function(client, appid) {
+const preLoadApplication = async function(client, appid, req) {
     if (cachedApplications[appid]) {
         return cachedApplications[appid];
     }
 
     let application = new Application();
-    await application.buildFromDatabase(client, appid);
+    await application.buildFromDatabase(client, appid, req);
     cachedApplications[appid] = application;
     return application;
 }
 
-const deployApplication = async function(client, appid, vanid, depid, deployLog) {
-    const app = await preLoadApplication(client, appid);
+const deployApplication = async function(client, appid, vanid, depid, deployLog, req) {
+    const app = await preLoadApplication(client, appid, req);
 
     //
     // Mark all of the instance blocks so we can check for unallocated blocks later.
@@ -1160,7 +1168,7 @@ const postLibraryBlocks = async function(req, res) {
         try {
             let items = loadAll(req.body);
 
-            const importCount = await queryWithContext(req, client, async (client) => {
+            const importCount = await queryWithContext(req, client, async (client, userInfo) => {
                 //
                 // Get the set of valid block types.
                 //
@@ -1186,7 +1194,7 @@ const postLibraryBlocks = async function(req, res) {
                 // Get a list of block names with their revision numbers
                 //
                 let blockRevisions = {};
-                const blockResult = await client.query("SELECT Name, Type, Revision FROM LibraryBlocks");
+                const blockResult = await client.query("SELECT Name, Type, Revision FROM LibraryBlocks WHERE Owner = $1 or OwnerGroup = Any($2) or is_admin()", [userInfo.userId, userInfo.userGroups]);
                 for (const br of blockResult.rows) {
                     if (!blockRevisions[br.name] || blockRevisions[br.name].revision < br.revision) {
                         blockRevisions[br.name] = {
@@ -1212,7 +1220,7 @@ const postLibraryBlocks = async function(req, res) {
                 //
                 let importCount = 0;
                 for (const block of items) {
-                    importCount += await importBlock(client, block, blockRevisions);
+                    importCount += await importBlock(client, block, blockRevisions, req);
                 }
                 return importCount;
             });
@@ -1246,15 +1254,16 @@ const createLibraryBlock = async function(req, res) {
             'ownerGroup': {type: 'string', optional: true, default: ''}
         });
 
-        const result = await queryWithContext(req, client, async (client, credentials) => {
-            const ownerId = credentials.userId;
-            const checkResult = await client.query("SELECT Id FROM LibraryBlocks WHERE Name = $1", [norm.name]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId;
+            const userGroups = userInfo.userGroups
+            const checkResult = await client.query("SELECT Id FROM LibraryBlocks WHERE Name = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.name, userId, userGroups]);
             if (checkResult.rowCount > 0) {
                 // Return error indicator - will be handled after COMMIT
                 return { error: true, message: `Library block with name ${norm.name} already exists` };
             } else {
                 const insertResult = await client.query("INSERT INTO LibraryBlocks (Type, Name, Provider, BodyStyle, Owner, OwnerGroup) VALUES ($1, $2, $3, $4, $5, $6) RETURNING Id",
-                    [norm.type, norm.name, norm.provider, norm.bodystyle, ownerId, norm.ownerGroup]);
+                    [norm.type, norm.name, norm.provider, norm.bodystyle, userId, norm.ownerGroup]);
                 if (insertResult.rowCount == 1) {
                     // Return success with data
                     return { success: true, data: insertResult.rows[0] };
@@ -1285,14 +1294,14 @@ const listLibraryBlocks = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        let where = "";
-        let whereData = [];
-        if (req.query.type) {
-            where = " WHERE type = $1"
-            whereData = [req.query.type];
-        }
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks" + where, whereData);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            let where = "";
+            let whereData = [userInfo.userId, userInfo.userGroups];
+            if (req.query.type) {
+                where = " and type = $3"
+                whereData.push(req.query.type);
+            }
+            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE (Owner = $1 or OwnerGroup = Any($2) or is_admin())" + where, whereData);
         })
         res.status(returnStatus).json(result.rows);
     } catch (error) {
@@ -1336,8 +1345,8 @@ const getLibraryBlock = async function(blockid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE Id = $1", [blockid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [blockid, userInfo.userId, userInfo.userGroups]);
         })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
@@ -1359,8 +1368,8 @@ const getLibraryBlockSection = async function(blockid, section, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query(`SELECT ${section} as data FROM LibraryBlocks WHERE Id = $1`, [blockid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query(`SELECT ${section} as data FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())`, [blockid, userInfo.userId, userInfo.userGroups]);
         })
         if (result.rowCount == 1) {
             const jdata = load(result.rows[0].data);
@@ -1384,8 +1393,8 @@ const putLibraryBlockSection = async function(blockid, section, req, res) {
     const data   = dump(req.body);
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
-            await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1`, [blockid, data]);
+        await queryWithContext(req, client, async (client, userInfo) => {
+            await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())`, [blockid, data, userInfo.userId, userInfo.userGroups]);
         })
         res.status(returnStatus).send('Updated');
     } catch (error) {
@@ -1402,8 +1411,8 @@ const deleteLibraryBlock = async function(blockid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("DELETE FROM LibraryBlocks WHERE Id = $1", [blockid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("DELETE FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [blockid, userInfo.userId, userInfo.userGroups]);
         })
         if (result.rowCount != 1) {
             returnStatus = 404;
@@ -1433,10 +1442,9 @@ const postApplication = async function(req, res) {
             'ownerGroup': {type: 'string', optional: true, default: ''}
         });
 
-        const result = await queryWithContext(req, client, async (client, credentials) => {
-            const ownerId = credentials.userId
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query("INSERT INTO Applications (Name, RootBlock, Owner, OwnerGroup) VALUES ($1, $2, $3, $4) RETURNING Id",
-                [norm.name, norm.rootblock, ownerId, norm.ownerGroup]);
+                [norm.name, norm.rootblock, userInfo.userId, norm.ownerGroup]);
         })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
@@ -1459,11 +1467,11 @@ const buildApplication = async function(apid, req, res) {
     const client   = await ClientFromPool();
     let   buildLog = new ProcessLog(true, 'build');
     try {
-        const response = await queryWithContext(req, client, async (client) => {
+        const response = await queryWithContext(req, client, async (client, userInfo) => {
 
             const result = await client.query("SELECT LibraryBlocks.Name as lbname, LibraryBlocks.Revision, Applications.Name as appname, Lifecycle FROM Applications " +
                                               "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                                              "WHERE Applications.Id = $1", [apid]);
+                                              "WHERE Applications.Id = $1 and (Applications.Owner = $2 or Applications.OwnerGroup = Any($3) or is_admin())", [apid, userInfo.userId, userInfo.userGroups]);
             if (result.rowCount == 1) {
                 const app = result.rows[0];
     
@@ -1544,7 +1552,7 @@ const buildApplication = async function(apid, req, res) {
                 //
                 // Update the lifecycle of the application and add the build log.
                 //
-                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
+                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [apid, buildLog.getText(), buildLog.getResult(), userInfo.userId, userInfo.userGroups]);
                 return response;
             }
         })
@@ -1554,8 +1562,8 @@ const buildApplication = async function(apid, req, res) {
             //
             // If we got a build error, update the build log for user visibility after rolling back the current transaction.
             //
-            await queryWithContext(req, client, async (client) => {
-                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
+            await queryWithContext(req, client, async (client, userInfo) => {
+                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [apid, buildLog.getText(), buildLog.getResult(), userInfo.userId, userInfo.userGroups]);
             })
             returnStatus = 200;
             res.status(returnStatus).send("Build Failed - See build log for details");
@@ -1574,10 +1582,12 @@ const listApplications = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query(
                 "SELECT Applications.Id, Applications.Name, RootBlock, Lifecycle, LibraryBlocks.Name as rootname FROM Applications " +
-                "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock"
+                "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
+                "WHERE Applications.Owner = $1 or Applications.OwnerGroup = Any($2) or is_admin()",
+                [userInfo.userId, userInfo.userGroups]
             );
         })
         res.status(returnStatus).json(result.rows);
@@ -1595,11 +1605,12 @@ const getApplication = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query(
                 "SELECT Applications.*, LibraryBlocks.Name as rootname FROM Applications " +
                 "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                "WHERE Applications.Id = $1", [apid]
+                "WHERE Applications.Id = $1 and (Applications.Owner = $2 or Applications.OwnerGroup = Any($3) or is_admin())",
+                [apid, userInfo.userId, userInfo.userGroups]
             );
         })
         if (result.rowCount == 1) {
@@ -1622,8 +1633,8 @@ const getApplicationBuildLog = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query("SELECT BuildLog FROM Applications WHERE Id = $1", [apid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            return await client.query("SELECT BuildLog FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userInfo.userId, userInfo.userGroups]);
         })
         if (result.rowCount == 1) {
             res.status(returnStatus).send(result.rows[0].buildlog);
@@ -1645,13 +1656,14 @@ const getApplicationImage = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const yamlDocument = await queryWithContext(req, client, async (client) => {
-
+        const yamlDocument = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups
             //
             // Get the application and ensure that it is in build-complete state.
             //
             const appResult = await client.query(
-                "SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]
+                "SELECT Lifecycle FROM Applications WHERE Id = $1 (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]
             );
     
             if (appResult.rowCount == 0) {
@@ -1687,7 +1699,7 @@ const getApplicationImage = async function(apid, req, res) {
             let libraryBlocks = {};
             for (const lbid of Object.keys(libraryReferencers)) {
                 const lbResult = await client.query(
-                    "SELECT * FROM LibraryBlocks WHERE Id = $1", [lbid]
+                    "SELECT * FROM LibraryBlocks WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [lbid, userId, userGroups]
                 );
                 if (lbResult.rowCount == 0) {
                     throw new Error(`Nonexistent library block (${lbid}) referenced by ${libraryReferencers[lbid]}`);
@@ -1764,15 +1776,17 @@ const deleteApplication = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            const check = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups
+            const check = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]);
             if (check.rowCount == 1 && check.rows[0].lifecycle == 'deployed') {
                 // Return error indicator - will be handled after COMMIT
                 return { error: true, status: 400, message: 'Cannot delete an Application that is deployed' };
             } else {
                 await client.query("DELETE FROM Bindings WHERE Application = $1", [apid]);
                 await client.query("DELETE FROM InstanceBlocks WHERE Application = $1", [apid]);
-                const deleteResult = await client.query("DELETE FROM Applications WHERE Id = $1", [apid]);
+                const deleteResult = await client.query("DELETE FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]);
                 return deleteResult;
             }
         })
@@ -1801,13 +1815,13 @@ const listApplicationBlocks = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             return await client.query(
                 "SELECT InstanceBlocks.Id, InstanceName, LibraryBlock, " +
                 "LibraryBlocks.Name as libname, LibraryBlocks.Revision FROM InstanceBlocks " +
                 "JOIN LibraryBlocks ON LibraryBlocks.Id = LibraryBlock " +
-                "WHERE Application = $1",
-                [apid]
+                "WHERE Application = $1 and (LibraryBlocks.Owner = $2 or LibraryBlocks.OwnerGroup = Any($3) or is_admin())",
+                [apid, userInfo.userId, userInfo.userGroups]
             );
         })
         res.status(returnStatus).json(result.rows);
@@ -1836,20 +1850,21 @@ const postDeployment = async function(req, res) {
             'ownerGroup': { type: 'string', optional: true, default: ''}
         });
 
-        const result = await queryWithContext(req, client, async (client, credentials) => {
-            const checkResult = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [norm.app]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups
+            const checkResult = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.app, userId, userGroups]);
             if (checkResult.rowCount == 0) {
                 throw new Error(`Application not found; ${norm.app}`);
             } else if (checkResult.rows[0].lifecycle == 'deployed') {
                 throw new Error(`Attempting to deploy an application that is already deployed: ${norm.app}`);
             }
-            const ownerId = credentials.userId
             return await client.query("INSERT INTO DeployedApplications (Application, Van, Owner, OwnerGroup) VALUES ($1, $2, $3, $4) RETURNING Id",
-                                              [norm.app, norm.van, ownerId, norm.ownerGroup]);
+                                              [norm.app, norm.van, userId, norm.ownerGroup]);
         })
         if (result.rowCount == 1) {
-            await queryWithContext(req, client, async (client) => {
-                await client.query("UPDATE Applications SET Lifecycle = 'deployed' WHERE Id = $1", [norm.app]);
+            await queryWithContext(req, client, async (client, userInfo) => {
+                await client.query("UPDATE Applications SET Lifecycle = 'deployed' WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [norm.app, userInfo.userId, userInfo.userGroups]);
             })
             res.status(returnStatus).json(result.rows[0]);
         } else {
@@ -1871,8 +1886,10 @@ const deployDeployment = async function(depid, req, res) {
     const client = await ClientFromPool();
     let   deployLog = new ProcessLog(true, 'deploy');
     try {
-        const response = await queryWithContext((req, client, async (client) => {
-            const checkResult = await client.query("SELECT Id, Lifecycle, Application, Van FROM DeployedApplications WHERE Id = $1", [depid]);
+        const response = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups
+            const checkResult = await client.query("SELECT Id, Lifecycle, Application, Van FROM DeployedApplications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [depid, userId, userGroups]);
             if (checkResult.rowCount == 0) {
                 throw new Error(`Deployment not found; ${depid}`);
             } else if (checkResult.rows[0].lifecycle == 'deployed') {
@@ -1880,7 +1897,7 @@ const deployDeployment = async function(depid, req, res) {
             }
     
             const deployment = checkResult.rows[0];
-            await deployApplication(client, deployment.application, deployment.van, deployment.id, deployLog);
+            await deployApplication(client, deployment.application, deployment.van, deployment.id, deployLog, req);
     
             //
             // Add final success log
@@ -1897,17 +1914,17 @@ const deployDeployment = async function(depid, req, res) {
             //
             // Update the lifecycle of the deployment and add the build log.
             //
-            await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), 'deployed']);
+            await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [depid, deployLog.getText(), 'deployed', userId, userGroups]);
             return response;
-        }))
+        })
         res.status(returnStatus).send(response);
     } catch (error) {
         if (error.message == PROCESS_ERROR) {
             //
             // If we got a process error, update the deploy log for user visibility after rolling back the current transaction.
             //
-            await queryWithContext(req, client, async (client) => {
-                await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), deployLog.getResult()]);
+            await queryWithContext(req, client, async (client, userInfo) => {
+                await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1, and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [depid, deployLog.getText(), deployLog.getResult(), userInfo.userId, userInfo.userGroups]);
             })
             returnStatus = 200;
             res.status(returnStatus).send("Deploy Failed - See deployment log for details");
@@ -1950,11 +1967,13 @@ const listDeployments = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             const result = await client.query(
                 "SELECT DeployedApplications.Id, DeployedApplications.Lifecycle, Application, Van, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
-                "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van"
+                "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van " + 
+                "WHERE DeployedApplications.Owner = $1 or DeployedApplications.OwnerGroup = Any($2) or is_admin()",
+                [userInfo.userId, userInfo.userGroups]
             );
             return result;
         })
@@ -1973,13 +1992,13 @@ const getDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
             const result = await client.query(
                 "SELECT DeployedApplications.*, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
                 "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van " +
-                "WHERE DeployedApplications.Id = $1",
-                [depid]
+                "WHERE DeployedApplications.Id = $1 and (DeployedApplications.Owner = $2 or DeployedApplications.OwnerGroup = Any($3) or is_admin())",
+                [depid, userInfo.userId, userInfo.userGroups]
             );
             return result;
         })
@@ -2003,20 +2022,22 @@ const deleteDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const message = await queryWithContext(req, client, async (client) => {
+        const message = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId
+            const userGroups = userInfo.userGroups
             await client.query("DELETE FROM SiteData WHERE DeployedApplication = $1", [depid]);
-            const result = await client.query("DELETE FROM DeployedApplications WHERE Id = $1 RETURNING Application", [depid]);
+            const result = await client.query("DELETE FROM DeployedApplications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin()) RETURNING Application", [depid, userId, userGroups]);
             let message = 'Not Found';
             if (result.rowCount != 1) {
                 returnStatus = 404;
             } else {
                 const appid = result.rows[0].application;
-                const listResult = await client.query("SELECT Id FROM DeployedApplications WHERE Application = $1", [appid]);
+                const listResult = await client.query("SELECT Id FROM DeployedApplications WHERE Application = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [appid, userId, userGroups]);
                 if (listResult.rowCount == 0) {
                     //
                     // If we just deleted the last deployment of the application, move its lifecycle back to 'build-complete'.
                     //
-                    await client.query("UPDATE Applications SET LifeCycle = 'build-complete' WHERE Id = $1", [appid]);
+                    await client.query("UPDATE Applications SET LifeCycle = 'build-complete' WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [appid, userId, userGroups]);
                     message = 'Deleted';
                 }
             }

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -1158,68 +1158,71 @@ const postLibraryBlocks = async function(req, res) {
     if (req.is('application/yaml')) {
         const client = await ClientFromPool();
         try {
-            await client.query("BEGIN");
             let items = loadAll(req.body);
 
-            //
-            // Get the set of valid block types.
-            //
-            let validTypes = {};
-            const result = await client.query("SELECT Name, AllowNorth, AllowSouth FROM BlockTypes");
-            for (const row of result.rows) {
-                validTypes[row.name] = {
-                    allowNorth : row.allownorth,
-                    allowSouth : row.allowsouth,
-                };
-            }
-
-            //
-            // Get the set of valid interface roles.
-            //
-            let validRoles = [];
-            const roleResult = await client.query("SELECT Name FROM InterfaceRoles");
-            for (const row of roleResult.rows) {
-                validRoles.push(row.name);
-            }
-
-            //
-            // Get a list of block names with their revision numbers
-            //
-            var blockRevisions = {};
-            const blockResult = await client.query("SELECT Name, Type, Revision FROM LibraryBlocks");
-            for (const br of blockResult.rows) {
-                if (!blockRevisions[br.name] || blockRevisions[br.name].revision < br.revision) {
-                    blockRevisions[br.name] = {
-                        revision : br.revision,
-                        btype    : br.type,
+            let importCount = await queryWithContext(req, client, async (client) => {
+                //
+                // Get the set of valid block types.
+                //
+                let validTypes = {};
+                const result = await client.query("SELECT Name, AllowNorth, AllowSouth FROM BlockTypes");
+                for (const row of result.rows) {
+                    validTypes[row.name] = {
+                        allowNorth : row.allownorth,
+                        allowSouth : row.allowsouth,
                     };
                 }
-            }
 
-            //
-            // Validate the items.  Ensure they are all Blocks with valid types, names, and specs
-            //
-            for (const block of items) {
-                const errorText = await validateBlock(block, validTypes, validRoles, blockRevisions);
-                if (errorText) {
-                    res.status(400).send(`Bad Request - ${errorText}`);
-                    await client.query("ROLLBACK");
-                    return;
+                //
+                // Get the set of valid interface roles.
+                //
+                let validRoles = [];
+                const roleResult = await client.query("SELECT Name FROM InterfaceRoles");
+                for (const row of roleResult.rows) {
+                    validRoles.push(row.name);
                 }
-            }
 
-            //
-            // Import the validated blocks into the database
-            //
-            let importCount = 0;
-            for (const block of items) {
-                importCount += await importBlock(client, block, blockRevisions);
-            }
-            await client.query("COMMIT");
+                //
+                // Get a list of block names with their revision numbers
+                //
+                let blockRevisions = {};
+                const blockResult = await client.query("SELECT Name, Type, Revision FROM LibraryBlocks");
+                for (const br of blockResult.rows) {
+                    if (!blockRevisions[br.name] || blockRevisions[br.name].revision < br.revision) {
+                        blockRevisions[br.name] = {
+                            revision : br.revision,
+                            btype    : br.type,
+                        };
+                    }
+                }
+
+                //
+                // Validate the items.  Ensure they are all Blocks with valid types, names, and specs
+                //
+                for (const block of items) {
+                    const errorText = await validateBlock(block, validTypes, validRoles, blockRevisions);
+                    if (errorText) {
+                        // Throw error to trigger rollback
+                        throw new Error(`Bad Request - ${errorText}`);
+                    }
+                }
+
+                //
+                // Import the validated blocks into the database
+                //
+                for (const block of items) {
+                    importCount += await importBlock(client, block, blockRevisions);
+                }
+                return importCount;
+            });
+
             res.status(201).send(`Imported ${importCount} Blocks`);
         } catch (error) {
-            res.status(500).send(error.stack);
-            await client.query("ROLLBACK");
+            if (error.message.startsWith('Bad Request -')) {
+                res.status(400).send(error.message);
+            } else {
+                res.status(500).send(error.stack);
+            }
         } finally {
             client.release();
         }
@@ -1229,38 +1232,47 @@ const postLibraryBlocks = async function(req, res) {
 }
 
 const createLibraryBlock = async function(req, res) {
-    var returnStatus = 201;
+    let returnStatus = 201;
     const client = await ClientFromPool();
     const form = new IncomingForm();
     try {
-        await client.query("BEGIN");
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
             'name'      : {type: 'dnsname', optional: false},
             'type'      : {type: 'string',  optional: false},
             'bodystyle' : {type: 'string',  optional: false},
             'provider'  : {type: 'dnsname', optional: true, default: ''},
+            'ownerGroup': {type: 'string', optional: true, default: ''}
         });
 
-        const checkResult = await client.query("SELECT Id FROM LibraryBlocks WHERE Name = $1", [norm.name]);
-        if (checkResult.rowCount > 0) {
-            returnStatus = 400;
-            res.status(returnStatus).send(`Library block with name ${norm.name} already exists`);
-        } else {
-            const result = await client.query("INSERT INTO LibraryBlocks (Type, Name, Provider, BodyStyle) VALUES ($1, $2, $3, $4) RETURNING Id",
-                                            [norm.type, norm.name, norm.provider, norm.bodystyle]);
-            await client.query("COMMIT");
-            if (result.rowCount == 1) {
-                res.status(returnStatus).json(result.rows[0]);
+        const result = await queryWithContext(req, client, async (client, credentials) => {
+            const ownerId = credentials.userId;
+            const checkResult = await client.query("SELECT Id FROM LibraryBlocks WHERE Name = $1", [norm.name]);
+            if (checkResult.rowCount > 0) {
+                // Return error indicator - will be handled after COMMIT
+                return { error: true, message: `Library block with name ${norm.name} already exists` };
             } else {
-                returnStatus = 400;
-                res.status(returnStatus).send(result.error);
+                const insertResult = await client.query("INSERT INTO LibraryBlocks (Type, Name, Provider, BodyStyle, Owner, OwnerGroup) VALUES ($1, $2, $3, $4, $5, $6) RETURNING Id",
+                    [norm.type, norm.name, norm.provider, norm.bodystyle, ownerId, norm.ownerGroup]);
+                if (insertResult.rowCount == 1) {
+                    // Return success with data
+                    return { success: true, data: insertResult.rows[0] };
+                } else {
+                    return { error: true, message: insertResult.error };
+                }
             }
+        })
+
+        // Send response after transaction commits successfully
+        if (result.error) {
+            returnStatus = 400;
+            res.status(returnStatus).send(result.message);
+        } else if (result.success) {
+            res.status(returnStatus).json(result.data);
         }
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
-        await client.query("ROLLBACK");
     } finally {
         client.release();
     }
@@ -1272,19 +1284,18 @@ const listLibraryBlocks = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
         let where = "";
         let whereData = [];
         if (req.query.type) {
             where = " WHERE type = $1"
             whereData = [req.query.type];
         }
-        const result = await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks" + where, whereData);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks" + where, whereData);
+        })
         res.status(returnStatus).json(result.rows);
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in listLibraryBlocks: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1297,21 +1308,21 @@ const getBlockTypes = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT * FROM BlockTypes");
-        let btmap = {};
-        for (const row of result.rows) {
-            btmap[row.name] = {
-                allownorth : row.allownorth,
-                allowsouth : row.allowsouth,
-                allocation : row.allocation,
-            };
-        }
-        res.status(returnStatus).json(btmap);
-        await client.query("COMMIT");
+        const blockTypeResult = await queryWithContext(req, client, async (client) => {
+            const result = await client.query("SELECT * FROM BlockTypes");
+            let btmap = {};
+            for (const row of result.rows) {
+                btmap[row.name] = {
+                    allownorth : row.allownorth,
+                    allowsouth : row.allowsouth,
+                    allocation : row.allocation,
+                };
+            }
+            return btmap;
+        })
+        res.status(returnStatus).json(blockTypeResult);
     } catch (error) {
         Log(`Exception in getBlockTypes: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1324,18 +1335,17 @@ const getLibraryBlock = async function(blockid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE Id = $1", [blockid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Id, Type, Name, Provider, BodyStyle, Revision, Created FROM LibraryBlocks WHERE Id = $1", [blockid]);
+        })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
         } else {
             returnStatus = 404;
             res.status(returnStatus).send('Not Found');
         }
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getLibraryBlock: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1348,8 +1358,9 @@ const getLibraryBlockSection = async function(blockid, section, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query(`SELECT ${section} as data FROM LibraryBlocks WHERE Id = $1`, [blockid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(`SELECT ${section} as data FROM LibraryBlocks WHERE Id = $1`, [blockid]);
+        })
         if (result.rowCount == 1) {
             const jdata = load(result.rows[0].data);
             res.status(returnStatus).json(jdata || []);
@@ -1357,10 +1368,8 @@ const getLibraryBlockSection = async function(blockid, section, req, res) {
             returnStatus = 404;
             res.status(returnStatus).send('Not Found');
         }
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getLibraryBlockSection(${section}): ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1374,13 +1383,12 @@ const putLibraryBlockSection = async function(blockid, section, req, res) {
     const data   = dump(req.body);
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1`, [blockid, data]);
-        await client.query("COMMIT");
+        await queryWithContext(req, client, async (client) => {
+            await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1`, [blockid, data]);
+        })
         res.status(returnStatus).send('Updated');
     } catch (error) {
         Log(`Exception in putLibraryBlockSection(${section}): ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1393,18 +1401,17 @@ const deleteLibraryBlock = async function(blockid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("DELETE FROM LibraryBlocks WHERE Id = $1", [blockid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("DELETE FROM LibraryBlocks WHERE Id = $1", [blockid]);
+        })
         if (result.rowCount != 1) {
             returnStatus = 404;
             res.status(returnStatus).send('Not Found');
         } else {
             res.status(returnStatus).send('Deleted');
         }
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in deleteLibraryBlock: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1418,16 +1425,18 @@ const postApplication = async function(req, res) {
     const client = await ClientFromPool();
     const form = new IncomingForm();
     try {
-        await client.query("BEGIN");
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
             'name'      : {type: 'dnsname', optional: false},
             'rootblock' : {type: 'uuid',    optional: false},
+            'ownerGroup': {type: 'string', optional: true, default: ''}
         });
 
-        const result = await client.query("INSERT INTO Applications (Name, RootBlock) VALUES ($1, $2) RETURNING Id",
-                                          [norm.name, norm.rootblock]);
-        await client.query("COMMIT");
+        const result = await queryWithContext(req, client, async (client, credentials) => {
+            const ownerId = credentials.userId
+            return await client.query("INSERT INTO Applications (Name, RootBlock, Owner, OwnerGroup) VALUES ($1, $2, $3, $4) RETURNING Id",
+                [norm.name, norm.rootblock, ownerId, norm.ownerGroup]);
+        })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
         } else {
@@ -1437,7 +1446,6 @@ const postApplication = async function(req, res) {
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
-        await client.query("ROLLBACK");
     } finally {
         client.release();
     }
@@ -1450,103 +1458,104 @@ const buildApplication = async function(apid, req, res) {
     const client   = await ClientFromPool();
     let   buildLog = new ProcessLog(true, 'build');
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT LibraryBlocks.Name as lbname, LibraryBlocks.Revision, Applications.Name as appname, Lifecycle FROM Applications " +
-                                          "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-                                          "WHERE Applications.Id = $1", [apid]);
-        if (result.rowCount == 1) {
-            const app = result.rows[0];
+        const response = await queryWithContext(req, client, async (client) => {
 
-            //
-            // Prevent against re-building applications that are deployed.  This needs to be well thought-through.
-            //
-            if (app.lifecycle == 'deployed') {
-                throw new Error('Cannot build an application that is deployed');
-            }
-
-            //
-            // Get an in-memory cache of the library blocks referenced from the root block.
-            //
-            const rootBlockName = `${app.lbname};${app.revision}`;
-            const library = await loadLibrary(client, rootBlockName, buildLog);
-
-            //
-            // Construct the application, resolving all of the inter-block bindings.
-            //
-            const application = new Application();
-            application.buildFromApi(rootBlockName, app.appname, library, buildLog);
-            cachedApplications[apid] = application;
-
-            //
-            // Get the block types to feed into the derivative generator.
-            //
-            const btypes = await client.query("SELECT * FROM BlockTypes");
-            let   blockTypes = {};
-            for (const rec of btypes.rows) {
-                blockTypes[rec.name] = rec;
-            }
-
-            //
-            // Generate the derivative data
-            //
-            generateDerivativeData(application, buildLog, blockTypes);
-
-            //
-            // Generate database entries for the instance blocks.
-            //
-            await client.query("DELETE FROM Bindings WHERE Application = $1", [apid]);
-            await client.query("DELETE FROM InstanceBlocks WHERE Application = $1", [apid]);
-            const instanceBlocks = application.getInstanceBlocks();
-            for (const [name, block] of Object.entries(instanceBlocks)) {
-                const result = await client.query("INSERT INTO InstanceBlocks (Application, LibraryBlock, InstanceName, Config, Metadata, Derivative) VALUES ($1, $2, $3, $4, $5, $6) RETURNING Id",
-                                                  [apid, block.libraryBlockDatabaseId(), name, JSON.stringify(block.getConfig()), JSON.stringify(block.getMetadata()), JSON.stringify(block.getDerivative())]);
-                if (result.rowCount == 1) {
-                    block.setDatabaseId(result.rows[0].id);
+            const result = await client.query("SELECT LibraryBlocks.Name as lbname, LibraryBlocks.Revision, Applications.Name as appname, Lifecycle FROM Applications " +
+                                              "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
+                                              "WHERE Applications.Id = $1", [apid]);
+            if (result.rowCount == 1) {
+                const app = result.rows[0];
+    
+                //
+                // Prevent against re-building applications that are deployed.  This needs to be well thought-through.
+                //
+                if (app.lifecycle == 'deployed') {
+                    throw new Error('Cannot build an application that is deployed');
                 }
+    
+                //
+                // Get an in-memory cache of the library blocks referenced from the root block.
+                //
+                const rootBlockName = `${app.lbname};${app.revision}`;
+                const library = await loadLibrary(client, rootBlockName, buildLog);
+    
+                //
+                // Construct the application, resolving all of the inter-block bindings.
+                //
+                const application = new Application();
+                application.buildFromApi(rootBlockName, app.appname, library, buildLog);
+                cachedApplications[apid] = application;
+    
+                //
+                // Get the block types to feed into the derivative generator.
+                //
+                const btypes = await client.query("SELECT * FROM BlockTypes");
+                let   blockTypes = {};
+                for (const rec of btypes.rows) {
+                    blockTypes[rec.name] = rec;
+                }
+    
+                //
+                // Generate the derivative data
+                //
+                generateDerivativeData(application, buildLog, blockTypes);
+    
+                //
+                // Generate database entries for the instance blocks.
+                //
+                await client.query("DELETE FROM Bindings WHERE Application = $1", [apid]);
+                await client.query("DELETE FROM InstanceBlocks WHERE Application = $1", [apid]);
+                const instanceBlocks = application.getInstanceBlocks();
+                for (const [name, block] of Object.entries(instanceBlocks)) {
+                    const result = await client.query("INSERT INTO InstanceBlocks (Application, LibraryBlock, InstanceName, Config, Metadata, Derivative) VALUES ($1, $2, $3, $4, $5, $6) RETURNING Id",
+                                                      [apid, block.libraryBlockDatabaseId(), name, JSON.stringify(block.getConfig()), JSON.stringify(block.getMetadata()), JSON.stringify(block.getDerivative())]);
+                    if (result.rowCount == 1) {
+                        block.setDatabaseId(result.rows[0].id);
+                    }
+                }
+    
+                //
+                // Insert Bindings records into the database
+                //
+                const bindings = application.getBindings();
+                for (const binding of bindings) {
+                    const northInterface = binding.getNorthInterface();
+                    const northBlock     = northInterface.getOwner();
+                    const southInterface = binding.getSouthInterface();
+                    const southBlock     = southInterface.getOwner();
+                    await client.query("INSERT INTO Bindings (Application, NorthBlock, NorthInterface, SouthBlock, SouthInterface) " +
+                                       "VALUES ($1, $2, $3, $4, $5)",
+                                       [apid, northBlock.getName(), northInterface.getName(), southBlock.getName(), southInterface.getName()]);
+                }
+    
+                //
+                // Add final success log
+                //
+                var response;
+                if (buildLog.getResult() == 'build-warnings') {
+                    buildLog.log("WARNING: Build completed with warnings");
+                    response = 'Warnings - See build log for details';
+                } else {
+                    buildLog.log("SUCCESS: Build completed successfully");
+                    response = 'Success - See build log for details';
+                }
+    
+                //
+                // Update the lifecycle of the application and add the build log.
+                //
+                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
+                return response;
             }
-
-            //
-            // Insert Bindings records into the database
-            //
-            const bindings = application.getBindings();
-            for (const binding of bindings) {
-                const northInterface = binding.getNorthInterface();
-                const northBlock     = northInterface.getOwner();
-                const southInterface = binding.getSouthInterface();
-                const southBlock     = southInterface.getOwner();
-                await client.query("INSERT INTO Bindings (Application, NorthBlock, NorthInterface, SouthBlock, SouthInterface) " +
-                                   "VALUES ($1, $2, $3, $4, $5)",
-                                   [apid, northBlock.getName(), northInterface.getName(), southBlock.getName(), southInterface.getName()]);
-            }
-
-            //
-            // Add final success log
-            //
-            var response;
-            if (buildLog.getResult() == 'build-warnings') {
-                buildLog.log("WARNING: Build completed with warnings");
-                response = 'Warnings - See build log for details';
-            } else {
-                buildLog.log("SUCCESS: Build completed successfully");
-                response = 'Success - See build log for details';
-            }
-
-            //
-            // Update the lifecycle of the application and add the build log.
-            //
-            await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
-        }
-        await client.query("COMMIT");
+        })
         res.status(returnStatus).send(response);
     } catch (error) {
-        await client.query("ROLLBACK");
         if (error.message == PROCESS_ERROR) {
             //
             // If we got a build error, update the build log for user visibility after rolling back the current transaction.
             //
-            await client.query("BEGIN");
-            await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
-            await client.query("COMMIT");
+            await queryWithContext(req, client, async (client) => {
+                await client.query("UPDATE Applications SET Lifecycle = $3, BuildLog = $2 WHERE Id = $1", [apid, buildLog.getText(), buildLog.getResult()]);
+            })
             returnStatus = 200;
             res.status(returnStatus).send("Build Failed - See build log for details");
         } else {
@@ -1564,16 +1573,15 @@ const listApplications = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query(
-            "SELECT Applications.Id, Applications.Name, RootBlock, Lifecycle, LibraryBlocks.Name as rootname FROM Applications " +
-            "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock"
-        );
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                "SELECT Applications.Id, Applications.Name, RootBlock, Lifecycle, LibraryBlocks.Name as rootname FROM Applications " +
+                "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock"
+            );
+        })
         res.status(returnStatus).json(result.rows);
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in listApplications: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1586,22 +1594,21 @@ const getApplication = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query(
-            "SELECT Applications.*, LibraryBlocks.Name as rootname FROM Applications " +
-            "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
-            "WHERE Applications.Id = $1", [apid]
-        );
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                "SELECT Applications.*, LibraryBlocks.Name as rootname FROM Applications " +
+                "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
+                "WHERE Applications.Id = $1", [apid]
+            );
+        })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);
         } else {
             returnStatus = 404;
             res.status(returnStatus).send('Not Found');
         }
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getApplication: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1614,18 +1621,17 @@ const getApplicationBuildLog = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT BuildLog FROM Applications WHERE Id = $1", [apid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT BuildLog FROM Applications WHERE Id = $1", [apid]);
+        })
         if (result.rowCount == 1) {
             res.status(returnStatus).send(result.rows[0].buildlog);
         } else {
             returnStatus = 404;
             res.status(returnStatus).send('Not Found');
         }
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getApplicationBuildLog: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1638,112 +1644,113 @@ const getApplicationImage = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        //
-        // Get the application and ensure that it is in build-complete state.
-        //
-        const appResult = await client.query(
-            "SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]
-        );
+        const yamlDocument = await queryWithContext(req, client, async (client) => {
 
-        if (appResult.rowCount == 0) {
-            throw new Error(`Application with id ${apid} not found`);
-        }
-
-        if (appResult.rows[0].lifecycle != 'build-complete') {
-            throw new Error(`Application lifecycle is ${appResult.rows[0].lifecycle}`);
-        }
-
-        //
-        // Fetch all of the instance blocks for this application
-        //
-        const instanceResult = await client.query(
-            "SELECT * FROM InstanceBlocks WHERE Application = $1", [apid]
-        );
-        const instances = instanceResult.rows;
-
-        //
-        // Collect the set of library blocks referenced by the instances
-        //
-        let libraryReferencers = {};
-        for (const instance of instances) {
-            if (!libraryReferencers[instance.libraryblock]) {
-                libraryReferencers[instance.libraryblock] = []
-            }
-            libraryReferencers[instance.libraryblock].push(instance.instancename);
-        }
-
-        //
-        // Fetch the library blocks in the set
-        //
-        let libraryBlocks = {};
-        for (const lbid of Object.keys(libraryReferencers)) {
-            const lbResult = await client.query(
-                "SELECT * FROM LibraryBlocks WHERE Id = $1", [lbid]
+            //
+            // Get the application and ensure that it is in build-complete state.
+            //
+            const appResult = await client.query(
+                "SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]
             );
-            if (lbResult.rowCount == 0) {
-                throw new Error(`Nonexistent library block (${lbid}) referenced by ${libraryReferencers[lbid]}`);
+    
+            if (appResult.rowCount == 0) {
+                throw new Error(`Application with id ${apid} not found`);
             }
-            libraryBlocks[lbid] = lbResult.rows[0];
-        }
-
-        //
-        // Fetch the interface bindings in the application
-        //
-        let interfaceBindings = [];
-        const ibResult = await client.query(
-            "SELECT * FROM Bindings WHERE Application = $1", [apid]
-        );
-        for (const row of ibResult.rows) {
-            interfaceBindings.push(row);
-        }
-
-        //
-        // Generate an image file with the libaray blocks, configured intance blocks, and interface bindings
-        //
-        let imageDocument = {
-            libraries : {},
-            instances : {},
-            bindings  : [],
-        };
-
-        for (const lblock of Object.values(libraryBlocks)) {
-            if (lblock.bodystyle == 'simple') {
-                imageDocument.libraries[`${lblock.name};${lblock.revision}`] = {
-                    config     : load(lblock.config),
-                    interfaces : load(lblock.interfaces),
-                    specbody   : load(lblock.specbody),
-                };
+    
+            if (appResult.rows[0].lifecycle != 'build-complete') {
+                throw new Error(`Application lifecycle is ${appResult.rows[0].lifecycle}`);
             }
-        }
-
-        for (const instance of instances) {
-            const lb = libraryBlocks[instance.libraryblock];
-            if (lb.bodystyle == 'simple') {
-                imageDocument.instances[instance.instancename] = {
-                    libraryblock : `${lb.name};${lb.revision}`,
-                    config       : JSON.parse(instance.config),
-                    metadata     : JSON.parse(instance.metadata),
-                    derivative   : JSON.parse(instance.derivative),
-                };
+    
+            //
+            // Fetch all of the instance blocks for this application
+            //
+            const instanceResult = await client.query(
+                "SELECT * FROM InstanceBlocks WHERE Application = $1", [apid]
+            );
+            const instances = instanceResult.rows;
+    
+            //
+            // Collect the set of library blocks referenced by the instances
+            //
+            let libraryReferencers = {};
+            for (const instance of instances) {
+                if (!libraryReferencers[instance.libraryblock]) {
+                    libraryReferencers[instance.libraryblock] = []
+                }
+                libraryReferencers[instance.libraryblock].push(instance.instancename);
             }
-        }
-
-        for (const binding of interfaceBindings) {
-            imageDocument.bindings.push({
-                northblock : binding.northblock,
-                northinterface : binding.northinterface,
-                southblock     : binding.southblock,
-                southinterface : binding.southinterface,
-            });
-        }
-
-        const yamlDocument = dump(imageDocument);
+    
+            //
+            // Fetch the library blocks in the set
+            //
+            let libraryBlocks = {};
+            for (const lbid of Object.keys(libraryReferencers)) {
+                const lbResult = await client.query(
+                    "SELECT * FROM LibraryBlocks WHERE Id = $1", [lbid]
+                );
+                if (lbResult.rowCount == 0) {
+                    throw new Error(`Nonexistent library block (${lbid}) referenced by ${libraryReferencers[lbid]}`);
+                }
+                libraryBlocks[lbid] = lbResult.rows[0];
+            }
+    
+            //
+            // Fetch the interface bindings in the application
+            //
+            let interfaceBindings = [];
+            const ibResult = await client.query(
+                "SELECT * FROM Bindings WHERE Application = $1", [apid]
+            );
+            for (const row of ibResult.rows) {
+                interfaceBindings.push(row);
+            }
+    
+            //
+            // Generate an image file with the libaray blocks, configured intance blocks, and interface bindings
+            //
+            let imageDocument = {
+                libraries : {},
+                instances : {},
+                bindings  : [],
+            };
+    
+            for (const lblock of Object.values(libraryBlocks)) {
+                if (lblock.bodystyle == 'simple') {
+                    imageDocument.libraries[`${lblock.name};${lblock.revision}`] = {
+                        config     : load(lblock.config),
+                        interfaces : load(lblock.interfaces),
+                        specbody   : load(lblock.specbody),
+                    };
+                }
+            }
+    
+            for (const instance of instances) {
+                const lb = libraryBlocks[instance.libraryblock];
+                if (lb.bodystyle == 'simple') {
+                    imageDocument.instances[instance.instancename] = {
+                        libraryblock : `${lb.name};${lb.revision}`,
+                        config       : JSON.parse(instance.config),
+                        metadata     : JSON.parse(instance.metadata),
+                        derivative   : JSON.parse(instance.derivative),
+                    };
+                }
+            }
+    
+            for (const binding of interfaceBindings) {
+                imageDocument.bindings.push({
+                    northblock : binding.northblock,
+                    northinterface : binding.northinterface,
+                    southblock     : binding.southblock,
+                    southinterface : binding.southinterface,
+                });
+            }
+    
+            const yamlDocument = dump(imageDocument);
+            return yamlDocument;
+        })
         res.status(returnStatus).send(yamlDocument);
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getApplicationImage: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1756,28 +1763,31 @@ const deleteApplication = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const check = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]);
-        if (check.rowCount == 1 && check.rows[0].lifecycle == 'deployed') {
-            returnStatus = 400;
-            await client.query("COMMIT");
-            res.status(returnStatus).send('Cannot delete an Application that is deployed');
-        } else {
-            await client.query("DELETE FROM Bindings WHERE Application = $1", [apid]);
-            await client.query("DELETE FROM InstanceBlocks WHERE Application = $1", [apid]);
-            const result = await client.query("DELETE FROM Applications WHERE Id = $1", [apid]);
-            await client.query("COMMIT");
-            if (result.rowCount != 1) {
-                returnStatus = 404;
-                res.status(returnStatus).send('Not Found');
+        const result = await queryWithContext(req, client, async (client) => {
+            const check = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [apid]);
+            if (check.rowCount == 1 && check.rows[0].lifecycle == 'deployed') {
+                // Return error indicator - will be handled after COMMIT
+                return { error: true, status: 400, message: 'Cannot delete an Application that is deployed' };
             } else {
-                delete cachedApplications[apid];
-                res.status(returnStatus).send('Deleted');
+                await client.query("DELETE FROM Bindings WHERE Application = $1", [apid]);
+                await client.query("DELETE FROM InstanceBlocks WHERE Application = $1", [apid]);
+                const deleteResult = await client.query("DELETE FROM Applications WHERE Id = $1", [apid]);
+                return deleteResult;
             }
+        })
+
+        if (result.error) {
+            returnStatus = result.status;
+            res.status(returnStatus).send(result.message);
+        } else if (result.rowCount != 1) {
+            returnStatus = 404;
+            res.status(returnStatus).send('Not Found');
+        } else {
+            delete cachedApplications[apid];
+            res.status(returnStatus).send('Deleted');
         }
     } catch (error) {
         Log(`Exception in deleteApplication: ${error.stack}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1790,19 +1800,18 @@ const listApplicationBlocks = async function(apid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query(
-            "SELECT InstanceBlocks.Id, InstanceName, LibraryBlock, " +
-            "LibraryBlocks.Name as libname, LibraryBlocks.Revision FROM InstanceBlocks " +
-            "JOIN LibraryBlocks ON LibraryBlocks.Id = LibraryBlock " +
-            "WHERE Application = $1",
-            [apid]
-        );
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                "SELECT InstanceBlocks.Id, InstanceName, LibraryBlock, " +
+                "LibraryBlocks.Name as libname, LibraryBlocks.Revision FROM InstanceBlocks " +
+                "JOIN LibraryBlocks ON LibraryBlocks.Id = LibraryBlock " +
+                "WHERE Application = $1",
+                [apid]
+            );
+        })
         res.status(returnStatus).json(result.rows);
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in listApplicationBlocks: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1819,31 +1828,34 @@ const postDeployment = async function(req, res) {
     const client = await ClientFromPool();
     const form = new IncomingForm();
     try {
-        await client.query("BEGIN");
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
             'app' : {type: 'uuid', optional: false},
             'van' : {type: 'uuid', optional: false},
+            'ownerGroup': { type: 'string', optional: true, default: ''}
         });
 
-        const checkResult = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [norm.app]);
-        if (checkResult.rowCount == 0) {
-            throw new Error(`Application not found; ${norm.app}`);
-        } else if (checkResult.rows[0].lifecycle == 'deployed') {
-            throw new Error(`Attempting to deploy an application that is already deployed: ${norm.app}`);
-        }
-        const result = await client.query("INSERT INTO DeployedApplications (Application, Van) VALUES ($1, $2) RETURNING Id",
-                                          [norm.app, norm.van]);
-        await client.query("COMMIT");
+        const result = await queryWithContext(req, client, async (client, credentials) => {
+            const checkResult = await client.query("SELECT Lifecycle FROM Applications WHERE Id = $1", [norm.app]);
+            if (checkResult.rowCount == 0) {
+                throw new Error(`Application not found; ${norm.app}`);
+            } else if (checkResult.rows[0].lifecycle == 'deployed') {
+                throw new Error(`Attempting to deploy an application that is already deployed: ${norm.app}`);
+            }
+            const ownerId = credentials.userId
+            return await client.query("INSERT INTO DeployedApplications (Application, Van, Owner, OwnerGroup) VALUES ($1, $2, $3, $4) RETURNING Id",
+                                              [norm.app, norm.van, ownerId, norm.ownerGroup]);
+        })
         if (result.rowCount == 1) {
-            await client.query("UPDATE Applications SET Lifecycle = 'deployed' WHERE Id = $1", [norm.app]);
+            await queryWithContext(req, client, async (client) => {
+                await client.query("UPDATE Applications SET Lifecycle = 'deployed' WHERE Id = $1", [norm.app]);
+            })
             res.status(returnStatus).json(result.rows[0]);
         } else {
             returnStatus = 400;
             res.status(returnStatus).send(result.error);
         }
     } catch (error) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(error.stack);
     } finally {
@@ -1858,44 +1870,44 @@ const deployDeployment = async function(depid, req, res) {
     const client = await ClientFromPool();
     let   deployLog = new ProcessLog(true, 'deploy');
     try {
-        await client.query("BEGIN");
-        const checkResult = await client.query("SELECT Id, Lifecycle, Application, Van FROM DeployedApplications WHERE Id = $1", [depid]);
-        if (checkResult.rowCount == 0) {
-            throw new Error(`Deployment not found; ${depid}`);
-        } else if (checkResult.rows[0].lifecycle == 'deployed') {
-            throw new Error(`Deployment is already deployed: ${depid}`);
-        }
-
-        const deployment = checkResult.rows[0];
-        await deployApplication(client, deployment.application, deployment.van, deployment.id, deployLog);
-
-        //
-        // Add final success log
-        //
-        var response;
-        if (deployLog.getResult() == 'deploy-warnings') {
-            deployLog.log("WARNING: Initial deployment completed with warnings");
-            response = 'Warnings - See deploy log for details';
-        } else {
-            deployLog.log("SUCCESS: Initial deployment completed successfully");
-            response = 'Success - See deploy log for details';
-        }
-
-        //
-        // Update the lifecycle of the deployment and add the build log.
-        //
-        await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), 'deployed']);
-        await client.query("COMMIT");
+        const response = await queryWithContext((req, client, async (client) => {
+            const checkResult = await client.query("SELECT Id, Lifecycle, Application, Van FROM DeployedApplications WHERE Id = $1", [depid]);
+            if (checkResult.rowCount == 0) {
+                throw new Error(`Deployment not found; ${depid}`);
+            } else if (checkResult.rows[0].lifecycle == 'deployed') {
+                throw new Error(`Deployment is already deployed: ${depid}`);
+            }
+    
+            const deployment = checkResult.rows[0];
+            await deployApplication(client, deployment.application, deployment.van, deployment.id, deployLog);
+    
+            //
+            // Add final success log
+            //
+            let response;
+            if (deployLog.getResult() == 'deploy-warnings') {
+                deployLog.log("WARNING: Initial deployment completed with warnings");
+                response = 'Warnings - See deploy log for details';
+            } else {
+                deployLog.log("SUCCESS: Initial deployment completed successfully");
+                response = 'Success - See deploy log for details';
+            }
+    
+            //
+            // Update the lifecycle of the deployment and add the build log.
+            //
+            await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), 'deployed']);
+            return response;
+        }))
         res.status(returnStatus).send(response);
     } catch (error) {
-        await client.query("ROLLBACK");
         if (error.message == PROCESS_ERROR) {
             //
             // If we got a process error, update the deploy log for user visibility after rolling back the current transaction.
             //
-            await client.query("BEGIN");
-            await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), deployLog.getResult()]);
-            await client.query("COMMIT");
+            await queryWithContext(req, client, async (client) => {
+                await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1", [depid, deployLog.getText(), deployLog.getResult()]);
+            })
             returnStatus = 200;
             res.status(returnStatus).send("Deploy Failed - See deployment log for details");
         } else {
@@ -1913,8 +1925,9 @@ const getDeploymentLog = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT DeployLog FROM DeployedApplications WHERE Id = $1", [depid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT DeployLog FROM DeployedApplications WHERE Id = $1", [depid]);
+        })
         if (result.rowCount == 1) {
             const reply = result.rows[0].deploylog || 'Deployment has not yet been deployed';
             res.status(returnStatus).send(reply);
@@ -1922,10 +1935,8 @@ const getDeploymentLog = async function(depid, req, res) {
             returnStatus = 404;
             res.status(returnStatus).send('Not Found');
         }
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getDeploymentLog: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -1938,14 +1949,15 @@ const listDeployments = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 "SELECT DeployedApplications.Id, DeployedApplications.Lifecycle, Application, Van, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
                 "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van"
             );
-            res.status(returnStatus).json(result.rows);
+            return result;
         })
+        res.status(returnStatus).json(result.rows);
     } catch (error) {
         Log(`Exception in listDeployments: ${error.message}`);
         returnStatus = 500;
@@ -1960,7 +1972,7 @@ const getDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 "SELECT DeployedApplications.*, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
@@ -1968,13 +1980,14 @@ const getDeployment = async function(depid, req, res) {
                 "WHERE DeployedApplications.Id = $1",
                 [depid]
             );
-            if (result.rowCount == 1) {
-                res.status(returnStatus).json(result.rows[0]);
-            } else {
-                returnStatus = 404;
-                res.status(returnStatus).send('Not Found');
-            }
+            return result;
         })
+        if (result.rowCount == 1) {
+            res.status(returnStatus).json(result.rows[0]);
+        } else {
+            returnStatus = 404;
+            res.status(returnStatus).send('Not Found');
+        }
     } catch (error) {
         Log(`Exception in getDeployment: ${error.message}`);
         returnStatus = 500;
@@ -1989,28 +2002,28 @@ const deleteDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        await client.query("DELETE FROM SiteData WHERE DeployedApplication = $1", [depid]);
-        const result = await client.query("DELETE FROM DeployedApplications WHERE Id = $1 RETURNING Application", [depid]);
-        let message = 'Not Found';
-        if (result.rowCount != 1) {
-            returnStatus = 404;
-        } else {
-            const appid = result.rows[0].application;
-            const listResult = await client.query("SELECT Id FROM DeployedApplications WHERE Application = $1", [appid]);
-            if (listResult.rowCount == 0) {
-                //
-                // If we just deleted the last deployment of the application, move its lifecycle back to 'build-complete'.
-                //
-                await client.query("UPDATE Applications SET LifeCycle = 'build-complete' WHERE Id = $1", [appid]);
-                message = 'Deleted';
+        const message = await queryWithContext(req, client, async (client) => {
+            await client.query("DELETE FROM SiteData WHERE DeployedApplication = $1", [depid]);
+            const result = await client.query("DELETE FROM DeployedApplications WHERE Id = $1 RETURNING Application", [depid]);
+            let message = 'Not Found';
+            if (result.rowCount != 1) {
+                returnStatus = 404;
+            } else {
+                const appid = result.rows[0].application;
+                const listResult = await client.query("SELECT Id FROM DeployedApplications WHERE Application = $1", [appid]);
+                if (listResult.rowCount == 0) {
+                    //
+                    // If we just deleted the last deployment of the application, move its lifecycle back to 'build-complete'.
+                    //
+                    await client.query("UPDATE Applications SET LifeCycle = 'build-complete' WHERE Id = $1", [appid]);
+                    message = 'Deleted';
+                }
             }
-        }
-        await client.query("COMMIT");
+            return message;
+        })
         res.status(returnStatus).send(message);
     } catch (error) {
         Log(`Exception in deleteApplication: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -2023,8 +2036,9 @@ const getSiteData = async function(depid, siteid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT Configuration FROM SiteData WHERE DeployedApplication = $1 AND MemberSite = $2", [depid, siteid]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT Configuration FROM SiteData WHERE DeployedApplication = $1 AND MemberSite = $2", [depid, siteid]);
+        })
         if (result.rowCount == 1) {
             res.setHeader('content-type', 'application/yaml');
             res.status(returnStatus).send(result.rows[0].configuration);
@@ -2032,10 +2046,8 @@ const getSiteData = async function(depid, siteid, req, res) {
             returnStatus = 404;
             res.status(returnStatus).send('Not Found');
         }
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getSiteData: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -2048,14 +2060,13 @@ const getTargetPlatforms = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT * FROM TargetPlatforms");
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT * FROM TargetPlatforms");
+        })
         res.setHeader('content-type', 'application/json');
         res.status(returnStatus).send(result.rows);
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getTargetPlatforms: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -2069,14 +2080,13 @@ const getInterfaceRoles = async function(req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query("SELECT * FROM InterfaceRoles");
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT * FROM InterfaceRoles");
+        })
         res.setHeader('content-type', 'application/json');
         res.status(returnStatus).send(result.rows);
-        await client.query("COMMIT");
     } catch (error) {
         Log(`Exception in getInterfaceRoles: ${error.message}`);
-        await client.query("ROLLBACK");
         returnStatus = 500;
         res.status(returnStatus).send(error.message);
     } finally {

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -22,7 +22,7 @@
 import { static as expressStatic, json } from 'express';
 import { load, dump, loadAll } from 'js-yaml';
 import { Log } from '@skupperx/modules/log'
-import { ClientFromPool, queryWithContext, SYSTEM_USER_ID } from './db.js';
+import { ClientFromPool, queryWithContext } from './db.js';
 import { IncomingForm } from 'formidable';
 import { ValidateAndNormalizeFields } from '@skupperx/modules/util'
 import { NewIdentity } from './ident.js';
@@ -1938,7 +1938,7 @@ const listDeployments = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 "SELECT DeployedApplications.Id, DeployedApplications.Lifecycle, Application, Van, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
@@ -1961,7 +1961,7 @@ const getDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 "SELECT DeployedApplications.*, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -2118,103 +2118,103 @@ const getInterfaceRoles = async function(req, res) {
 }
 
 export function ApiInit(app, keycloak) {
-    app.post(COMPOSE_PREFIX + 'library/blocks/import', keycloak.protect(), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'library/blocks/import', keycloak.protect('realm:can-import-library-blocks'), async (req, res) => {
         await postLibraryBlocks(req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'library/blocks', keycloak.protect(), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'library/blocks', keycloak.protect('realm:can-create-library-block'), async (req, res) => {
         await createLibraryBlock(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks', keycloak.protect('realm:can-list-library-blocks'), async (req, res) => {
         await listLibraryBlocks(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocktypes', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocktypes', keycloak.protect('realm:can-list-block-types'), async (req, res) => {
         await getBlockTypes(req, res);
     })
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect('realm:can-read-library-block'), async (req, res) => {
         await getLibraryBlock(req.params.blockid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect('realm:can-read-library-block-config'), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'Config', req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect('realm:can-read-library-block-interfaces'), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'Interfaces', req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect('realm:can-read-library-block-body'), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'SpecBody', req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect(), async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect('realm:can-delete-library-block'), async (req, res) => {
         await deleteLibraryBlock(req.params.blockid, req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'applications', keycloak.protect(), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'applications', keycloak.protect('realm:can-create-application'), async (req, res) => {
         await postApplication(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications', keycloak.protect('realm:can-list-applications'), async (req, res) => {
         await listApplications(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect('realm:can-read-application'), async (req, res) => {
         await getApplication(req.params.apid, req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'applications/:apid/build', keycloak.protect(), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'applications/:apid/build', keycloak.protect('realm:can-build-application'), async (req, res) => {
         await buildApplication(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/log', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/log', keycloak.protect('realm:can-read-application-build-log'), async (req, res) => {
         await getApplicationBuildLog(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/image', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/image', keycloak.protect('realm:can-read-application-image'), async (req, res) => {
         await getApplicationImage(req.params.apid, req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect(), async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect('realm:can-delete-application'), async (req, res) => {
         await deleteApplication(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks', keycloak.protect('realm:can-list-application-blocks'), async (req, res) => {
         await listApplicationBlocks(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks/:blockid', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks/:blockid', keycloak.protect('realm:can-read-application-block'), async (req, res) => {
         await getApplicationBlock(req.params.blockid, req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'deployments', keycloak.protect(), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'deployments', keycloak.protect('realm:can-create-deployment'), async (req, res) => {
         await postDeployment(req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'deployments/:depid/deploy', keycloak.protect(), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'deployments/:depid/deploy', keycloak.protect('realm:can-deploy-deployment'), async (req, res) => {
         await deployDeployment(req.params.depid, req, res)
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/log', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/log', keycloak.protect('realm:can-read-deployment-log'), async (req, res) => {
         await getDeploymentLog(req.params.depid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments', keycloak.protect('realm:can-list-deployments'), async (req, res) => {
         await listDeployments(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect('realm:can-read-deployment'), async (req, res) => {
         await getDeployment(req.params.depid, req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect(), async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect('realm:can-delete-deployment'), async (req, res) => {
         await deleteDeployment(req.params.depid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata', keycloak.protect('realm:can-read-site-data'), async (req, res) => {
         await getSiteData(req.params.depid, req.params.siteid, req, res);
     });
 
@@ -2223,32 +2223,32 @@ export function ApiInit(app, keycloak) {
     // the name of the file that is saved (rather than always downloading to 'sitedata').
     // We ignore the filename.  We are simply allowing it to be included on the API path.
     //
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata/:filename', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata/:filename', keycloak.protect('realm:can-read-site-data'), async (req, res) => {
         await getSiteData(req.params.depid, req.params.siteid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'targetplatforms', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'targetplatforms', keycloak.protect('realm:can-list-target-platforms'), async (req, res) => {
         await getTargetPlatforms(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'interfaceroles', keycloak.protect(), async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'interfaceroles', keycloak.protect('realm:can-list-interface-roles'), async (req, res) => {
         await getInterfaceRoles(req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'template', keycloak.protect(), async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'template', keycloak.protect('realm:can-expand-template'), async (req, res) => {
         await ExpandTemplate(req, res);
     })
 
     app.use(json());
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect(), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect('realm:can-update-library-block-config'), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'Config', req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect(), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect('realm:can-update-library-block-interfaces'), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'Interfaces', req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect(), async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect('realm:can-update-library-block-body'), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'SpecBody', req, res);
     });
 

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -1468,7 +1468,6 @@ const buildApplication = async function(apid, req, res) {
     let   buildLog = new ProcessLog(true, 'build');
     try {
         const response = await queryWithContext(req, client, async (client, userInfo) => {
-
             const result = await client.query("SELECT LibraryBlocks.Name as lbname, LibraryBlocks.Revision, Applications.Name as appname, Lifecycle FROM Applications " +
                                               "JOIN LibraryBlocks ON LibraryBlocks.Id = RootBlock " +
                                               "WHERE Applications.Id = $1 and (Applications.Owner = $2 or Applications.OwnerGroup = Any($3) or is_admin())", [apid, userInfo.userId, userInfo.userGroups]);
@@ -1540,7 +1539,7 @@ const buildApplication = async function(apid, req, res) {
                 //
                 // Add final success log
                 //
-                var response;
+                let response;
                 if (buildLog.getResult() == 'build-warnings') {
                     buildLog.log("WARNING: Build completed with warnings");
                     response = 'Warnings - See build log for details';
@@ -1993,14 +1992,14 @@ const getDeployment = async function(depid, req, res) {
     const client = await ClientFromPool();
     try {
         const result = await queryWithContext(req, client, async (client, userInfo) => {
-            const result = await client.query(
+            const deploymentResult = await client.query(
                 "SELECT DeployedApplications.*, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
                 "JOIN Applications ON Applications.Id = Application " +
                 "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van " +
                 "WHERE DeployedApplications.Id = $1 and (DeployedApplications.Owner = $2 or DeployedApplications.OwnerGroup = Any($3) or is_admin())",
                 [depid, userInfo.userId, userInfo.userGroups]
             );
-            return result;
+            return deploymentResult;
         })
         if (result.rowCount == 1) {
             res.status(returnStatus).json(result.rows[0]);

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -2118,103 +2118,103 @@ const getInterfaceRoles = async function(req, res) {
 }
 
 export function ApiInit(app, keycloak) {
-    app.post(COMPOSE_PREFIX + 'library/blocks/import', async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'library/blocks/import', keycloak.protect(), async (req, res) => {
         await postLibraryBlocks(req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'library/blocks', async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'library/blocks', keycloak.protect(), async (req, res) => {
         await createLibraryBlock(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks', keycloak.protect(), async (req, res) => {
         await listLibraryBlocks(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocktypes', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocktypes', keycloak.protect(), async (req, res) => {
         await getBlockTypes(req, res);
     })
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect(), async (req, res) => {
         await getLibraryBlock(req.params.blockid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/config', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect(), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'Config', req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect(), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'Interfaces', req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/body', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect(), async (req, res) => {
         await getLibraryBlockSection(req.params.blockid, 'SpecBody', req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'library/blocks/:blockid', async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'library/blocks/:blockid', keycloak.protect(), async (req, res) => {
         await deleteLibraryBlock(req.params.blockid, req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'applications', async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'applications', keycloak.protect(), async (req, res) => {
         await postApplication(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications', keycloak.protect(), async (req, res) => {
         await listApplications(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect(), async (req, res) => {
         await getApplication(req.params.apid, req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'applications/:apid/build', async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'applications/:apid/build', keycloak.protect(), async (req, res) => {
         await buildApplication(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/log', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/log', keycloak.protect(), async (req, res) => {
         await getApplicationBuildLog(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/image', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/image', keycloak.protect(), async (req, res) => {
         await getApplicationImage(req.params.apid, req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'applications/:apid', async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'applications/:apid', keycloak.protect(), async (req, res) => {
         await deleteApplication(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks', keycloak.protect(), async (req, res) => {
         await listApplicationBlocks(req.params.apid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks/:blockid', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'applications/:apid/blocks/:blockid', keycloak.protect(), async (req, res) => {
         await getApplicationBlock(req.params.blockid, req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'deployments', async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'deployments', keycloak.protect(), async (req, res) => {
         await postDeployment(req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'deployments/:depid/deploy', async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'deployments/:depid/deploy', keycloak.protect(), async (req, res) => {
         await deployDeployment(req.params.depid, req, res)
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/log', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/log', keycloak.protect(), async (req, res) => {
         await getDeploymentLog(req.params.depid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments', keycloak.protect(), async (req, res) => {
         await listDeployments(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect(), async (req, res) => {
         await getDeployment(req.params.depid, req, res);
     });
 
-    app.delete(COMPOSE_PREFIX + 'deployments/:depid', async (req, res) => {
+    app.delete(COMPOSE_PREFIX + 'deployments/:depid', keycloak.protect(), async (req, res) => {
         await deleteDeployment(req.params.depid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata', keycloak.protect(), async (req, res) => {
         await getSiteData(req.params.depid, req.params.siteid, req, res);
     });
 
@@ -2223,32 +2223,32 @@ export function ApiInit(app, keycloak) {
     // the name of the file that is saved (rather than always downloading to 'sitedata').
     // We ignore the filename.  We are simply allowing it to be included on the API path.
     //
-    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata/:filename', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'deployments/:depid/site/:siteid/sitedata/:filename', keycloak.protect(), async (req, res) => {
         await getSiteData(req.params.depid, req.params.siteid, req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'targetplatforms', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'targetplatforms', keycloak.protect(), async (req, res) => {
         await getTargetPlatforms(req, res);
     });
 
-    app.get(COMPOSE_PREFIX + 'interfaceroles', async (req, res) => {
+    app.get(COMPOSE_PREFIX + 'interfaceroles', keycloak.protect(), async (req, res) => {
         await getInterfaceRoles(req, res);
     });
 
-    app.post(COMPOSE_PREFIX + 'template', async (req, res) => {
+    app.post(COMPOSE_PREFIX + 'template', keycloak.protect(), async (req, res) => {
         await ExpandTemplate(req, res);
     })
 
     app.use(json());
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/config', async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/config', keycloak.protect(), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'Config', req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/interfaces', keycloak.protect(), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'Interfaces', req, res);
     });
 
-    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/body', async (req, res) => {
+    app.put(COMPOSE_PREFIX + 'library/blocks/:blockid/body', keycloak.protect(), async (req, res) => {
         await putLibraryBlockSection(req.params.blockid, 'SpecBody', req, res);
     });
 

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -22,7 +22,7 @@
 import { static as expressStatic, json } from 'express';
 import { load, dump, loadAll } from 'js-yaml';
 import { Log } from '@skupperx/modules/log'
-import { ClientFromPool } from './db.js';
+import { ClientFromPool, queryWithContext, SYSTEM_USER_ID } from './db.js';
 import { IncomingForm } from 'formidable';
 import { ValidateAndNormalizeFields } from '@skupperx/modules/util'
 import { NewIdentity } from './ident.js';
@@ -1935,17 +1935,17 @@ const getDeploymentLog = async function(depid, req, res) {
 }
 
 const listDeployments = async function(req, res) {
-    var   returnStatus = 200;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query(
-            "SELECT DeployedApplications.Id, DeployedApplications.Lifecycle, Application, Van, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
-            "JOIN Applications ON Applications.Id = Application " +
-            "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van"
-        );
-        res.status(returnStatus).json(result.rows);
-        await client.query("COMMIT");
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
+                "SELECT DeployedApplications.Id, DeployedApplications.Lifecycle, Application, Van, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
+                "JOIN Applications ON Applications.Id = Application " +
+                "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van"
+            );
+            res.status(returnStatus).json(result.rows);
+        })
     } catch (error) {
         Log(`Exception in listDeployments: ${error.message}`);
         await client.query("ROLLBACK");
@@ -1961,21 +1961,21 @@ const getDeployment = async function(depid, req, res) {
     var   returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query("BEGIN");
-        const result = await client.query(
-            "SELECT DeployedApplications.*, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
-            "JOIN Applications ON Applications.Id = Application " +
-            "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van " +
-            "WHERE DeployedApplications.Id = $1",
-            [depid]
-        );
-        if (result.rowCount == 1) {
-            res.status(returnStatus).json(result.rows[0]);
-        } else {
-            returnStatus = 404;
-            res.status(returnStatus).send('Not Found');
-        }
-        await client.query("COMMIT");
+        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+            const result = await client.query(
+                "SELECT DeployedApplications.*, Applications.Name as appname, ApplicationNetworks.Name as vanname FROM DeployedApplications " +
+                "JOIN Applications ON Applications.Id = Application " +
+                "JOIN ApplicationNetworks ON ApplicationNetworks.Id = Van " +
+                "WHERE DeployedApplications.Id = $1",
+                [depid]
+            );
+            if (result.rowCount == 1) {
+                res.status(returnStatus).json(result.rows[0]);
+            } else {
+                returnStatus = 404;
+                res.status(returnStatus).send('Not Found');
+            }
+        })
     } catch (error) {
         Log(`Exception in getDeployment: ${error.message}`);
         await client.query("ROLLBACK");
@@ -2088,7 +2088,7 @@ const getInterfaceRoles = async function(req, res) {
 
 }
 
-export function ApiInit(app) {
+export function ApiInit(app, keycloak) {
     app.post(COMPOSE_PREFIX + 'library/blocks/import', async (req, res) => {
         await postLibraryBlocks(req, res);
     });

--- a/components/management-controller/src/compose.js
+++ b/components/management-controller/src/compose.js
@@ -1394,7 +1394,7 @@ const putLibraryBlockSection = async function(blockid, section, req, res) {
     const client = await ClientFromPool();
     try {
         await queryWithContext(req, client, async (client, userInfo) => {
-            await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())`, [blockid, data, userInfo.userId, userInfo.userGroups]);
+            await client.query(`UPDATE LibraryBlocks SET ${section} = $2 WHERE Id = $1 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())`, [blockid, data, userInfo.userId, userInfo.userGroups]);
         })
         res.status(returnStatus).send('Updated');
     } catch (error) {
@@ -1662,7 +1662,7 @@ const getApplicationImage = async function(apid, req, res) {
             // Get the application and ensure that it is in build-complete state.
             //
             const appResult = await client.query(
-                "SELECT Lifecycle FROM Applications WHERE Id = $1 (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]
+                "SELECT Lifecycle FROM Applications WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [apid, userId, userGroups]
             );
     
             if (appResult.rowCount == 0) {
@@ -1923,7 +1923,7 @@ const deployDeployment = async function(depid, req, res) {
             // If we got a process error, update the deploy log for user visibility after rolling back the current transaction.
             //
             await queryWithContext(req, client, async (client, userInfo) => {
-                await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1, and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [depid, deployLog.getText(), deployLog.getResult(), userInfo.userId, userInfo.userGroups]);
+                await client.query("UPDATE DeployedApplications SET Lifecycle = $3, DeployLog = $2 WHERE Id = $1 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [depid, deployLog.getText(), deployLog.getResult(), userInfo.userId, userInfo.userGroups]);
             })
             returnStatus = 200;
             res.status(returnStatus).send("Deploy Failed - See deployment log for details");

--- a/components/management-controller/src/db.js
+++ b/components/management-controller/src/db.js
@@ -107,15 +107,15 @@ export async function queryWithContext(req, client, callback) {
         
         if ((context === 'user' || context === 'admin') && userId) {
             // Get or create internal user ID for regular users
-            const userIdentityResult = await client.query(
-                `INSERT INTO UserIdentities (KeycloakSub, IsAdmin, LastSeen) 
+            const userResult = await client.query(
+                `INSERT INTO Users (KeycloakSub, IsAdmin, LastSeen) 
                 VALUES ($1, $2, CURRENT_TIMESTAMP)
                 ON CONFLICT (KeycloakSub) 
                 DO UPDATE SET LastSeen = CURRENT_TIMESTAMP, IsAdmin = $2
                 RETURNING Id`,
                 [userId, isAdmin]
             );
-            internalUserId = userIdentityResult.rows[0].id;
+            internalUserId = userResult.rows[0].id;
             
             // Set RLS session variables for users
             await client.query('SELECT set_config(\'session.user_id\', $1, true)', [internalUserId])

--- a/components/management-controller/src/db.js
+++ b/components/management-controller/src/db.js
@@ -124,8 +124,8 @@ export async function queryWithContext(req, client, callback) {
         } 
         
         const result = await callback(client, { 
-            userId: internalUserId, 
-            isAdmin: isAdmin
+            userId: internalUserId,
+            userGroups: userGroups
         })
         await client.query("COMMIT")
         return result

--- a/components/management-controller/src/db.js
+++ b/components/management-controller/src/db.js
@@ -81,68 +81,56 @@ export function IntervalMilliseconds (value) {
 }
 
 export function extractUserInfo(req) {
-    // Handle system context case (for background processes)
-    if (req && typeof req === 'object' && req.system === true) {
-        return {
-            context: 'system',
-            userId: null,
-            userGroups: [],
-            isAdmin: false
-        }
-    }
-    
     const userCredentials = req?.kauth?.grant?.access_token?.content
     if (userCredentials) {
-        const admin = isAdmin(userCredentials.clientGroups)
+        const admin = isAdmin(userCredentials.realm_access?.roles)
         return {
             context: admin ? 'admin' : 'user',
             userId: userCredentials.sub,
-            userGroups: userCredentials.clientGroups,
+            userGroups: userCredentials.clientGroups || [],
             isAdmin: admin
         }
     }
     return { context: 'user', userId: null, userGroups: [], isAdmin: false }
 }
 
-export function isAdmin(userGroups) {
-    return userGroups?.includes('admin') || false
+export function isAdmin(userRoles) {
+    return userRoles?.includes('admin') || false
 }
 
 export async function queryWithContext(req, client, callback) {
     const { context, userId, userGroups, isAdmin } = extractUserInfo(req)
-  try {
-    await client.query("BEGIN")
+    try {
+        await client.query("BEGIN")
 
-    // For system and admin contexts, RLS is bypassed by the database role
-    // We still set session variables for logging/auditing purposes, but they're not needed for RLS
-    let internalUserId = null
-    
-    if ((context === 'user' || context === 'admin') && userId) {
-        // Get or create internal user ID for regular users
-        const userIdentityResult = await client.query(
-            `INSERT INTO UserIdentities (KeycloakSub, IsAdmin, LastSeen) 
-            VALUES ($1, $2, CURRENT_TIMESTAMP)
-            ON CONFLICT (KeycloakSub) 
-            DO UPDATE SET LastSeen = CURRENT_TIMESTAMP, IsAdmin = $2
-            RETURNING Id`,
-            [userId, isAdmin]
-        );
-        internalUserId = userIdentityResult.rows[0].id;
+        let internalUserId = null
         
-        // Set RLS session variables for users
-        await client.query('SELECT set_config(\'session.user_id\', $1, true)', [internalUserId])
-        await client.query('SELECT set_config(\'session.user_groups\', $1, true)', [userGroups])
-        await client.query('SELECT set_config(\'session.is_admin\', $1, true)', [String(isAdmin)])
-    } 
-    
-    const result = await callback(client, { 
-        userId: internalUserId, 
-        isAdmin: isAdmin
-    })
-    await client.query("COMMIT")
-    return result
-  } catch (error) {
-    await client.query("ROLLBACK")
-    throw error
-  }
+        if ((context === 'user' || context === 'admin') && userId) {
+            // Get or create internal user ID for regular users
+            const userIdentityResult = await client.query(
+                `INSERT INTO UserIdentities (KeycloakSub, IsAdmin, LastSeen) 
+                VALUES ($1, $2, CURRENT_TIMESTAMP)
+                ON CONFLICT (KeycloakSub) 
+                DO UPDATE SET LastSeen = CURRENT_TIMESTAMP, IsAdmin = $2
+                RETURNING Id`,
+                [userId, isAdmin]
+            );
+            internalUserId = userIdentityResult.rows[0].id;
+            
+            // Set RLS session variables for users
+            await client.query('SELECT set_config(\'session.user_id\', $1, true)', [internalUserId])
+            await client.query('SELECT set_config(\'session.user_groups\', $1, true)', [userGroups])
+            await client.query('SELECT set_config(\'session.is_admin\', $1, true)', [String(isAdmin)])
+        } 
+        
+        const result = await callback(client, { 
+            userId: internalUserId, 
+            isAdmin: isAdmin
+        })
+        await client.query("COMMIT")
+        return result
+    } catch (error) {
+        await client.query("ROLLBACK")
+        throw error
+    }
 }

--- a/components/management-controller/src/db.js
+++ b/components/management-controller/src/db.js
@@ -80,6 +80,7 @@ export function IntervalMilliseconds (value) {
     }
 }
 
+// pull user info out of keycloak token
 export function extractUserInfo(req) {
     const userCredentials = req?.kauth?.grant?.access_token?.content
     if (userCredentials) {

--- a/components/management-controller/src/db.js
+++ b/components/management-controller/src/db.js
@@ -22,19 +22,28 @@
 import { Log } from '@skupperx/modules/log'
 import { Pool } from 'pg';
 
-var connectionPool;
+let userPool;
+let systemPool;
 
 export async function Start() {
     Log('[Database module starting]');
-    connectionPool = new Pool();
+    // Create separate connection pools for different roles
+    userPool = new Pool({ user: 'app_user', password: process.env.APP_USER_PASSWORD });
+    systemPool = new Pool({ user: 'app_system', password: process.env.APP_SYSTEM_PASSWORD });
 }
 
-export function ClientFromPool() {
-    return connectionPool.connect();
+// Get client from appropriate pool based on context string
+export function ClientFromPool(context = 'user') {
+    if (context === 'system') {
+        return systemPool.connect();
+    }
+    // Default to user pool (includes admin users - they use user pool but admin role bypasses RLS)
+    return userPool.connect();
 }
 
 export function QueryConfig () {
-    return connectionPool.query('SELECT * FROM configuration WHERE id = 0')
+    // QueryConfig uses system pool as it's a system-level operation
+    return systemPool.query('SELECT * FROM configuration WHERE id = 0')
     .then(result => result.rows[0]);
 }
 
@@ -72,72 +81,64 @@ export function IntervalMilliseconds (value) {
 }
 
 export function extractUserInfo(req) {
-  // Handle system user case
-  if (req && typeof req === 'object' && req.userId && !req.kauth) {
-    return {
-      userId: req.userId,
-      userGroups: req.userGroups || [],
-      isAdmin: false
+    // Handle system context case (for background processes)
+    if (req && typeof req === 'object' && req.system === true) {
+        return {
+            context: 'system',
+            userId: null,
+            userGroups: [],
+            isAdmin: false
+        }
     }
-  }
-  
-  const userCredentials = req?.kauth?.grant?.access_token?.content
-  if (userCredentials) {
-    return {
-      userId: userCredentials.sub,
-      userGroups: userCredentials.clientGroups || [],
-      isAdmin: isAdmin(userCredentials.clientGroups)
+    
+    const userCredentials = req?.kauth?.grant?.access_token?.content
+    if (userCredentials) {
+        const admin = isAdmin(userCredentials.clientGroups)
+        return {
+            context: admin ? 'admin' : 'user',
+            userId: userCredentials.sub,
+            userGroups: userCredentials.clientGroups,
+            isAdmin: admin
+        }
     }
-  }
-  return { userId: null, userGroups: [], isAdmin: false }
+    return { context: 'user', userId: null, userGroups: [], isAdmin: false }
 }
 
 export function isAdmin(userGroups) {
-  return userGroups?.includes('admin') || false
-}
-
-export function convertArrayLiteral(arr) {
-  if (!arr || !Array.isArray(arr)) {
-    return '{}'
-  }
-  // Escape single quotes and wrap each element in quotes if needed
-  const escaped = arr.map(item => {
-    const str = String(item)
-    // Escape single quotes by doubling them
-    const escapedStr = str.replaceAll('\'', "''")
-    // Wrap in double quotes
-    return `"${escapedStr}"`
-  })
-  return `{${escaped.join(',')}}`
+    return userGroups?.includes('admin') || false
 }
 
 export async function queryWithContext(req, client, callback) {
-  let { userId, userGroups, isAdmin } = extractUserInfo(req)
-  userGroups = convertArrayLiteral(userGroups)
+    const { context, userId, userGroups, isAdmin } = extractUserInfo(req)
   try {
     await client.query("BEGIN")
 
-    let internalUserId
-    if (userId == SYSTEM_USER_ID) {
-      internalUserId = "00000000-0000-0000-0000-000000000001"
-    } else {
-      // Get or create internal user ID
-      const userIdentityResult = await client.query(
-        `INSERT INTO UserIdentities (KeycloakSub, IsAdmin, LastSeen) 
-         VALUES ($1, $2, CURRENT_TIMESTAMP)
-         ON CONFLICT (KeycloakSub) 
-         DO UPDATE SET LastSeen = CURRENT_TIMESTAMP
-         RETURNING Id`,
-         [userId, isAdmin]
-      );
-      internalUserId = userIdentityResult.rows[0].id;
-    }
-
-
-    await client.query('SELECT set_config(\'app.user_id\', $1, true)', [internalUserId])
-    await client.query('SELECT set_config(\'app.user_groups\', $1, true)', [userGroups])
-    await client.query('SELECT set_config(\'app.is_admin\', $1, true)', [isAdmin])
-    const result = await callback(client, { userId: internalUserId, userGroups: userGroups, isAdmin: isAdmin })
+    // For system and admin contexts, RLS is bypassed by the database role
+    // We still set session variables for logging/auditing purposes, but they're not needed for RLS
+    let internalUserId = null
+    
+    if ((context === 'user' || context === 'admin') && userId) {
+        // Get or create internal user ID for regular users
+        const userIdentityResult = await client.query(
+            `INSERT INTO UserIdentities (KeycloakSub, IsAdmin, LastSeen) 
+            VALUES ($1, $2, CURRENT_TIMESTAMP)
+            ON CONFLICT (KeycloakSub) 
+            DO UPDATE SET LastSeen = CURRENT_TIMESTAMP, IsAdmin = $2
+            RETURNING Id`,
+            [userId, isAdmin]
+        );
+        internalUserId = userIdentityResult.rows[0].id;
+        
+        // Set RLS session variables for users
+        await client.query('SELECT set_config(\'session.user_id\', $1, true)', [internalUserId])
+        await client.query('SELECT set_config(\'session.user_groups\', $1, true)', [userGroups])
+        await client.query('SELECT set_config(\'session.is_admin\', $1, true)', [String(isAdmin)])
+    } 
+    
+    const result = await callback(client, { 
+        userId: internalUserId, 
+        isAdmin: isAdmin
+    })
     await client.query("COMMIT")
     return result
   } catch (error) {
@@ -145,6 +146,3 @@ export async function queryWithContext(req, client, callback) {
     throw error
   }
 }
-
-export const SYSTEM_USER_ID = "system:management-controller";
-

--- a/components/management-controller/src/external-vans.js
+++ b/components/management-controller/src/external-vans.js
@@ -29,7 +29,7 @@
 import { Log } from '@skupperx/modules/log'
 import { ListAddresses, Start as RouterStart, NotifyApiReady } from '@skupperx/modules/router'
 import { RegisterHandler } from "./backbone-links.js";
-import { ClientFromPool } from './db.js';
+import { ClientFromPool, queryWithContext } from './db.js';
 
 const getNetworkIds = async function() {
     const addresses   = await ListAddresses(['key']);
@@ -46,9 +46,9 @@ const getNetworkIds = async function() {
 
 const reconcileConnectedNetworks = async function() {
     let reschedule_delay = 5000;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             let pending_change = {};
             const network_ids = await getNetworkIds();
             const db_result = await client.query(

--- a/components/management-controller/src/external-vans.js
+++ b/components/management-controller/src/external-vans.js
@@ -29,7 +29,7 @@
 import { Log } from '@skupperx/modules/log'
 import { ListAddresses, Start as RouterStart, NotifyApiReady } from '@skupperx/modules/router'
 import { RegisterHandler } from "./backbone-links.js";
-import { ClientFromPool, queryWithContext } from './db.js';
+import { ClientFromPool } from './db.js';
 
 const getNetworkIds = async function() {
     const addresses   = await ListAddresses(['key']);
@@ -48,33 +48,35 @@ const reconcileConnectedNetworks = async function() {
     let reschedule_delay = 5000;
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            let pending_change = {};
-            const network_ids = await getNetworkIds();
-            const db_result = await client.query(
-                "SELECT id, name, vanid, connected FROM ApplicationNetworks"
-            );
-            for (const net of db_result.rows) {
-                if (network_ids.indexOf(net.vanid) >= 0) {
-                    // The network is attached
-                    if (!net.connected) {
-                        pending_change[net.id] = true;
-                        Log(`External VAN '${net.name}' is now connected`);
-                    }
-                } else {
-                    // The network is not attached
-                    if (net.connected) {
-                        pending_change[net.id] = false;
-                        Log(`External VAN '${net.name}' connection lost`);
-                    }
+        await client.query("BEGIN");
+        let   pending_change = {};
+        const network_ids = await getNetworkIds();
+        const db_result = await client.query(
+            "SELECT id, name, vanid, connected FROM ApplicationNetworks"
+        );
+        for (const net of db_result.rows) {
+            if (network_ids.indexOf(net.vanid) >= 0) {
+                // The network is attached
+                if (!net.connected) {
+                    pending_change[net.id] = true;
+                    Log(`External VAN '${net.name}' is now connected`);
+                }
+            } else {
+                // The network is not attached
+                if (net.connected) {
+                    pending_change[net.id] = false;
+                    Log(`External VAN '${net.name}' connection lost`);
                 }
             }
+        }
 
-            for (const [vid, connected] of Object.entries(pending_change)) {
-                await client.query("UPDATE ApplicationNetworks SET Connected = $2 WHERE Id = $1", [vid, connected]);
-            }
-        })
+        for (const [vid, connected] of Object.entries(pending_change)) {
+            await client.query("UPDATE ApplicationNetworks SET Connected = $2 WHERE Id = $1", [vid, connected]);
+        }
+
+        await client.query("COMMIT");
     } catch (err) {
+        await client.query("ROLLBACK");
         reschedule_delay = 10000;
     } finally {
         client.release();

--- a/components/management-controller/src/external-vans.js
+++ b/components/management-controller/src/external-vans.js
@@ -75,7 +75,6 @@ const reconcileConnectedNetworks = async function() {
             }
         })
     } catch (err) {
-        await client.query("ROLLBACK");
         reschedule_delay = 10000;
     } finally {
         client.release();

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -573,11 +573,11 @@ export async function Start(is_standalone) {
 
     app.use(morgan(':ts :remote-addr :remote-user :method :url :status :res[content-length] :response-time ms'));
 
-    app.get(API_PREFIX + 'invitations/:iid/kube', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'invitations/:iid/kube', keycloak.protect('realm:can-read-invitation'), async (req, res) => {
         await fetchInvitationKube(req, res);
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/:target', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/:target', keycloak.protect('realm:can-read-backbone-site'), async (req, res) => {
         switch (req.params.target) {
             case 'sk2'  : await fetchBackboneSiteSkupper2(req, res);   break;
             case 'm-server':
@@ -587,7 +587,7 @@ export async function Start(is_standalone) {
         }
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/accesspoints/:target', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/accesspoints/:target', keycloak.protect('realm:can-list-backbone-access-points'), async (req, res) => {
         switch (req.params.target) {
             case 'sk2'  :
             case 'kube' :
@@ -599,35 +599,35 @@ export async function Start(is_standalone) {
         }
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/links/outgoing/kube', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/links/outgoing/kube', keycloak.protect('realm:can-list-backbone-links-outgoing'), async (req, res) => {
         await fetchBackboneLinksOutgoingKube(req, res);
     });
 
-    app.post(API_PREFIX + 'backbonesite/:bsid/ingress', keycloak.protect(), async (req, res) => {
+    app.post(API_PREFIX + 'backbonesite/:bsid/ingress', keycloak.protect('realm:can-create-backbone-ingress'), async (req, res) => {
         await postBackboneIngress(req.params.bsid, req, res);
     });
 
-    app.get(API_PREFIX + 'targetplatforms', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'targetplatforms', keycloak.protect('realm:can-list-target-platforms'), async (req, res) => {
         await getTargetPlatforms(req, res);
     });
 
-    app.get(API_PREFIX + 'vans/:vid/config/connecting/:apid', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'vans/:vid/config/connecting/:apid', keycloak.protect('realm:can-read-van-config-connecting'), async (req, res) => {
         await getVanConfigConnecting(req, res);
     });
 
-    app.get(API_PREFIX + 'vans/:vid/config/nonconnecting', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'vans/:vid/config/nonconnecting', keycloak.protect('realm:can-read-van-config-nonconnecting'), async (req, res) => {
         await getVanConfigNonConnecting(req, res);
     });
 
-    app.get(API_PREFIX + 'certs', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'certs', keycloak.protect('realm:can-list-certificates'), async (req, res) => {
         await getCertsSignedBy(req, res);
     });
 
-    app.get(API_PREFIX + 'certs/:cid', keycloak.protect(), async (req, res) => {
+    app.get(API_PREFIX + 'certs/:cid', keycloak.protect('realm:can-read-certificate'), async (req, res) => {
         await getCertDetail(req, res);
     });
 
-    app.get(API_PREFIX + 'user/groups', keycloak.protect(),async (req, res) => {
+    app.get(API_PREFIX + 'user/groups', keycloak.protect(), async (req, res) => {
         await getUserGroups(req, res);
     })
 

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -30,7 +30,7 @@ import formidable from 'formidable';
 import yaml       from 'js-yaml';
 import bodyParser from 'body-parser';
 import { X509Certificate } from 'node:crypto';
-import { ClientFromPool } from './db.js';
+import { ClientFromPool, queryWithContext } from './db.js';
 import * as siteTemplates from './site-templates.js';
 import * as crdTemplates  from './crd-templates.js';
 import { LoadSecret } from '@skupperx/modules/kube'
@@ -57,7 +57,7 @@ app.use(
      store: memoryStore,
    })
  );
-const keycloak = new kcConnect({store: memoryStore});
+const keycloak = new kcConnect({ store: memoryStore });
 
 const link_config_map_yaml = function(name, data) {
     let configMap = {
@@ -99,39 +99,42 @@ const claim_config_map_yaml = function(claimId, hostname, port, interactive, nam
     return "---\n" + yaml.dump(configMap);
 }
 
-const fetchInvitationKube = async function (iid, res) {
-    var returnStatus = 200;
+const fetchInvitationKube = async function (req, res) {
+    const iid = req.params.iid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT MemberInvitations.*, TlsCertificates.ObjectName as secret_name, ApplicationNetworks.VanId, " +
-                                          "BackboneAccessPoints.Id as accessid, BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM MemberInvitations " +
-                                          "JOIN TlsCertificates ON MemberInvitations.Certificate = TlsCertificates.Id " +
-                                          "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id " +
-                                          "JOIN BackboneAccessPoints ON MemberInvitations.ClaimAccess = BackboneAccessPoints.Id " +
-                                          "WHERE MemberInvitations.Id = $1 AND BackboneAccessPoints.Lifecycle = 'ready' AND MemberInvitations.Lifecycle = 'ready'", [iid]);
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            const secret = await LoadSecret(row.secret_name);
-            let text = '';
-
-            text += siteTemplates.ServiceAccountYaml();
-            text += siteTemplates.MemberRoleYaml();
-            text += siteTemplates.RoleBindingYaml();
-            text += siteTemplates.ConfigMapYaml('edge', null, row.vanid, row.vanid);
-            text += siteTemplates.DeploymentYaml(iid, false, 'kube');
-            text += siteTemplates.SiteApiServiceYaml();
-            text += siteTemplates.SecretYaml(secret, 'skupperx-claim', false);
-            text += claim_config_map_yaml(row.id, row.hostname, row.port, row.interactiveclaim, row.membernameprefix);
-
-            res.status(returnStatus).send(text);
-
-            //
-            // Bump the fetch-count for the invitation.
-            //
-            await client.query("UPDATE MemberInvitations SET FetchCount = FetchCount + 1 WHERE Id = $1", [row.id]);
-        } else {
-            throw(Error('Valid invitation not found'));
-        }
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query("SELECT MemberInvitations.*, TlsCertificates.ObjectName as secret_name, ApplicationNetworks.VanId, " +
+                                              "BackboneAccessPoints.Id as accessid, BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM MemberInvitations " +
+                                              "JOIN TlsCertificates ON MemberInvitations.Certificate = TlsCertificates.Id " +
+                                              "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id " +
+                                              "JOIN BackboneAccessPoints ON MemberInvitations.ClaimAccess = BackboneAccessPoints.Id " +
+                                              "WHERE MemberInvitations.Id = $1 AND BackboneAccessPoints.Lifecycle = 'ready' AND MemberInvitations.Lifecycle = 'ready'", [iid]);
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                const secret = await LoadSecret(row.secret_name);
+                let text = '';
+    
+                text += siteTemplates.ServiceAccountYaml();
+                text += siteTemplates.MemberRoleYaml();
+                text += siteTemplates.RoleBindingYaml();
+                text += siteTemplates.ConfigMapYaml('edge', null, row.vanid, row.vanid);
+                text += siteTemplates.DeploymentYaml(iid, false, 'kube');
+                text += siteTemplates.SiteApiServiceYaml();
+                text += siteTemplates.SecretYaml(secret, 'skupperx-claim', false);
+                text += claim_config_map_yaml(row.id, row.hostname, row.port, row.interactiveclaim, row.membernameprefix);
+    
+                res.status(returnStatus).send(text);
+    
+                //
+                // Bump the fetch-count for the invitation.
+                //
+                await client.query("UPDATE MemberInvitations SET FetchCount = FetchCount + 1 WHERE Id = $1", [row.id]);
+            } else {
+                throw new Error('Valid invitation not found');
+            }
+        })
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
@@ -142,20 +145,23 @@ const fetchInvitationKube = async function (iid, res) {
     return returnStatus;
 }
 
-const fetchBackboneSiteKube = async function (siteId, platform, res) {
-    var returnStatus = 200;
+const fetchBackboneSiteKube = async function (req, res) {
+    const siteId = req.params.bsid;
+    const platform = req.params.target;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            'SELECT InteriorSites.Name as sitename, InteriorSites.Certificate, InteriorSites.Lifecycle, InteriorSites.DeploymentState, TlsCertificates.ObjectName as secret_name FROM InteriorSites ' +
-            'JOIN TlsCertificates ON InteriorSites.Certificate = TlsCertificates.Id WHERE Interiorsites.Id = $1', [siteId]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                'SELECT InteriorSites.Name as sitename, InteriorSites.Certificate, InteriorSites.Lifecycle, InteriorSites.DeploymentState, TlsCertificates.ObjectName as secret_name FROM InteriorSites ' +
+                'JOIN TlsCertificates ON InteriorSites.Certificate = TlsCertificates.Id WHERE Interiorsites.Id = $1', [siteId]);
+        })
         if (result.rowCount == 1) {
             if (result.rows[0].deploymentstate == 'deployed') {
-                throw(Error("Not permitted, site already deployed"));
+                throw new Error("Not permitted, site already deployed");
             }
             if (result.rows[0].deploymentstate == 'not-ready') {
-                throw(Error("Not permitted, site not ready for deployment"));
+                throw new Error("Not permitted, site not ready for deployment");
             }
             let secret = await LoadSecret(result.rows[0].secret_name);
             let text = '';
@@ -178,7 +184,7 @@ const fetchBackboneSiteKube = async function (siteId, platform, res) {
 
             res.status(returnStatus).send(text);
         } else {
-            throw Error('Site secret not found');
+            throw new Error('Site secret not found');
         }
         await client.query('COMMIT');
     } catch (err) {
@@ -192,23 +198,25 @@ const fetchBackboneSiteKube = async function (siteId, platform, res) {
     return returnStatus;
 }
 
-const fetchBackboneSiteSkupper2 = async function (siteId, res) {
-    var returnStatus = 200;
+const fetchBackboneSiteSkupper2 = async function (req, res) {
+    const siteId = req.params.bsid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            "SELECT Name, DeploymentState, Certificate, TlsCertificates.ObjectName " +
-            "FROM   InteriorSites " +
-            "JOIN   TlsCertificates ON Certificate = TlsCertificates.Id " +
-            "WHERE  Interiorsites.Id = $1", [siteId]);
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                "SELECT Name, DeploymentState, Certificate, TlsCertificates.ObjectName " +
+                "FROM   InteriorSites " +
+                "JOIN   TlsCertificates ON Certificate = TlsCertificates.Id " +
+                "WHERE  Interiorsites.Id = $1", [siteId]);
+        })
         if (result.rowCount == 1) {
             const site = result.rows[0];
             if (site.deploymentstate == 'deployed') {
-                throw(Error("Not permitted, site already deployed"));
+                throw new Error("Not permitted, site already deployed");
             }
             if (site.deploymentstate == 'not-ready') {
-                throw(Error("Not permitted, site not ready for deployment"));
+                throw new Error("Not permitted, site not ready for deployment");
             }
             const secret = await LoadSecret(site.objectname);
             let text = '';
@@ -233,9 +241,8 @@ const fetchBackboneSiteSkupper2 = async function (siteId, res) {
 
             res.status(returnStatus).send(text);
         } else {
-            throw Error('Site secret not found');
+            throw new Error('Site secret not found');
         }
-        await client.query('COMMIT');
     } catch (err) {
         await client.query('ROLLBACK');
         returnStatus = 400;
@@ -247,37 +254,38 @@ const fetchBackboneSiteSkupper2 = async function (siteId, res) {
     return returnStatus;
 }
 
-const fetchBackboneAccessPointsKube = async function (bsid, res) {
-    var returnStatus = 200;
+const fetchBackboneAccessPointsKube = async function (req, res) {
+    const bsid = req.params.bsid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(
-            'SELECT DeploymentState FROM InteriorSites WHERE Id = $1', [bsid]);
-        if (result.rowCount == 1) {
-            let site = result.rows[0];
-
-            if (site.deploymentstate != 'ready-bootfinish') {
-                throw(Error('Not permitted, site not ready for bootstrap deployment'));
-            }
-
-            let text = '';
-            const ap_result = await client.query("SELECT TlsCertificates.ObjectName, BackboneAccessPoints.Id as apid, Lifecycle, Kind FROM BackboneAccessPoints " +
-                                                 "JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
-                                                 "WHERE BackboneAccessPoints.InteriorSite = $1", [bsid]);
-            for (const ap of ap_result.rows) {
-                if (ap.lifecycle != 'ready') {
-                    throw Error(`Certificate for access point of kind ${ap.kind} is not yet ready`);
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query(
+                'SELECT DeploymentState FROM InteriorSites WHERE Id = $1', [bsid]);
+            if (result.rowCount == 1) {
+                let site = result.rows[0];
+    
+                if (site.deploymentstate != 'ready-bootfinish') {
+                    throw new Error('Not permitted, site not ready for bootstrap deployment');
                 }
-                let secret = await LoadSecret(ap.objectname);
-                text += siteTemplates.SecretYaml(secret, `skx-access-${ap.apid}`, common.INJECT_TYPE_ACCESS_POINT, `tls-server-${ap.apid}`);
+    
+                let text = '';
+                const ap_result = await client.query("SELECT TlsCertificates.ObjectName, BackboneAccessPoints.Id as apid, Lifecycle, Kind FROM BackboneAccessPoints " +
+                                                     "JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
+                                                     "WHERE BackboneAccessPoints.InteriorSite = $1", [bsid]);
+                for (const ap of ap_result.rows) {
+                    if (ap.lifecycle != 'ready') {
+                        throw new Error(`Certificate for access point of kind ${ap.kind} is not yet ready`);
+                    }
+                    let secret = await LoadSecret(ap.objectname);
+                    text += siteTemplates.SecretYaml(secret, `skx-access-${ap.apid}`, common.INJECT_TYPE_ACCESS_POINT, `tls-server-${ap.apid}`);
+                }
+    
+                res.status(returnStatus).send(text);
+            } else {
+                throw new Error('Site not found');
             }
-
-            res.status(returnStatus).send(text);
-        } else {
-            throw Error('Site not found');
-        }
-        await client.query('COMMIT');
+        })
     } catch (error) {
         await client.query('ROLLBACK');
         returnStatus = 400;
@@ -289,14 +297,15 @@ const fetchBackboneAccessPointsKube = async function (bsid, res) {
     return returnStatus;
 }
 
-const fetchBackboneLinksOutgoingKube = async function (bsid, res) {
-    var returnStatus = 200;
+const fetchBackboneLinksOutgoingKube = async function (req, res) {
+    const bsid = req.params.bsid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const outgoing = await sync.GetBackboneLinks_TX(client, bsid);
+        const outgoing = await queryWithContext(req, client, async (client) => {
+            return await sync.GetBackboneLinks_TX(client, bsid);
+        })
         res.status(returnStatus).send(link_config_map_yaml('skupperx-outgoing', outgoing));
-        await client.query('COMMIT');
     } catch (err) {
         await client.query('ROLLBACK');
         returnStatus = 400;
@@ -308,21 +317,25 @@ const fetchBackboneLinksOutgoingKube = async function (bsid, res) {
     return returnStatus;
 }
 
-const getVanConfigConnecting = async function(vid, apid, res) {
-    var returnStatus = 200;
+const getVanConfigConnecting = async function (req, res) {
+    const vid = req.params.vid
+    const apid = req.params.apid
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query(
-            "SELECT VanId, ObjectName FROM ApplicationNetworks " +
-            "JOIN NetworkCredentials ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
-            "JOIN TlsCertificates ON TlsCertificates.Id = NetworkCredentials.Certificate " +
-            "WHERE ApplicationNetworks.Id = $1",
-            [vid]);
-        const apResult = await client.query(
-            "SELECT hostname, port FROM BackboneAccessPoints " +
-            "WHERE Id = $1",
-            [apid]
-        );
+        const { result, apResult } = await queryWithContext(req, client, async (client) => {
+            const result = await client.query(
+                "SELECT VanId, ObjectName FROM ApplicationNetworks " +
+                "JOIN NetworkCredentials ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
+                "JOIN TlsCertificates ON TlsCertificates.Id = NetworkCredentials.Certificate " +
+                "WHERE ApplicationNetworks.Id = $1",
+                [vid])
+            const apResult = await client.query(
+                "SELECT hostname, port FROM BackboneAccessPoints " +
+                "WHERE Id = $1",
+                [apid])
+            return { result, apResult }
+        })
         if (result.rowCount == 0 || apResult.rowCount == 0) {
             returnStatus = 404;
             res.status(returnStatus).send('Network or Access Point not found');
@@ -345,19 +358,22 @@ const getVanConfigConnecting = async function(vid, apid, res) {
     return returnStatus;
 }
 
-const getVanConfigNonConnecting = async function(vid, res) {
-    var returnStatus = 200;
+const getVanConfigNonConnecting = async function(req, res) {
+    const vid = req.params.vid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await client.query("SELECT VanId FROM ApplicationNetworks WHERE id = $1", [vid]);
-        if (result.rowCount == 0) {
-            returnStatus = 404;
-            res.status(returnStatus).send('Network not found');
-        } else {
-            const van = result.rows[0];
-            const text = crdTemplates.NetworkCRYaml(van.vanid);
-            res.status(returnStatus).send(text);
-        }
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query("SELECT VanId FROM ApplicationNetworks WHERE id = $1", [vid]);
+            if (result.rowCount == 0) {
+                returnStatus = 404;
+                res.status(returnStatus).send('Network not found');
+            } else {
+                const van = result.rows[0];
+                const text = crdTemplates.NetworkCRYaml(van.vanid);
+                res.status(returnStatus).send(text);
+            }
+        })
     } catch (err) {
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
@@ -369,10 +385,9 @@ const getVanConfigNonConnecting = async function(vid, res) {
 }
 
 const getCertsSignedBy = async function(req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try{
-        await client.query("BEGIN");
         const ca = req.query.signedby;
         if (ca && !util.IsValidUuid(ca)) {
             throw new Error(`Malformed signedby reference: ${ca}`);
@@ -383,19 +398,14 @@ const getCertsSignedBy = async function(req, res) {
                 throw new Error(`signedby certificate is not an issuer`);
             }
         }
-        var result;
-        if (ca) {
-            result = await client.query(
-                "SELECT * FROM tlsCertificates WHERE signedBy = $1",
-                [ca]
-            );
-        } else {
-            result = await client.query(
-                "SELECT * FROM tlsCertificates WHERE signedBy IS NULL"
-            );
-        }
+
+        const result = await queryWithContext(req, client, async (client) => {
+            if (ca) {
+                return await client.query("SELECT * FROM tlsCertificates WHERE signedBy = $1", [ca])
+            }
+            return await client.query("SELECT * FROM tlsCertificates WHERE signedBy IS NULL")
+        })
         res.status(returnStatus).json(result.rows);
-        await client.query("COMMIT");
     } catch (err) {
         await client.query("ROLLBACK");
         returnStatus = 400;
@@ -405,18 +415,22 @@ const getCertsSignedBy = async function(req, res) {
     }
 }
 
-const getCertDetail = async function(cid, res) {
-    var returnStatus = 200;
+const getCertDetail = async function(req, res) {
+    const cid = req.params.cid;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try{
-        await client.query("BEGIN");
         if (!util.IsValidUuid(cid)) {
             throw new Error(`Malformed certificate ID: ${cid}`);
         }
-        const result = await client.query(
-            "SELECT objectname, label, isca FROM tlsCertificates WHERE id = $1",
-            [cid]
-        );
+
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query(
+                "SELECT objectname, label, isca FROM tlsCertificates WHERE id = $1",
+                [cid]
+            );
+        })
+
         if (result.rowCount == 0) {
             throw new Error('Not Found');
         }
@@ -437,7 +451,6 @@ const getCertDetail = async function(cid, res) {
         },
         }
         res.status(returnStatus).json(data);
-        await client.query("COMMIT");
     } catch (err) {
         await client.query("ROLLBACK");
         returnStatus = 400;
@@ -447,34 +460,34 @@ const getCertDetail = async function(cid, res) {
     }
 }
 
-export async function AddHostToAccessPoint(siteId, apid, hostname, port) {
+export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
     let retval = 1;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query(`SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints WHERE Id = $1 AND InteriorSite = $2`, [apid, siteId]);
-        if (result.rowCount == 1) {
-            let access = result.rows[0];
-            if (access.hostname != hostname || access.port != port) {
-                if (access.hostname) {
-                    throw Error(`Referenced access (${access.access_ref}) already has a hostname`);
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query(`SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints WHERE Id = $1 AND InteriorSite = $2`, [apid, siteId]);
+            if (result.rowCount == 1) {
+                let access = result.rows[0];
+                if (access.hostname != hostname || access.port != port) {
+                    if (access.hostname) {
+                        throw new Error(`Referenced access (${access.access_ref}) already has a hostname`);
+                    }
+                    if (access.lifecycle != 'partial') {
+                        throw new Error(`Referenced access (${access.access_ref}) has lifecycle ${access.lifecycle}, expected partial`);
+                    }
+                    await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3", [hostname, port, apid]);
                 }
-                if (access.lifecycle != 'partial') {
-                    throw Error(`Referenced access (${access.access_ref}) has lifecycle ${access.lifecycle}, expected partial`);
+    
+                //
+                // Alert the sync module that an access point has advanced from 'partial' state if this is a peer ingress
+                //
+                if (access.kind == 'peer') {
+                    await sync.NewIngressAvailable(siteId);
                 }
-                await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3", [hostname, port, apid]);
+            } else {
+                throw new Error(`Access point not found for site ${siteId} (${apid})`);
             }
-            await client.query("COMMIT");
-
-            //
-            // Alert the sync module that an access point has advanced from 'partial' state if this is a peer ingress
-            //
-            if (access.kind == 'peer') {
-                await sync.NewIngressAvailable(siteId);
-            }
-        } else {
-            throw Error(`Access point not found for site ${siteId} (${apid})`);
-        }
+        })
     } catch (err) {
         await client.query('ROLLBACK');
         Log(`Host add to AccessPoint failed: ${err.message}`);
@@ -486,7 +499,7 @@ export async function AddHostToAccessPoint(siteId, apid, hostname, port) {
 }
 
 const postBackboneIngress = async function (bsid, req, res) {
-    var returnStatus = 201;
+    let returnStatus = 201;
     const form = formidable();
     try {
         let count = 0;
@@ -500,7 +513,7 @@ const postBackboneIngress = async function (bsid, req, res) {
                 'port' : {type: 'number', optional: false},
             });
 
-            count += await AddHostToAccessPoint(bsid, apid, norm.host, norm.port);
+            count += await AddHostToAccessPoint(req, bsid, apid, norm.host, norm.port);
         }
 
         if (count == 0) {
@@ -517,13 +530,13 @@ const postBackboneIngress = async function (bsid, req, res) {
 }
 
 const getTargetPlatforms = async function (req, res) {
-    var returnStatus = 200;
+    let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await client.query('BEGIN');
-        const result = await client.query("SELECT ShortName, LongName FROM TargetPlatforms");
+        const result = await queryWithContext(req, client, async (client) => {
+            return await client.query("SELECT ShortName, LongName FROM TargetPlatforms");
+        })
         res.status(returnStatus).json(result.rows);
-        await client.query('COMMIT');
     } catch (err) {
         await client.query('ROLLBACK');
         returnStatus = 400;
@@ -550,14 +563,14 @@ export async function Start(is_standalone) {
     app.use(morgan(':ts :remote-addr :remote-user :method :url :status :res[content-length] :response-time ms'));
 
     app.get(API_PREFIX + 'invitations/:iid/kube', async (req, res) => {
-        await fetchInvitationKube(req.params.iid, res);
+        await fetchInvitationKube(req, res);
     });
 
     app.get(API_PREFIX + 'backbonesite/:bsid/:target', async (req, res) => {
         switch (req.params.target) {
-            case 'sk2'  : await fetchBackboneSiteSkupper2(req.params.bsid, res);   break;
+            case 'sk2'  : await fetchBackboneSiteSkupper2(req, res);   break;
             case 'm-server':
-            case 'kube' : await fetchBackboneSiteKube(req.params.bsid, req.params.target, res);  break;
+            case 'kube' : await fetchBackboneSiteKube(req, res);  break;
             default:
                 res.status(400).send(`Unsupported target: ${req.params.target}`);
         }
@@ -568,7 +581,7 @@ export async function Start(is_standalone) {
             case 'sk2'  :
             case 'kube' :
             case 'm-server' :
-                await fetchBackboneAccessPointsKube(req.params.bsid, res);
+                await fetchBackboneAccessPointsKube(req, res);
                 break;
             default:
                 res.status(400).send(`Unsupported target: ${req.params.target}`);
@@ -576,7 +589,7 @@ export async function Start(is_standalone) {
     });
 
     app.get(API_PREFIX + 'backbonesite/:bsid/links/outgoing/kube', async (req, res) => {
-        await fetchBackboneLinksOutgoingKube(req.params.bsid, res);
+        await fetchBackboneLinksOutgoingKube(req, res);
     });
 
     app.post(API_PREFIX + 'backbonesite/:bsid/ingress', async (req, res) => {
@@ -588,11 +601,11 @@ export async function Start(is_standalone) {
     });
 
     app.get(API_PREFIX + 'vans/:vid/config/connecting/:apid', async (req, res) => {
-        await getVanConfigConnecting(req.params.vid, req.params.apid, res);
+        await getVanConfigConnecting(req, res);
     });
 
     app.get(API_PREFIX + 'vans/:vid/config/nonconnecting', async (req, res) => {
-        await getVanConfigNonConnecting(req.params.vid, res);
+        await getVanConfigNonConnecting(req, res);
     });
 
     app.get(API_PREFIX + 'certs', async (req, res) => {
@@ -600,14 +613,14 @@ export async function Start(is_standalone) {
     });
 
     app.get(API_PREFIX + 'certs/:cid', async (req, res) => {
-        await getCertDetail(req.params.cid, res);
+        await getCertDetail(req, res);
     });
 
     app.use(bodyParser.text({ type: ['application/yaml'] }));
 
     adminApi.Initialize(app, keycloak);
     userApi.Initialize(app, keycloak);
-    compose.ApiInit(app);
+    compose.ApiInit(app, keycloak);
 
     const console_path = is_standalone ? '../../../console/build' : '../vms-web-app';
     app.use(expressStatic(path.join(__dirname, console_path)));

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -548,6 +548,22 @@ const getTargetPlatforms = async function (req, res) {
     return returnStatus;
 }
 
+const getUserGroups = async function (req, res) {
+    let returnStatus = 200;
+    try {
+        const userCredentials = req?.kauth?.grant?.access_token?.content;
+        const groups = Array.isArray(userCredentials?.clientGroups)
+            ? userCredentials.clientGroups.map(group => ({ id: group, name: group }))
+            : []; 
+        res.status(returnStatus).json(groups);
+    } catch (err) {
+        returnStatus = 401;
+        Log(`Error retrieving user groups: ${err.message}`);
+        res.status(returnStatus).send(err.message);
+    }
+    return returnStatus;
+}
+
 export async function Start(is_standalone) {
     Log('[API Server module started]');
     app.use(cors());
@@ -615,6 +631,10 @@ export async function Start(is_standalone) {
     app.get(API_PREFIX + 'certs/:cid', async (req, res) => {
         await getCertDetail(req, res);
     });
+
+    app.get(API_PREFIX + 'user/groups', keycloak.protect(),async (req, res) => {
+        await getUserGroups(req, res);
+    })
 
     app.use(bodyParser.text({ type: ['application/yaml'] }));
 

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -104,7 +104,7 @@ const fetchInvitationKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
+        const text = await queryWithContext(req, client, async (client) => {
             const result = await client.query("SELECT MemberInvitations.*, TlsCertificates.ObjectName as secret_name, ApplicationNetworks.VanId, " +
                                               "BackboneAccessPoints.Id as accessid, BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM MemberInvitations " +
                                               "JOIN TlsCertificates ON MemberInvitations.Certificate = TlsCertificates.Id " +
@@ -125,16 +125,16 @@ const fetchInvitationKube = async function (req, res) {
                 text += siteTemplates.SecretYaml(secret, 'skupperx-claim', false);
                 text += claim_config_map_yaml(row.id, row.hostname, row.port, row.interactiveclaim, row.membernameprefix);
     
-                res.status(returnStatus).send(text);
-    
                 //
                 // Bump the fetch-count for the invitation.
                 //
                 await client.query("UPDATE MemberInvitations SET FetchCount = FetchCount + 1 WHERE Id = $1", [row.id]);
+                return text
             } else {
                 throw new Error('Valid invitation not found');
             }
         })
+        res.status(returnStatus).send(text);
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
@@ -262,7 +262,7 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
+        const text = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 'SELECT DeploymentState FROM InteriorSites WHERE Id = $1', [bsid]);
             if (result.rowCount == 1) {
@@ -284,11 +284,12 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
                     text += siteTemplates.SecretYaml(secret, `skx-access-${ap.apid}`, common.INJECT_TYPE_ACCESS_POINT, `tls-server-${ap.apid}`);
                 }
     
-                res.status(returnStatus).send(text);
+                return text;
             } else {
                 throw new Error('Site not found');
             }
-        })
+        });
+        res.status(returnStatus).send(text);
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
@@ -364,24 +365,23 @@ const getVanConfigNonConnecting = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
+        const result = await queryWithContext(req, client, async (client) => {
             const result = await client.query("SELECT VanId FROM ApplicationNetworks WHERE id = $1", [vid]);
             if (result.rowCount == 0) {
-                returnStatus = 404;
-                res.status(returnStatus).send('Network not found');
+                return {status: 404, text: 'Network not found'};
             } else {
                 const van = result.rows[0];
                 const text = crdTemplates.NetworkCRYaml(van.vanid);
-                res.status(returnStatus).send(text);
+                return {status: returnStatus, text: text};
             }
         })
+        res.status(result.status).send(result.text);
     } catch (err) {
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
     } finally {
         client.release();
     }
-
     return returnStatus;
 }
 

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -104,13 +104,13 @@ const fetchInvitationKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client, userInfo) => {
+        const text = await queryWithContext(req, client, async (client) => {
             const result = await client.query("SELECT MemberInvitations.*, TlsCertificates.ObjectName as secret_name, ApplicationNetworks.VanId, " +
                                               "BackboneAccessPoints.Id as accessid, BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM MemberInvitations " +
                                               "JOIN TlsCertificates ON MemberInvitations.Certificate = TlsCertificates.Id " +
                                               "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id " +
                                               "JOIN BackboneAccessPoints ON MemberInvitations.ClaimAccess = BackboneAccessPoints.Id " +
-                                              "WHERE MemberInvitations.Id = $1 AND BackboneAccessPoints.Lifecycle = 'ready' AND MemberInvitations.Lifecycle = 'ready' AND (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [iid, userInfo.userId, userInfo.userGroups]);
+                                              "WHERE MemberInvitations.Id = $1 AND BackboneAccessPoints.Lifecycle = 'ready' AND MemberInvitations.Lifecycle = 'ready'", [iid]);
             if (result.rowCount == 1) {
                 const row = result.rows[0];
                 const secret = await LoadSecret(row.secret_name);
@@ -151,10 +151,10 @@ const fetchBackboneSiteKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client, userInfo) => {
+        const text = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 'SELECT InteriorSites.Name as sitename, InteriorSites.Certificate, InteriorSites.Lifecycle, InteriorSites.DeploymentState, TlsCertificates.ObjectName as secret_name FROM InteriorSites ' +
-                'JOIN TlsCertificates ON InteriorSites.Certificate = TlsCertificates.Id WHERE Interiorsites.Id = $1 and (InteriorSites.Owner = $2 or InteriorSites.OwnerGroup = Any($3) or is_admin())', [siteId, userInfo.userId, userInfo.userGroups]);
+                'JOIN TlsCertificates ON InteriorSites.Certificate = TlsCertificates.Id WHERE Interiorsites.Id = $1', [siteId]);
             
             if (result.rowCount != 1) {
                 throw new Error('Site secret not found');
@@ -204,12 +204,12 @@ const fetchBackboneSiteSkupper2 = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client, userInfo) => {
+        const text = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 "SELECT Name, DeploymentState, Certificate, TlsCertificates.ObjectName " +
                 "FROM   InteriorSites " +
                 "JOIN   TlsCertificates ON Certificate = TlsCertificates.Id " +
-                "WHERE  Interiorsites.Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [siteId, userInfo.userId, userInfo.userGroups]);
+                "WHERE  Interiorsites.Id = $1", [siteId]);
             
             if (result.rowCount != 1) {
                 throw new Error('Site secret not found');
@@ -262,11 +262,9 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId;
-            const userGroups = userInfo.userGroups;
+        const text = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
-                'SELECT DeploymentState FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())', [bsid, userId, userGroups]);
+                'SELECT DeploymentState FROM InteriorSites WHERE Id = $1', [bsid]);
             if (result.rowCount !== 1) {
                 throw new Error('Site not found');
             }
@@ -280,7 +278,7 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
             let text = '';
             const ap_result = await client.query("SELECT TlsCertificates.ObjectName, BackboneAccessPoints.Id as apid, Lifecycle, Kind FROM BackboneAccessPoints " +
                                                     "JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
-                                                    "WHERE BackboneAccessPoints.InteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bsid, userId, userGroups]);
+                                                    "WHERE BackboneAccessPoints.InteriorSite = $1", [bsid]);
             for (const ap of ap_result.rows) {
                 if (ap.lifecycle != 'ready') {
                     throw new Error(`Certificate for access point of kind ${ap.kind} is not yet ready`);
@@ -327,19 +325,17 @@ const getVanConfigConnecting = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const { result, apResult } = await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId;
-            const userGroups = userInfo.userGroups;
+        const { result, apResult } = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 "SELECT VanId, ObjectName FROM ApplicationNetworks " +
                 "JOIN NetworkCredentials ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
                 "JOIN TlsCertificates ON TlsCertificates.Id = NetworkCredentials.Certificate " +
-                "WHERE ApplicationNetworks.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())",
-                [vid, userId, userGroups])
+                "WHERE ApplicationNetworks.Id = $1",
+                [vid])
             const apResult = await client.query(
                 "SELECT hostname, port FROM BackboneAccessPoints " +
-                "WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())",
-                [apid, userId, userGroups])
+                "WHERE Id = $1",
+                [apid])
             return { result, apResult }
         })
         if (result.rowCount == 0 || apResult.rowCount == 0) {
@@ -370,7 +366,7 @@ const getVanConfigNonConnecting = async function(req, res) {
     const client = await ClientFromPool();
     try {
         const result = await queryWithContext(req, client, async (client, userInfo) => {
-            const result = await client.query("SELECT VanId FROM ApplicationNetworks WHERE id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [vid, userInfo.userId, userInfo.userGroups]);
+            const result = await client.query("SELECT VanId FROM ApplicationNetworks WHERE id = $1", [vid]);
             if (result.rowCount == 0) {
                 return {status: 404, text: 'Network not found'};
             } else {
@@ -465,10 +461,8 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
     let retval = 1;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client, userInfo) => {
-            const userId = userInfo.userId;
-            const userGroups = userInfo.userGroups;
-            const result = await client.query(`SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints WHERE Id = $1 AND InteriorSite = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())`, [apid, siteId, userId, userGroups]);
+        await queryWithContext(req, client, async (client) => {
+            const result = await client.query(`SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints WHERE Id = $1 AND InteriorSite = $2`, [apid, siteId]);
             if (result.rowCount == 1) {
                 let access = result.rows[0];
                 if (access.hostname != hostname || access.port != port) {
@@ -478,7 +472,7 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
                     if (access.lifecycle != 'partial') {
                         throw new Error(`Referenced access (${access.access_ref}) has lifecycle ${access.lifecycle}, expected partial`);
                     }
-                    await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [hostname, port, apid, userId, userGroups]);
+                    await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3", [hostname, port, apid]);
                 }
     
                 //

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -579,11 +579,11 @@ export async function Start(is_standalone) {
 
     app.use(morgan(':ts :remote-addr :remote-user :method :url :status :res[content-length] :response-time ms'));
 
-    app.get(API_PREFIX + 'invitations/:iid/kube', keycloak.protect('realm:can-read-invitation'), async (req, res) => {
+    app.get(API_PREFIX + 'invitations/:iid/kube', keycloak.protect('realm:van-owner'), async (req, res) => {
         await fetchInvitationKube(req, res);
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/:target', keycloak.protect('realm:can-read-backbone-site'), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/:target', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         switch (req.params.target) {
             case 'sk2'  : await fetchBackboneSiteSkupper2(req, res);   break;
             case 'm-server':
@@ -593,7 +593,7 @@ export async function Start(is_standalone) {
         }
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/accesspoints/:target', keycloak.protect('realm:can-list-backbone-access-points'), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/accesspoints/:target', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         switch (req.params.target) {
             case 'sk2'  :
             case 'kube' :
@@ -605,31 +605,31 @@ export async function Start(is_standalone) {
         }
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/links/outgoing/kube', keycloak.protect('realm:can-list-backbone-links-outgoing'), async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/links/outgoing/kube', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         await fetchBackboneLinksOutgoingKube(req, res);
     });
 
-    app.post(API_PREFIX + 'backbonesite/:bsid/ingress', keycloak.protect('realm:can-create-backbone-ingress'), async (req, res) => {
+    app.post(API_PREFIX + 'backbonesite/:bsid/ingress', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         await postBackboneIngress(req.params.bsid, req, res);
     });
 
-    app.get(API_PREFIX + 'targetplatforms', keycloak.protect('realm:can-list-target-platforms'), async (req, res) => {
+    app.get(API_PREFIX + 'targetplatforms', keycloak.protect('realm:backbone-owner'), async (req, res) => {
         await getTargetPlatforms(req, res);
     });
 
-    app.get(API_PREFIX + 'vans/:vid/config/connecting/:apid', keycloak.protect('realm:can-read-van-config-connecting'), async (req, res) => {
+    app.get(API_PREFIX + 'vans/:vid/config/connecting/:apid', keycloak.protect('realm:van-owner'), async (req, res) => {
         await getVanConfigConnecting(req, res);
     });
 
-    app.get(API_PREFIX + 'vans/:vid/config/nonconnecting', keycloak.protect('realm:can-read-van-config-nonconnecting'), async (req, res) => {
+    app.get(API_PREFIX + 'vans/:vid/config/nonconnecting', keycloak.protect('realm:van-owner'), async (req, res) => {
         await getVanConfigNonConnecting(req, res);
     });
 
-    app.get(API_PREFIX + 'certs', keycloak.protect('realm:can-list-certificates'), async (req, res) => {
+    app.get(API_PREFIX + 'certs', keycloak.protect('realm:certificate-manager'), async (req, res) => {
         await getCertsSignedBy(req, res);
     });
 
-    app.get(API_PREFIX + 'certs/:cid', keycloak.protect('realm:can-read-certificate'), async (req, res) => {
+    app.get(API_PREFIX + 'certs/:cid', keycloak.protect('realm:certificate-manager'), async (req, res) => {
         await getCertDetail(req, res);
     });
 

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -265,29 +265,29 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
         const text = await queryWithContext(req, client, async (client) => {
             const result = await client.query(
                 'SELECT DeploymentState FROM InteriorSites WHERE Id = $1', [bsid]);
-            if (result.rowCount == 1) {
-                let site = result.rows[0];
-    
-                if (site.deploymentstate != 'ready-bootfinish') {
-                    throw new Error('Not permitted, site not ready for bootstrap deployment');
-                }
-    
-                let text = '';
-                const ap_result = await client.query("SELECT TlsCertificates.ObjectName, BackboneAccessPoints.Id as apid, Lifecycle, Kind FROM BackboneAccessPoints " +
-                                                     "JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
-                                                     "WHERE BackboneAccessPoints.InteriorSite = $1", [bsid]);
-                for (const ap of ap_result.rows) {
-                    if (ap.lifecycle != 'ready') {
-                        throw new Error(`Certificate for access point of kind ${ap.kind} is not yet ready`);
-                    }
-                    let secret = await LoadSecret(ap.objectname);
-                    text += siteTemplates.SecretYaml(secret, `skx-access-${ap.apid}`, common.INJECT_TYPE_ACCESS_POINT, `tls-server-${ap.apid}`);
-                }
-    
-                return text;
-            } else {
+            if (result.rowCount !== 1) {
                 throw new Error('Site not found');
             }
+
+            let site = result.rows[0];
+
+            if (site.deploymentstate != 'ready-bootfinish') {
+                throw new Error('Not permitted, site not ready for bootstrap deployment');
+            }
+
+            let text = '';
+            const ap_result = await client.query("SELECT TlsCertificates.ObjectName, BackboneAccessPoints.Id as apid, Lifecycle, Kind FROM BackboneAccessPoints " +
+                                                    "JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
+                                                    "WHERE BackboneAccessPoints.InteriorSite = $1", [bsid]);
+            for (const ap of ap_result.rows) {
+                if (ap.lifecycle != 'ready') {
+                    throw new Error(`Certificate for access point of kind ${ap.kind} is not yet ready`);
+                }
+                let secret = await LoadSecret(ap.objectname);
+                text += siteTemplates.SecretYaml(secret, `skx-access-${ap.apid}`, common.INJECT_TYPE_ACCESS_POINT, `tls-server-${ap.apid}`);
+            }
+
+            return text;
         });
         res.status(returnStatus).send(text);
     } catch (error) {
@@ -382,6 +382,7 @@ const getVanConfigNonConnecting = async function(req, res) {
     } finally {
         client.release();
     }
+    
     return returnStatus;
 }
 

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -104,13 +104,13 @@ const fetchInvitationKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client) => {
+        const text = await queryWithContext(req, client, async (client, userInfo) => {
             const result = await client.query("SELECT MemberInvitations.*, TlsCertificates.ObjectName as secret_name, ApplicationNetworks.VanId, " +
                                               "BackboneAccessPoints.Id as accessid, BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM MemberInvitations " +
                                               "JOIN TlsCertificates ON MemberInvitations.Certificate = TlsCertificates.Id " +
                                               "JOIN ApplicationNetworks ON MemberInvitations.MemberOf = ApplicationNetworks.Id " +
                                               "JOIN BackboneAccessPoints ON MemberInvitations.ClaimAccess = BackboneAccessPoints.Id " +
-                                              "WHERE MemberInvitations.Id = $1 AND BackboneAccessPoints.Lifecycle = 'ready' AND MemberInvitations.Lifecycle = 'ready'", [iid]);
+                                              "WHERE MemberInvitations.Id = $1 AND BackboneAccessPoints.Lifecycle = 'ready' AND MemberInvitations.Lifecycle = 'ready' AND (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())", [iid, userInfo.userId, userInfo.userGroups]);
             if (result.rowCount == 1) {
                 const row = result.rows[0];
                 const secret = await LoadSecret(row.secret_name);
@@ -325,13 +325,13 @@ const getVanConfigConnecting = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const { result, apResult } = await queryWithContext(req, client, async (client) => {
+        const { result, apResult } = await queryWithContext(req, client, async (client, userInfo) => {
             const result = await client.query(
                 "SELECT VanId, ObjectName FROM ApplicationNetworks " +
                 "JOIN NetworkCredentials ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
                 "JOIN TlsCertificates ON TlsCertificates.Id = NetworkCredentials.Certificate " +
-                "WHERE ApplicationNetworks.Id = $1",
-                [vid])
+                "WHERE ApplicationNetworks.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())",
+                [vid, userInfo.userId, userInfo.userGroups])
             const apResult = await client.query(
                 "SELECT hostname, port FROM BackboneAccessPoints " +
                 "WHERE Id = $1",
@@ -365,8 +365,8 @@ const getVanConfigNonConnecting = async function(req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            const result = await client.query("SELECT VanId FROM ApplicationNetworks WHERE id = $1", [vid]);
+        const result = await queryWithContext(req, client, async (client, userInfo) => {
+            const result = await client.query("SELECT VanId FROM ApplicationNetworks WHERE id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [vid, userInfo.userId, userInfo.userGroups]);
             if (result.rowCount == 0) {
                 return {status: 404, text: 'Network not found'};
             } else {
@@ -393,15 +393,12 @@ const getCertsSignedBy = async function(req, res) {
         if (ca && !util.IsValidUuid(ca)) {
             throw new Error(`Malformed signedby reference: ${ca}`);
         }
-        if (ca) {
-            const ca_result = await client.query("SELECT isca FROM tlsCertificates WHERE id = $1", [ca]);
-            if (ca_result.rowCount == 0 || !ca_result.rows[0].isca) {
-                throw new Error(`signedby certificate is not an issuer`);
-            }
-        }
-
         const result = await queryWithContext(req, client, async (client) => {
             if (ca) {
+                const ca_result = await client.query("SELECT isca FROM tlsCertificates WHERE id = $1", [ca]);
+                if (ca_result.rowCount == 0 || !ca_result.rows[0].isca) {
+                    throw new Error(`signedby certificate is not an issuer`);
+                }
                 return await client.query("SELECT * FROM tlsCertificates WHERE signedBy = $1", [ca])
             }
             return await client.query("SELECT * FROM tlsCertificates WHERE signedBy IS NULL")

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -51,7 +51,7 @@ const app = express();
 const memoryStore = new session.MemoryStore();
 app.use(
    session({
-     secret: process.env.VMS_SESSION_SECRET,
+     secret: process.env.VMS_SESSION_SECRET || 'mysecret',
      resave: false,
      saveUninitialized: true,
      store: memoryStore,
@@ -543,6 +543,20 @@ const getTargetPlatforms = async function (req, res) {
     return returnStatus;
 }
 
+const getUserProfile = async function (req, res) {
+    let returnStatus = 200;
+    try {
+      const userCredentials = req?.kauth?.grant?.access_token?.content;
+      const user = userCredentials?.given_name + ' ' + userCredentials?.family_name
+      res.status(returnStatus).json({name: user});
+    } catch (err) {
+      returnStatus = 401;
+      Log(`Error retrieving user profile: ${err.message}`);
+      res.status(returnStatus).send(err.message);
+    }
+    return returnStatus;
+}
+
 const getUserGroups = async function (req, res) {
     let returnStatus = 200;
     try {
@@ -625,6 +639,10 @@ export async function Start(is_standalone) {
 
     app.get(API_PREFIX + 'certs/:cid', keycloak.protect('realm:certificate-manager'), async (req, res) => {
         await getCertDetail(req, res);
+    });
+
+    app.get(API_PREFIX + 'user/profile', keycloak.protect(), async (req, res) => {
+        await getUserProfile(req, res);
     });
 
     app.get(API_PREFIX + 'user/groups', keycloak.protect(), async (req, res) => {

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -51,7 +51,7 @@ const app = express();
 const memoryStore = new session.MemoryStore();
 app.use(
    session({
-     secret: 'mySecret',
+     secret: process.env.VMS_SESSION_SECRET,
      resave: false,
      saveUninitialized: true,
      store: memoryStore,

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -21,6 +21,8 @@
 
 import { static as expressStatic, json } from 'express';
 import express    from 'express';
+import session from 'express-session';
+import kcConnect from 'keycloak-connect';
 import path       from 'path';
 import morgan     from 'morgan';
 import cors       from 'cors';
@@ -45,19 +47,17 @@ const __dirname = import.meta.dirname;
 const API_PREFIX = '/api/v1alpha1/';
 const API_PORT   = 8085;
 const app = express();
-//const memoryStore = new session.MemoryStore();
-//app.use(
-//    session({
-//      secret: 'mySecret',
-//      resave: false,
-//      saveUninitialized: true,
-//      store: memoryStore,
-//    })
-//  );
-//const keycloak    = new kcConnect({store: memoryStore});
-const keycloak = {
-    protect : function(arg) { return (req, res, next) => { next(); } }
-};
+
+const memoryStore = new session.MemoryStore();
+app.use(
+   session({
+     secret: 'mySecret',
+     resave: false,
+     saveUninitialized: true,
+     store: memoryStore,
+   })
+ );
+const keycloak = new kcConnect({store: memoryStore});
 
 const link_config_map_yaml = function(name, data) {
     let configMap = {
@@ -538,10 +538,10 @@ const getTargetPlatforms = async function (req, res) {
 export async function Start(is_standalone) {
     Log('[API Server module started]');
     app.use(cors());
-    //app.set('trust proxy', true );
-    //app.use(keycloak.middleware());
+    app.set('trust proxy', true );
+    app.use(keycloak.middleware());
 
-    //app.get('/', keycloak.protect('realm:van-owner'));
+    app.get('/', keycloak.protect());
 
     morgan.token('ts', (req, res) => {
         return new Date().toISOString();

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -151,12 +151,15 @@ const fetchBackboneSiteKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query(
+        const text = await queryWithContext(req, client, async (client) => {
+            const result = await client.query(
                 'SELECT InteriorSites.Name as sitename, InteriorSites.Certificate, InteriorSites.Lifecycle, InteriorSites.DeploymentState, TlsCertificates.ObjectName as secret_name FROM InteriorSites ' +
                 'JOIN TlsCertificates ON InteriorSites.Certificate = TlsCertificates.Id WHERE Interiorsites.Id = $1', [siteId]);
-        })
-        if (result.rowCount == 1) {
+            
+            if (result.rowCount != 1) {
+                throw new Error('Site secret not found');
+            }
+            
             if (result.rows[0].deploymentstate == 'deployed') {
                 throw new Error("Not permitted, site already deployed");
             }
@@ -182,13 +185,11 @@ const fetchBackboneSiteKube = async function (req, res) {
                 text += siteTemplates.AccessPointConfigMapYaml(apId, apData);
             }
 
-            res.status(returnStatus).send(text);
-        } else {
-            throw new Error('Site secret not found');
-        }
-        await client.query('COMMIT');
+            return text;
+        })
+        
+        res.status(returnStatus).send(text);
     } catch (err) {
-        await client.query('ROLLBACK');
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
     } finally {
@@ -203,14 +204,17 @@ const fetchBackboneSiteSkupper2 = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const result = await queryWithContext(req, client, async (client) => {
-            return await client.query(
+        const text = await queryWithContext(req, client, async (client) => {
+            const result = await client.query(
                 "SELECT Name, DeploymentState, Certificate, TlsCertificates.ObjectName " +
                 "FROM   InteriorSites " +
                 "JOIN   TlsCertificates ON Certificate = TlsCertificates.Id " +
                 "WHERE  Interiorsites.Id = $1", [siteId]);
-        })
-        if (result.rowCount == 1) {
+            
+            if (result.rowCount != 1) {
+                throw new Error('Site secret not found');
+            }
+            
             const site = result.rows[0];
             if (site.deploymentstate == 'deployed') {
                 throw new Error("Not permitted, site already deployed");
@@ -239,12 +243,11 @@ const fetchBackboneSiteSkupper2 = async function (req, res) {
             text += "---\n" + yaml.dump(crdTemplates.BackboneSite(site.name, siteId));
             text += crdTemplates.NetworkCRYaml('mbone');
 
-            res.status(returnStatus).send(text);
-        } else {
-            throw new Error('Site secret not found');
-        }
+            return text;
+        })
+        
+        res.status(returnStatus).send(text);
     } catch (err) {
-        await client.query('ROLLBACK');
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
     } finally {
@@ -287,7 +290,6 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
             }
         })
     } catch (error) {
-        await client.query('ROLLBACK');
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
     } finally {
@@ -307,7 +309,6 @@ const fetchBackboneLinksOutgoingKube = async function (req, res) {
         })
         res.status(returnStatus).send(link_config_map_yaml('skupperx-outgoing', outgoing));
     } catch (err) {
-        await client.query('ROLLBACK');
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
     } finally {
@@ -407,7 +408,6 @@ const getCertsSignedBy = async function(req, res) {
         })
         res.status(returnStatus).json(result.rows);
     } catch (err) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
     } finally {
@@ -452,7 +452,6 @@ const getCertDetail = async function(req, res) {
         }
         res.status(returnStatus).json(data);
     } catch (err) {
-        await client.query("ROLLBACK");
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
     } finally {
@@ -489,7 +488,6 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
             }
         })
     } catch (err) {
-        await client.query('ROLLBACK');
         Log(`Host add to AccessPoint failed: ${err.message}`);
         retval = 0;
     } finally {
@@ -538,7 +536,6 @@ const getTargetPlatforms = async function (req, res) {
         })
         res.status(returnStatus).json(result.rows);
     } catch (err) {
-        await client.query('ROLLBACK');
         returnStatus = 400;
         res.status(returnStatus).send(err.message);
     } finally {
@@ -578,11 +575,11 @@ export async function Start(is_standalone) {
 
     app.use(morgan(':ts :remote-addr :remote-user :method :url :status :res[content-length] :response-time ms'));
 
-    app.get(API_PREFIX + 'invitations/:iid/kube', async (req, res) => {
+    app.get(API_PREFIX + 'invitations/:iid/kube', keycloak.protect(), async (req, res) => {
         await fetchInvitationKube(req, res);
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/:target', async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/:target', keycloak.protect(), async (req, res) => {
         switch (req.params.target) {
             case 'sk2'  : await fetchBackboneSiteSkupper2(req, res);   break;
             case 'm-server':
@@ -592,7 +589,7 @@ export async function Start(is_standalone) {
         }
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/accesspoints/:target', async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/accesspoints/:target', keycloak.protect(), async (req, res) => {
         switch (req.params.target) {
             case 'sk2'  :
             case 'kube' :
@@ -604,31 +601,31 @@ export async function Start(is_standalone) {
         }
     });
 
-    app.get(API_PREFIX + 'backbonesite/:bsid/links/outgoing/kube', async (req, res) => {
+    app.get(API_PREFIX + 'backbonesite/:bsid/links/outgoing/kube', keycloak.protect(), async (req, res) => {
         await fetchBackboneLinksOutgoingKube(req, res);
     });
 
-    app.post(API_PREFIX + 'backbonesite/:bsid/ingress', async (req, res) => {
+    app.post(API_PREFIX + 'backbonesite/:bsid/ingress', keycloak.protect(), async (req, res) => {
         await postBackboneIngress(req.params.bsid, req, res);
     });
 
-    app.get(API_PREFIX + 'targetplatforms', async (req, res) => {
+    app.get(API_PREFIX + 'targetplatforms', keycloak.protect(), async (req, res) => {
         await getTargetPlatforms(req, res);
     });
 
-    app.get(API_PREFIX + 'vans/:vid/config/connecting/:apid', async (req, res) => {
+    app.get(API_PREFIX + 'vans/:vid/config/connecting/:apid', keycloak.protect(), async (req, res) => {
         await getVanConfigConnecting(req, res);
     });
 
-    app.get(API_PREFIX + 'vans/:vid/config/nonconnecting', async (req, res) => {
+    app.get(API_PREFIX + 'vans/:vid/config/nonconnecting', keycloak.protect(), async (req, res) => {
         await getVanConfigNonConnecting(req, res);
     });
 
-    app.get(API_PREFIX + 'certs', async (req, res) => {
+    app.get(API_PREFIX + 'certs', keycloak.protect(), async (req, res) => {
         await getCertsSignedBy(req, res);
     });
 
-    app.get(API_PREFIX + 'certs/:cid', async (req, res) => {
+    app.get(API_PREFIX + 'certs/:cid', keycloak.protect(), async (req, res) => {
         await getCertDetail(req, res);
     });
 

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -151,10 +151,10 @@ const fetchBackboneSiteKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client) => {
+        const text = await queryWithContext(req, client, async (client, userInfo) => {
             const result = await client.query(
                 'SELECT InteriorSites.Name as sitename, InteriorSites.Certificate, InteriorSites.Lifecycle, InteriorSites.DeploymentState, TlsCertificates.ObjectName as secret_name FROM InteriorSites ' +
-                'JOIN TlsCertificates ON InteriorSites.Certificate = TlsCertificates.Id WHERE Interiorsites.Id = $1', [siteId]);
+                'JOIN TlsCertificates ON InteriorSites.Certificate = TlsCertificates.Id WHERE Interiorsites.Id = $1 and (InteriorSites.Owner = $2 or InteriorSites.OwnerGroup = Any($3) or is_admin())', [siteId, userInfo.userId, userInfo.userGroups]);
             
             if (result.rowCount != 1) {
                 throw new Error('Site secret not found');
@@ -204,12 +204,12 @@ const fetchBackboneSiteSkupper2 = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client) => {
+        const text = await queryWithContext(req, client, async (client, userInfo) => {
             const result = await client.query(
                 "SELECT Name, DeploymentState, Certificate, TlsCertificates.ObjectName " +
                 "FROM   InteriorSites " +
                 "JOIN   TlsCertificates ON Certificate = TlsCertificates.Id " +
-                "WHERE  Interiorsites.Id = $1", [siteId]);
+                "WHERE  Interiorsites.Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [siteId, userInfo.userId, userInfo.userGroups]);
             
             if (result.rowCount != 1) {
                 throw new Error('Site secret not found');
@@ -262,9 +262,11 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
     let returnStatus = 200;
     const client = await ClientFromPool();
     try {
-        const text = await queryWithContext(req, client, async (client) => {
+        const text = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId;
+            const userGroups = userInfo.userGroups;
             const result = await client.query(
-                'SELECT DeploymentState FROM InteriorSites WHERE Id = $1', [bsid]);
+                'SELECT DeploymentState FROM InteriorSites WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())', [bsid, userId, userGroups]);
             if (result.rowCount !== 1) {
                 throw new Error('Site not found');
             }
@@ -278,7 +280,7 @@ const fetchBackboneAccessPointsKube = async function (req, res) {
             let text = '';
             const ap_result = await client.query("SELECT TlsCertificates.ObjectName, BackboneAccessPoints.Id as apid, Lifecycle, Kind FROM BackboneAccessPoints " +
                                                     "JOIN TlsCertificates ON TlsCertificates.Id = Certificate " +
-                                                    "WHERE BackboneAccessPoints.InteriorSite = $1", [bsid]);
+                                                    "WHERE BackboneAccessPoints.InteriorSite = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())", [bsid, userId, userGroups]);
             for (const ap of ap_result.rows) {
                 if (ap.lifecycle != 'ready') {
                     throw new Error(`Certificate for access point of kind ${ap.kind} is not yet ready`);
@@ -326,16 +328,18 @@ const getVanConfigConnecting = async function (req, res) {
     const client = await ClientFromPool();
     try {
         const { result, apResult } = await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId;
+            const userGroups = userInfo.userGroups;
             const result = await client.query(
                 "SELECT VanId, ObjectName FROM ApplicationNetworks " +
                 "JOIN NetworkCredentials ON NetworkCredentials.MemberOf = ApplicationNetworks.Id " +
                 "JOIN TlsCertificates ON TlsCertificates.Id = NetworkCredentials.Certificate " +
                 "WHERE ApplicationNetworks.Id = $1 and (ApplicationNetworks.Owner = $2 or ApplicationNetworks.OwnerGroup = Any($3) or is_admin())",
-                [vid, userInfo.userId, userInfo.userGroups])
+                [vid, userId, userGroups])
             const apResult = await client.query(
                 "SELECT hostname, port FROM BackboneAccessPoints " +
-                "WHERE Id = $1",
-                [apid])
+                "WHERE Id = $1 and (Owner = $2 or OwnerGroup = Any($3) or is_admin())",
+                [apid, userId, userGroups])
             return { result, apResult }
         })
         if (result.rowCount == 0 || apResult.rowCount == 0) {
@@ -461,8 +465,10 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
     let retval = 1;
     const client = await ClientFromPool();
     try {
-        await queryWithContext(req, client, async (client) => {
-            const result = await client.query(`SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints WHERE Id = $1 AND InteriorSite = $2`, [apid, siteId]);
+        await queryWithContext(req, client, async (client, userInfo) => {
+            const userId = userInfo.userId;
+            const userGroups = userInfo.userGroups;
+            const result = await client.query(`SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints WHERE Id = $1 AND InteriorSite = $2 and (Owner = $3 or OwnerGroup = Any($4) or is_admin())`, [apid, siteId, userId, userGroups]);
             if (result.rowCount == 1) {
                 let access = result.rows[0];
                 if (access.hostname != hostname || access.port != port) {
@@ -472,7 +478,7 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
                     if (access.lifecycle != 'partial') {
                         throw new Error(`Referenced access (${access.access_ref}) has lifecycle ${access.lifecycle}, expected partial`);
                     }
-                    await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3", [hostname, port, apid]);
+                    await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3 and (Owner = $4 or OwnerGroup = Any($5) or is_admin())", [hostname, port, apid, userId, userGroups]);
                 }
     
                 //

--- a/components/management-controller/src/prune.js
+++ b/components/management-controller/src/prune.js
@@ -29,10 +29,10 @@ import {
 } from '@skupperx/modules/kube'
 import { Log } from '@skupperx/modules/log'
 import { META_ANNOTATION_SKUPPERX_CONTROLLED } from '@skupperx/modules/common'
-import { ClientFromPool, queryWithContext, SYSTEM_USER_ID } from './db.js';
+import { ClientFromPool, queryWithContext } from './db.js';
 
 const reconcileCertificates = async function() {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         const result = await client.query("SELECT ObjectName FROM TlsCertificates");
         var   db_cert_names = [];
@@ -71,10 +71,9 @@ const reconcileCertificates = async function() {
 }
 
 export async function DeleteOrphanCertificates() {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
-        
-        await queryWithContext({ userId: SYSTEM_USER_ID }, client, async (client) => {
+        await queryWithContext({ system: true }, client, async (client) => {
             let deleteMap = {};
             const tlsResult = await client.query("SELECT Id, SignedBy FROM TlsCertificates");
             for (const tlsRow of tlsResult.rows) {

--- a/components/management-controller/src/prune.js
+++ b/components/management-controller/src/prune.js
@@ -127,7 +127,6 @@ export async function DeleteOrphanCertificates() {
 
         })
     } catch (error) {
-        await client.query("ROLLBACK");
         Log(`Exception in DeleteOrphanCertificates: ${error.message}`);
         Log(error.stack);
     } finally {

--- a/components/management-controller/src/prune.js
+++ b/components/management-controller/src/prune.js
@@ -29,7 +29,7 @@ import {
 } from '@skupperx/modules/kube'
 import { Log } from '@skupperx/modules/log'
 import { META_ANNOTATION_SKUPPERX_CONTROLLED } from '@skupperx/modules/common'
-import { ClientFromPool, queryWithContext } from './db.js';
+import { ClientFromPool } from './db.js';
 
 const reconcileCertificates = async function() {
     const client = await ClientFromPool('system');
@@ -73,60 +73,61 @@ const reconcileCertificates = async function() {
 export async function DeleteOrphanCertificates() {
     const client = await ClientFromPool('system');
     try {
-        await queryWithContext({ system: true }, client, async (client) => {
-            let deleteMap = {};
-            const tlsResult = await client.query("SELECT Id, SignedBy FROM TlsCertificates");
-            for (const tlsRow of tlsResult.rows) {
-                if (tlsRow.signedby) {
-                    if (!deleteMap[tlsRow.signedby]) {
-                        deleteMap[tlsRow.signedby] = {
-                            pleaseDelete : false,
-                            children     : [],
-                        };
-                    }
-                    deleteMap[tlsRow.signedby].children.push(tlsRow.id);
-                }
-                if (!deleteMap[tlsRow.id]) {
-                    deleteMap[tlsRow.id] = {
-                        pleaseDelete : true,
+        await client.query("BEGIN");
+        let deleteMap = {};
+        const tlsResult = await client.query("SELECT Id, SignedBy FROM TlsCertificates");
+        for (const tlsRow of tlsResult.rows) {
+            if (tlsRow.signedby) {
+                if (!deleteMap[tlsRow.signedby]) {
+                    deleteMap[tlsRow.signedby] = {
+                        pleaseDelete : false,
                         children     : [],
                     };
-                } else {
-                    deleteMap[tlsRow.id].pleaseDelete = true;
                 }
+                deleteMap[tlsRow.signedby].children.push(tlsRow.id);
             }
-    
-            for (const table of ['ManagementControllers', 'Backbones', 'BackboneAccessPoints', 'InteriorSites', 'ApplicationNetworks', 'NetworkCredentials', 'MemberInvitations', 'MemberSites']) {
-                const result = await client.query(`SELECT Id, Certificate FROM ${table}`);
-                for (const row of result.rows) {
-                    if (row.certificate) {
-                        if (deleteMap[row.certificate]) {
-                            deleteMap[row.certificate].pleaseDelete = false;
-                        } else {
-                            Log(`Record ${table}[${row.id}] references a non-exist TlsCertificate`);
-                        }
+            if (!deleteMap[tlsRow.id]) {
+                deleteMap[tlsRow.id] = {
+                    pleaseDelete : true,
+                    children     : [],
+                };
+            } else {
+                deleteMap[tlsRow.id].pleaseDelete = true;
+            }
+        }
+
+        for (const table of ['ManagementControllers', 'Backbones', 'BackboneAccessPoints', 'InteriorSites', 'ApplicationNetworks', 'NetworkCredentials', 'MemberInvitations', 'MemberSites']) {
+            const result = await client.query(`SELECT Id, Certificate FROM ${table}`);
+            for (const row of result.rows) {
+                if (row.certificate) {
+                    if (deleteMap[row.certificate]) {
+                        deleteMap[row.certificate].pleaseDelete = false;
+                    } else {
+                        Log(`Record ${table}[${row.id}] references a non-exist TlsCertificate`);
                     }
                 }
             }
-    
-            const depthFirstDelete = async function(client, certId) {
-                const record = deleteMap[certId];
-                for (const childId of record.children) {
-                    await depthFirstDelete(client, childId);
-                }
-                if (record.pleaseDelete) {
-                    await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [certId]);
-                    Log(`Orphan TlsCertificate ${certId} to be deleted`);
-                    record.pleaseDelete = false;
-                }
-            }
-    
-            for (const certId of Object.keys(deleteMap)) {
-                await depthFirstDelete(client, certId);
-            }
+        }
 
-        })
+        const depthFirstDelete = async function(client, certId) {
+            const record = deleteMap[certId];
+            for (const childId of record.children) {
+                await depthFirstDelete(client, childId);
+            }
+            if (record.pleaseDelete) {
+                await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [certId]);
+                Log(`Orphan TlsCertificate ${certId} to be deleted`);
+                record.pleaseDelete = false;
+            }
+        }
+
+        for (const certId of Object.keys(deleteMap)) {
+            await depthFirstDelete(client, certId);
+        }
+
+        await client.query("COMMIT");
     } catch (error) {
+        await client.query("ROLLBACK");
         Log(`Exception in DeleteOrphanCertificates: ${error.message}`);
         Log(error.stack);
     } finally {

--- a/components/management-controller/src/site-deployment-state.js
+++ b/components/management-controller/src/site-deployment-state.js
@@ -86,7 +86,7 @@ export async function SiteLifecycleChanged_TX(client, siteId, newState) {
 }
 
 export async function LinkAddedOrDeleted(connectingSiteId, accessPointId) {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         //
@@ -112,7 +112,7 @@ export async function LinkAddedOrDeleted(connectingSiteId, accessPointId) {
 }
 
 export async function ManageIngressAdded(siteId) {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT Id, Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1", [siteId]);
@@ -133,7 +133,7 @@ export async function ManageIngressAdded(siteId) {
 }
 
 export async function ManageIngressDeleted(siteId) {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT Id, Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1", [siteId]);

--- a/components/management-controller/src/site-deployment-state.js
+++ b/components/management-controller/src/site-deployment-state.js
@@ -154,7 +154,7 @@ export async function ManageIngressDeleted(siteId) {
 }
 
 export async function AccessPointCertReady(apId) {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query(
@@ -177,7 +177,7 @@ export async function AccessPointCertReady(apId) {
 }
 
 export async function EvaluateAllSites() {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT * FROM InteriorSites");

--- a/components/management-controller/src/sync-application.js
+++ b/components/management-controller/src/sync-application.js
@@ -183,7 +183,7 @@ export async function onMewMember(memberId, localState, remoteState) {
     const revertLocalState  = localState;
     const revertRemoteState = remoteState;
 
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const [vanId, siteClasses] = await getMemberInfo_TX(client, memberId);
@@ -211,7 +211,7 @@ export async function StateRequest(memberId, stateKey) {
     var hash = null;
     var data = {};
 
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const [vanId, siteClasses] = await getMemberInfo_TX(client, memberId);

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -648,7 +648,7 @@ export async function SiteIngressChanged(siteId, accessPointId) {
             const result = await client.query("SELECT Kind, BindHost, Certificate, Lifecycle FROM BackboneAccessPoints WHERE Id = $1", [accessPointId]);
             if (result.rowCount == 1) {
                 const row = result.rows[0];
-                var ap = {kind : row.kind};
+                let ap = {kind : row.kind};
                 if (row.bindhost) {
                     ap.bindhost = row.bindhost;
                 }

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -672,7 +672,7 @@ export async function LinkChanged(connectingSiteId, linkId) {
     // Update the link-<id> hash for the one affected connecting site
     //
     if (peers[connectingSiteId]) {
-        const client = await ClientFromPool();
+        const client = await ClientFromPool('system');
         try {
             let hash = null;
             await client.query("BEGIN");

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -93,7 +93,7 @@ const onNewBackboneSite = async function(peerId) {
     Log(`Detected backbone site: ${peerId}`);
     var localState  = {};
     var remoteState = {};
-    const client    = await ClientFromPool();
+    const client    = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
 
@@ -194,7 +194,7 @@ const onStateChangeBackbone = async function(peerId, stateKey, hash, data) {
         }
 
         const accessId = stateKey.substring(13);
-        const client = await ClientFromPool();
+        const client = await ClientFromPool('system');
         try {
             await client.query("BEGIN");
             await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port = $2, Lifecycle = 'new' " +
@@ -215,7 +215,7 @@ const onStateChangeBackbone = async function(peerId, stateKey, hash, data) {
 const getStateTlsBackboneSite = async function(siteId) {
     var hash = null;
     var data = null;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT TlsCertificates.ObjectName FROM InteriorSites " +
@@ -240,7 +240,7 @@ const getStateTlsBackboneSite = async function(siteId) {
 const getStateTlsMemberSite = async function(siteId) {
     var hash = null;
     var data = null;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT TlsCertificates.ObjectName FROM MemberSites " +
@@ -265,7 +265,7 @@ const getStateTlsMemberSite = async function(siteId) {
 const getStateTlsServer = async function(apid) {
     var hash = null;
     var data = null;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT TlsCertificates.ObjectName FROM BackboneAccessPoints " +
@@ -290,7 +290,7 @@ const getStateTlsServer = async function(apid) {
 const getStateAccessPoint = async function(apId) {
     var hash = null;
     var data = null;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT Kind, Bindhost FROM BackboneAccessPoints WHERE Id = $1", [apId]);
@@ -318,7 +318,7 @@ const getStateAccessPoint = async function(apId) {
 const getStateBackboneLink = async function(linkId) {
     var hash = null;
     var data = null;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT Cost, BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM InterRouterLinks " +
@@ -347,7 +347,7 @@ const getStateBackboneLink = async function(linkId) {
 const getStateMemberLink = async function(linkId) {
     var hash = null;
     var data = null;
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM EdgeLinks " +
@@ -408,7 +408,7 @@ const onNewMember = async function(peerId) {
     Log(`Detected member site: ${peerId}`);
     var localState  = {};
     var remoteState = {};
-    const client    = await ClientFromPool();
+    const client    = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
 
@@ -548,7 +548,7 @@ const onStateRequest = async function(peerId, stateKey) {
 }
 
 const onPing = async function(peerId) {
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const peer = peers[peerId];
@@ -586,7 +586,7 @@ export async function SiteCertificateChanged(certId) {
     //
     // Update the tls-site-<id> hash for the one affected site
     //
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT InteriorSites.Id, TlsCertificates.ObjectName FROM InteriorSites " +
@@ -613,7 +613,7 @@ export async function AccessCertificateChanged(certId) {
     //
     // Update the tls-server-<id> hashes for the one affected site
     //
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT BackboneAccessPoints.Id as apid, InteriorSites.Id, TlsCertificates.ObjectName FROM BackboneAccessPoints " +
@@ -642,7 +642,7 @@ export async function SiteIngressChanged(siteId, accessPointId) {
     // Update the access-<id> hash for the one affected site
     //
     if (peers[siteId]) {
-        const client = await ClientFromPool();
+        const client = await ClientFromPool('system');
         try {
             await client.query("BEGIN");
             const result = await client.query("SELECT Kind, BindHost, Certificate, Lifecycle FROM BackboneAccessPoints WHERE Id = $1", [accessPointId]);
@@ -705,7 +705,7 @@ export async function NewIngressAvailable(siteId) {
     //
     // Update the links/outgoing hash for each site that connects to the indicated site
     //
-    const client = await ClientFromPool();
+    const client = await ClientFromPool('system');
     try {
         const result = await client.query("SELECT ConnectingInteriorSite FROM InterRouterLinks WHERE ListeningInteriorSite = $1", [siteId]);
         for (const row of result.rows) {

--- a/console/src/App.js
+++ b/console/src/App.js
@@ -4,6 +4,7 @@ import AppHeader from './components/Header/Header';
 import Navigation from './components/Navigation/Navigation';
 import Dashboard from './pages/Dashboard/Dashboard';
 import Backbones from './pages/Network/Backbones/Backbones';
+import BackboneContext from './pages/Network/Backbones/BackboneContext';
 import BackboneDetail from './pages/Network/Backbones/BackboneDetail';
 import SiteDetail from './pages/Network/Backbones/SiteDetail';
 import VANs from './pages/Network/VANs/VANs';
@@ -24,8 +25,10 @@ function App() {
             <Routes>
               <Route path="/" element={<Dashboard />} />
               <Route path="/network/backbones" element={<Backbones />} />
-              <Route path="/network/backbones/:backboneId" element={<BackboneDetail />} />
-              <Route path="/network/backbones/:backboneId/sites/:siteId" element={<SiteDetail />} />
+              <Route path="/network/backbones/:backboneId" element={<BackboneContext />}>
+                <Route index element={<BackboneDetail />} />
+                <Route path="sites/:siteId" element={<SiteDetail />} />
+              </Route>
               <Route path="/network/vans" element={<VANs />} />
               <Route path="/network/tls" element={<TLS />} />
               <Route path="/compose/library" element={<Library />} />

--- a/console/src/components/Header/Header.js
+++ b/console/src/components/Header/Header.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import {
   Header,
   HeaderName,
   HeaderGlobalBar,
   HeaderGlobalAction,
+  OverflowMenu,
+  OverflowMenuItem,
 } from '@carbon/react';
 import { UserAvatar, Notification } from '@carbon/icons-react';
 
 const AppHeader = () => {
+  const [displayName, setDisplayName] = useState('');
+
+  useEffect(() => {
+    fetchDisplayName();
+  }, []);
+
+  const fetchDisplayName = async () => {
+    try {
+      const response = await fetch('/api/v1alpha1/user/profile');
+      const data = await response.json();
+      setDisplayName(data.name);
+    } catch (error) {
+      console.error('Error fetching display name:', error);
+    }
+  };
+
+  const handleLogout = useCallback(() => {
+    window.location.assign('/logout');
+  }, []);
+
   return (
     <Header aria-label="SkupperVMS">
       <HeaderName href="/" prefix="">
@@ -21,10 +43,16 @@ const AppHeader = () => {
           <Notification size={20} />
         </HeaderGlobalAction>
         <HeaderGlobalAction
-          aria-label="User Avatar"
+          aria-label="User Menu"
           tooltipAlignment="end"
         >
-          <UserAvatar size={20} />
+          <OverflowMenu renderIcon={() => <UserAvatar size={20} />} flipped>
+            <OverflowMenuItem style={{ color: 'black' }} itemText={displayName} disabled />
+            <OverflowMenuItem
+              itemText="Logout"
+              onClick={handleLogout}
+            />
+          </OverflowMenu>
         </HeaderGlobalAction>
       </HeaderGlobalBar>
     </Header>

--- a/console/src/components/OwnerGroupSelect/OwnerGroupSelect.js
+++ b/console/src/components/OwnerGroupSelect/OwnerGroupSelect.js
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+import { Select, SelectItem } from '@carbon/react';
+
+// Matches compose-web-app util.js OwnerGroupSelector: GET /api/v1alpha1/user/groups, then unset / public / groups.
+const OwnerGroupSelect = ({
+  id = 'owner-group-select',
+  labelText = 'Owner group',
+  value,
+  onChange,
+  disabled = false,
+  style,
+}) => {
+  const [groups, setGroups] = useState([]);
+  const [loadState, setLoadState] = useState('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await fetch('/api/v1alpha1/user/groups');
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const data = await res.json();
+        if (!cancelled) {
+          setGroups(Array.isArray(data) ? data : []);
+          setLoadState('ok');
+        }
+      } catch (err) {
+        console.error('Error fetching user groups:', err);
+        if (!cancelled) {
+          setGroups([]);
+          setLoadState('error');
+        }
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleChange = (e) => {
+    onChange(e.target.value);
+  };
+
+  const selectDisabled = disabled || loadState === 'loading';
+
+  return (
+    <Select
+      id={id}
+      labelText={labelText}
+      value={value}
+      onChange={handleChange}
+      disabled={selectDisabled}
+      helperText={
+        loadState === 'error'
+          ? 'Could not load your groups. You can still choose public or leave unset.'
+          : undefined
+      }
+      invalid={loadState === 'error'}
+      invalidText={loadState === 'error' ? 'Groups request failed' : undefined}
+      style={style}
+    >
+      <SelectItem value="" text="-- Select a group --" />
+      <SelectItem value="public" text="public" />
+      {groups.map((g) => (
+        <SelectItem key={g.id} value={g.id} text={g.name} />
+      ))}
+    </Select>
+  );
+};
+
+export default OwnerGroupSelect;

--- a/console/src/pages/Network/Backbones/BackboneContext.js
+++ b/console/src/pages/Network/Backbones/BackboneContext.js
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+import { Outlet, useParams } from 'react-router-dom';
+
+const BackboneContext = () => {
+  const { backboneId } = useParams();
+  const [backboneName, setBackboneName] = useState('');
+  const [backboneOwnerGroup, setBackboneOwnerGroup] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setBackboneName('');
+      setBackboneOwnerGroup('');
+      try {
+        const response = await fetch(`/api/v1alpha1/backbones/${backboneId}`);
+        if (!response.ok || cancelled) return;
+        const bb = await response.json();
+        setBackboneName(bb.name);
+        setBackboneOwnerGroup(bb.ownergroup);
+      } catch (err) {
+        console.error('Error loading backbone metadata:', err);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [backboneId]);
+
+  return (
+    <Outlet
+      context={{
+        backboneName,
+        backboneOwnerGroup,
+      }}
+    />
+  );
+};
+
+export default BackboneContext;

--- a/console/src/pages/Network/Backbones/BackboneDetail.js
+++ b/console/src/pages/Network/Backbones/BackboneDetail.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useOutletContext } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -13,31 +13,16 @@ import BackboneNetworkView from './BackboneNetworkView';
 
 const BackboneDetail = () => {
   const { backboneId } = useParams();
+  const { backboneName = '', backboneOwnerGroup = '' } = useOutletContext() || {};
   const [sites, setSites] = useState([]);
-  const [backboneName, setBackboneName] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [viewMode, setViewMode] = useState('list'); // 'list' or 'network'
 
   useEffect(() => {
     fetchSites();
-    fetchBackboneInfo();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backboneId]);
-
-  const fetchBackboneInfo = async () => {
-    try {
-      const response = await fetch('/api/v1alpha1/backbones');
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      const backbones = await response.json();
-      const backbone = backbones.find(b => b.id === backboneId);
-      if (backbone) {
-        setBackboneName(backbone.name);
-      }
-    } catch (err) {
-      console.error('Error fetching backbone info:', err);
-    }
-  };
 
   const fetchSites = async () => {
     try {
@@ -104,6 +89,7 @@ const BackboneDetail = () => {
           sites={sites}
           backboneName={backboneName}
           backboneId={backboneId}
+          backboneOwnerGroup={backboneOwnerGroup}
           onSiteCreated={fetchSites}
         />
       )}

--- a/console/src/pages/Network/Backbones/BackboneListView.js
+++ b/console/src/pages/Network/Backbones/BackboneListView.js
@@ -24,7 +24,13 @@ import {
 import { Add, TrashCan, Deploy } from '@carbon/icons-react';
 import SiteDeployment from './SiteDeployment';
 
-const BackboneListView = ({ sites, backboneName, backboneId, onSiteCreated }) => {
+const BackboneListView = ({
+  sites,
+  backboneName,
+  backboneId,
+  backboneOwnerGroup = '',
+  onSiteCreated,
+}) => {
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [siteName, setSiteName] = useState('');
@@ -79,6 +85,7 @@ const BackboneListView = ({ sites, backboneName, backboneId, onSiteCreated }) =>
         body: JSON.stringify({
           name: siteName.trim(),
           platform: selectedPlatform,
+          ownerGroup: backboneOwnerGroup,
         }),
       });
 

--- a/console/src/pages/Network/Backbones/Backbones.js
+++ b/console/src/pages/Network/Backbones/Backbones.js
@@ -22,6 +22,7 @@ import {
   IconButton,
 } from '@carbon/react';
 import { Add, TrashCan } from '@carbon/icons-react';
+import OwnerGroupSelect from '../../../components/OwnerGroupSelect/OwnerGroupSelect';
 
 const Backbones = () => {
   const navigate = useNavigate();
@@ -30,6 +31,7 @@ const Backbones = () => {
   const [error, setError] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [backboneName, setBackboneName] = useState('');
+  const [ownerGroup, setOwnerGroup] = useState('');
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -79,6 +81,7 @@ const Backbones = () => {
         },
         body: JSON.stringify({
           name: backboneName.trim(),
+          ownerGroup,
         }),
       });
 
@@ -88,6 +91,7 @@ const Backbones = () => {
 
       // Reset form and close modal
       setBackboneName('');
+      setOwnerGroup('');
       setIsModalOpen(false);
       
       // Refresh the backbones list
@@ -324,6 +328,7 @@ const Backbones = () => {
         onRequestClose={() => {
           setIsModalOpen(false);
           setBackboneName('');
+          setOwnerGroup('');
           setCreateError(null);
         }}
         onRequestSubmit={handleCreateBackbone}
@@ -346,6 +351,15 @@ const Backbones = () => {
           value={backboneName}
           onChange={(e) => setBackboneName(e.target.value)}
           disabled={isCreating}
+          style={{ marginBottom: '1rem' }}
+        />
+        <OwnerGroupSelect
+          id="backbone-owner-group"
+          labelText="Owner group"
+          value={ownerGroup}
+          onChange={setOwnerGroup}
+          disabled={isCreating}
+          style={{ marginBottom: '1rem' }}
         />
       </Modal>
 

--- a/console/src/pages/Network/Backbones/SiteDetail.js
+++ b/console/src/pages/Network/Backbones/SiteDetail.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useOutletContext } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -31,6 +31,7 @@ import { ArrowLeft, Add, TrashCan, Edit } from '@carbon/icons-react';
 const SiteDetail = () => {
   const { backboneId, siteId } = useParams();
   const navigate = useNavigate();
+  const { backboneOwnerGroup = '' } = useOutletContext() || {};
   const [site, setSite] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -252,7 +253,8 @@ const SiteDetail = () => {
       
       const payload = {
         connectingsite: siteId,
-        cost: linkCost
+        cost: linkCost,
+        ownerGroup: backboneOwnerGroup,
       };
 
       const response = await fetch(`/api/v1alpha1/accesspoints/${selectedPeerAP}/links`, {
@@ -376,6 +378,7 @@ const SiteDetail = () => {
       for (const kind of selectedApKinds) {
         const payload = {
           kind: kind,
+          ownerGroup: backboneOwnerGroup,
         };
 
         // Add optional fields only if exactly one kind is selected

--- a/console/src/pages/Network/VANs/VANs.js
+++ b/console/src/pages/Network/VANs/VANs.js
@@ -31,6 +31,7 @@ import {
   Link,
 } from '@carbon/react';
 import { Add, TrashCan, Gui, Deploy } from '@carbon/icons-react';
+import OwnerGroupSelect from '../../../components/OwnerGroupSelect/OwnerGroupSelect';
 
 const VANs = () => {
   const [vans, setVans] = useState([]);
@@ -41,6 +42,7 @@ const VANs = () => {
   const [error, setError] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [vanName, setVanName] = useState('');
+  const [ownerGroup, setOwnerGroup] = useState('');
   const [networkType, setNetworkType] = useState('external');
   const [startDate, setStartDate] = useState(new Date());
   const [startTimeValue, setStartTimeValue] = useState(new Date().toTimeString().slice(0, 5));
@@ -129,6 +131,7 @@ const VANs = () => {
       const payload = {
         name: vanName.trim(),
         nettype: networkType,
+        ownerGroup,
       };
 
       // Add optional fields only for tenant VANs
@@ -178,6 +181,7 @@ const VANs = () => {
 
       // Reset form and close modal
       setVanName('');
+      setOwnerGroup('');
       setNetworkType('external');
       setStartDate(new Date());
       setStartTimeValue(new Date().toTimeString().slice(0, 5));
@@ -561,6 +565,7 @@ const VANs = () => {
         onRequestClose={() => {
           setIsModalOpen(false);
           setVanName('');
+          setOwnerGroup('');
           setNetworkType('external');
           setStartDate(new Date());
           setStartTimeValue(new Date().toTimeString().slice(0, 5));
@@ -588,6 +593,15 @@ const VANs = () => {
           placeholder="Enter VAN name"
           value={vanName}
           onChange={(e) => setVanName(e.target.value)}
+          disabled={isCreating}
+          style={{ marginBottom: '1rem' }}
+        />
+
+        <OwnerGroupSelect
+          id="van-owner-group"
+          labelText="Owner group"
+          value={ownerGroup}
+          onChange={setOwnerGroup}
           disabled={isCreating}
           style={{ marginBottom: '1rem' }}
         />

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -537,6 +537,8 @@ CREATE POLICY group_access_backbones_policy
 ON Backbones
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
@@ -553,6 +555,8 @@ CREATE POLICY group_access_application_networks_policy
 ON ApplicationNetworks
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
@@ -569,6 +573,8 @@ CREATE POLICY group_access_library_blocks_policy
 ON LibraryBlocks
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
@@ -585,6 +591,8 @@ CREATE POLICY group_access_applications_policy
 ON Applications
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
@@ -601,6 +609,8 @@ CREATE POLICY group_access_deployed_applications_policy
 ON DeployedApplications
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
@@ -617,6 +627,8 @@ CREATE POLICY group_access_backbone_access_points_policy
 ON BackboneAccessPoints
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
@@ -633,6 +645,8 @@ CREATE POLICY group_access_interior_sites_policy
 ON InteriorSites
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
@@ -649,6 +663,8 @@ CREATE POLICY group_access_inter_router_links_policy
 ON InterRouterLinks
 FOR ALL
 USING (
+    OwnerGroup = 'public'
+    OR
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -76,6 +76,23 @@ CREATE TYPE DeploymentStateType AS ENUM ('not-ready', 'ready-bootstrap', 'ready-
 CREATE TYPE ApplicationNetworkType AS ENUM ('tenant', 'external');
 
 --
+-- Database roles for connection pooling and RLS control
+--
+-- app_user: Regular application users, subject to RLS policies
+-- app_system: System/background processes, bypasses RLS
+--
+
+\getenv APP_USER_PASSWORD APP_USER_PASSWORD
+\getenv APP_SYSTEM_PASSWORD APP_SYSTEM_PASSWORD
+
+CREATE ROLE app_user LOGIN PASSWORD :APP_USER_PASSWORD;
+CREATE ROLE app_system LOGIN PASSWORD :APP_SYSTEM_PASSWORD;
+
+-- Grant connect and usage permissions
+GRANT CONNECT ON DATABASE postgres TO app_user;
+GRANT CONNECT ON DATABASE postgres TO app_system;
+
+--
 -- Global configuration for Skupper-X
 --
 CREATE TABLE Configuration (
@@ -157,7 +174,7 @@ CREATE TABLE Backbones (
     Failure text,
     Certificate UUID REFERENCES TlsCertificates,
     Owner UUID REFERENCES UserIdentities,
-    OwnerGroups text ARRAY
+    OwnerGroup text 
 );
 
 --
@@ -237,7 +254,7 @@ CREATE TABLE ApplicationNetworks (
     Backbone UUID REFERENCES Backbones (Id) ON DELETE CASCADE,
     NetworkType ApplicationNetworkType,
     Owner UUID REFERENCES UserIdentities,
-    OwnerGroups text ARRAY,
+    OwnerGroup text,
     VanId text,
     StartTime timestamptz DEFAULT now(),
     EndTime timestamptz,
@@ -494,21 +511,6 @@ INSERT INTO InterfaceRoles (Name) VALUES
     ('request'), ('respond'),
     ('mount'),   ('manage');
 
--- Create System service account
-INSERT INTO UserIdentities (Id, KeycloakSub, DisplayName) 
-VALUES (
-    '00000000-0000-0000-0000-000000000001'::uuid,
-    'system:management-controller',
-    'System Service Account'
-) ON CONFLICT (KeycloakSub) DO NOTHING;
-
--- Function to check if the current user is the system user
-CREATE OR REPLACE FUNCTION is_system_user()
-RETURNS boolean AS $$
-BEGIN
-    RETURN current_setting('app.user_id', true)::uuid = '00000000-0000-0000-0000-000000000001'::uuid;
-END;
-$$ LANGUAGE plpgsql STABLE;
 
 -- Function to check if the current user is an admin
 CREATE OR REPLACE FUNCTION is_admin()
@@ -523,9 +525,7 @@ CREATE POLICY user_access_backbones_policy
 ON Backbones
 FOR ALL
 USING (
-    Owner = NULLIF(current_setting('app.user_id', true), '')::uuid 
-    OR 
-    is_system_user()
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
     OR 
     is_admin()
 );
@@ -534,16 +534,14 @@ CREATE POLICY group_access_backbones_policy
 ON Backbones
 FOR ALL
 USING (
-    (OwnerGroups && current_setting('app.user_groups', true)::text[])
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
 CREATE POLICY user_access_application_networks_policy
 ON ApplicationNetworks
 FOR ALL
 USING (
-    Owner = NULLIF(current_setting('app.user_id', true), '')::uuid 
-    OR 
-    is_system_user()
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
     OR 
     is_admin()
 );
@@ -552,17 +550,34 @@ CREATE POLICY group_access_application_networks_policy
 ON ApplicationNetworks
 FOR ALL
 USING (
-    (OwnerGroups && current_setting('app.user_groups', true)::text[])
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
 ALTER TABLE Backbones ENABLE ROW LEVEL SECURITY;
 ALTER TABLE ApplicationNetworks ENABLE ROW LEVEL SECURITY;
 
--- index owner and ownergroups columns for better performance
+-- Grant permissions to roles
+-- app_user gets standard permissions (subject to RLS)
+GRANT USAGE ON SCHEMA public TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+
+-- app_system bypass RLS (they have BYPASSRLS attribute)
+ALTER ROLE app_system BYPASSRLS;
+
+GRANT USAGE ON SCHEMA public TO app_system;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_system;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_system;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_system;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_system;
+
+-- index owner and ownergroup columns for better performance
 CREATE INDEX idx_backbones_owner ON Backbones (Owner);
-CREATE INDEX idx_backbones_ownergroups ON Backbones (OwnerGroups);
+CREATE INDEX idx_backbones_ownergroup ON Backbones (OwnerGroup);
 CREATE INDEX idx_application_networks_owner ON ApplicationNetworks (Owner);
-CREATE INDEX idx_application_networks_ownergroups ON ApplicationNetworks (OwnerGroups);
+CREATE INDEX idx_application_networks_ownergroup ON ApplicationNetworks (OwnerGroup);
 
 /*
 Notes:

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -110,13 +110,6 @@ CREATE TABLE Configuration (
 -- Users who have access to the service application
 --
 CREATE TABLE Users (
-    Id integer PRIMARY KEY,
-    DisplayName text,
-    Email text,
-    PasswordHash text
-);
-
-CREATE TABLE UserIdentities (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     KeycloakSub text UNIQUE NOT NULL,
     IsAdmin boolean DEFAULT false,
@@ -131,7 +124,7 @@ CREATE TABLE UserIdentities (
 --
 CREATE TABLE WebSessions (
     Id UUID PRIMARY KEY,
-    UserId integer REFERENCES Users ON DELETE CASCADE,
+    UserId UUID REFERENCES Users ON DELETE CASCADE,
     StartTime timestamptz DEFAULT CURRENT_TIMESTAMP,
     EndTime timestamptz
 );
@@ -173,7 +166,7 @@ CREATE TABLE Backbones (
     Lifecycle LifecycleType DEFAULT 'new',
     Failure text,
     Certificate UUID REFERENCES TlsCertificates,
-    Owner UUID REFERENCES UserIdentities,
+    Owner UUID REFERENCES Users,
     OwnerGroup text 
 );
 
@@ -253,7 +246,7 @@ CREATE TABLE ApplicationNetworks (
 
     Backbone UUID REFERENCES Backbones (Id) ON DELETE CASCADE,
     NetworkType ApplicationNetworkType,
-    Owner UUID REFERENCES UserIdentities,
+    Owner UUID REFERENCES Users,
     OwnerGroup text,
     VanId text,
     StartTime timestamptz DEFAULT now(),
@@ -429,7 +422,7 @@ CREATE TABLE LibraryBlocks (
     Config      text,
     Interfaces  text,
     SpecBody    text,
-    Owner       UUID REFERENCES UserIdentities(Id),
+    Owner       UUID REFERENCES Users,
     OwnerGroup  text
 );
 
@@ -441,7 +434,7 @@ CREATE TABLE Applications (
     Lifecycle  ApplicationLifecycle DEFAULT 'created',
     BuildLog   text,
     Derivative text,
-    Owner       UUID REFERENCES UserIdentities(Id),
+    Owner       UUID REFERENCES Users,
     OwnerGroup  text
 );
 
@@ -472,7 +465,7 @@ CREATE TABLE DeployedApplications (
     Van         UUID REFERENCES ApplicationNetworks(Id),
     Lifecycle   DeploymentLifecycle DEFAULT 'created',
     DeployLog   text,
-    Owner       UUID REFERENCES UserIdentities(Id),
+    Owner       UUID REFERENCES Users,
     OwnerGroup  text
 );
 
@@ -491,8 +484,6 @@ CREATE TABLE SiteData (
 --
 INSERT INTO Configuration (Id, RootIssuer, DefaultCaExpiration, DefaultCertExpiration, BackboneCaExpiration, SiteDataplaneImage, SiteControllerImage, CertOrganization)
     VALUES (0, 'skupperx-root', '30 days', '1 week', '1 year', 'quay.io/tedlross/skupper-router:multi-van', 'quay.io/tedlross/skupperx-site-controller:skx-0.2.0', 'enterprise.com');
-INSERT INTO Users (Id, DisplayName, Email, PasswordHash) VALUES (1, 'Ted Ross', 'tross@redhat.com', '18f4e1168a37a7a2d5ac2bff043c12c862d515a2cbb9ab5fe207ab4ef235e129c1a475ffca25c4cb3831886158c3836664d489c98f68c0ac7af5a8f6d35e04fa');
-INSERT INTO WebSessions (Id, UserId) VALUES (gen_random_uuid(), 1);
 
 INSERT INTO TargetPlatforms (ShortName, LongName) VALUES
     ('sk2',      'Kubernetes/OpenShift'),

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -99,6 +99,16 @@ CREATE TABLE Users (
     PasswordHash text
 );
 
+CREATE TABLE UserIdentities (
+    Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    KeycloakSub text UNIQUE NOT NULL,
+    IsAdmin boolean DEFAULT false,
+    Email text,
+    DisplayName text,
+    CreatedAt timestamptz DEFAULT CURRENT_TIMESTAMP,
+    LastSeen timestamptz DEFAULT CURRENT_TIMESTAMP
+);
+
 --
 -- Tracking of user login sessions in the service application
 --
@@ -145,7 +155,9 @@ CREATE TABLE Backbones (
     Name text UNIQUE,
     Lifecycle LifecycleType DEFAULT 'new',
     Failure text,
-    Certificate UUID REFERENCES TlsCertificates
+    Certificate UUID REFERENCES TlsCertificates,
+    Owner UUID REFERENCES UserIdentities,
+    OwnerGroups text ARRAY
 );
 
 --
@@ -224,7 +236,8 @@ CREATE TABLE ApplicationNetworks (
 
     Backbone UUID REFERENCES Backbones (Id) ON DELETE CASCADE,
     NetworkType ApplicationNetworkType,
-    Owner integer REFERENCES Users,
+    Owner UUID REFERENCES UserIdentities,
+    OwnerGroups text ARRAY,
     VanId text,
     StartTime timestamptz DEFAULT now(),
     EndTime timestamptz,
@@ -481,7 +494,75 @@ INSERT INTO InterfaceRoles (Name) VALUES
     ('request'), ('respond'),
     ('mount'),   ('manage');
 
+-- Create System service account
+INSERT INTO UserIdentities (Id, KeycloakSub, DisplayName) 
+VALUES (
+    '00000000-0000-0000-0000-000000000001'::uuid,
+    'system:management-controller',
+    'System Service Account'
+) ON CONFLICT (KeycloakSub) DO NOTHING;
 
+-- Function to check if the current user is the system user
+CREATE OR REPLACE FUNCTION is_system_user()
+RETURNS boolean AS $$
+BEGIN
+    RETURN current_setting('app.user_id', true)::uuid = '00000000-0000-0000-0000-000000000001'::uuid;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Function to check if the current user is an admin
+CREATE OR REPLACE FUNCTION is_admin()
+RETURNS boolean AS $$
+BEGIN
+    RETURN current_setting('app.is_admin', true)::boolean;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- RLS policies
+CREATE POLICY user_access_backbones_policy
+ON Backbones
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('app.user_id', true), '')::uuid 
+    OR 
+    is_system_user()
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_backbones_policy
+ON Backbones
+FOR ALL
+USING (
+    (OwnerGroups && current_setting('app.user_groups', true)::text[])
+);
+
+CREATE POLICY user_access_application_networks_policy
+ON ApplicationNetworks
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('app.user_id', true), '')::uuid 
+    OR 
+    is_system_user()
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_application_networks_policy
+ON ApplicationNetworks
+FOR ALL
+USING (
+    (OwnerGroups && current_setting('app.user_groups', true)::text[])
+);
+
+ALTER TABLE Backbones ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ApplicationNetworks ENABLE ROW LEVEL SECURITY;
+
+-- index owner and ownergroups columns for better performance
+CREATE INDEX idx_backbones_owner ON Backbones (Owner);
+CREATE INDEX idx_backbones_ownergroups ON Backbones (OwnerGroups);
+CREATE INDEX idx_application_networks_owner ON ApplicationNetworks (Owner);
+CREATE INDEX idx_application_networks_ownergroups ON ApplicationNetworks (OwnerGroups);
 
 /*
 Notes:

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -85,8 +85,8 @@ CREATE TYPE ApplicationNetworkType AS ENUM ('tenant', 'external');
 \getenv APP_USER_PASSWORD APP_USER_PASSWORD
 \getenv APP_SYSTEM_PASSWORD APP_SYSTEM_PASSWORD
 
-CREATE ROLE app_user LOGIN PASSWORD :APP_USER_PASSWORD;
-CREATE ROLE app_system LOGIN PASSWORD :APP_SYSTEM_PASSWORD;
+CREATE ROLE app_user LOGIN PASSWORD :'APP_USER_PASSWORD';
+CREATE ROLE app_system LOGIN PASSWORD :'APP_SYSTEM_PASSWORD';
 
 -- Grant connect and usage permissions
 GRANT CONNECT ON DATABASE postgres TO app_user;
@@ -428,7 +428,9 @@ CREATE TABLE LibraryBlocks (
     Inherit     text,
     Config      text,
     Interfaces  text,
-    SpecBody    text
+    SpecBody    text,
+    Owner       UUID REFERENCES UserIdentities(Id),
+    OwnerGroup  text
 );
 
 CREATE TABLE Applications (
@@ -438,7 +440,9 @@ CREATE TABLE Applications (
     RootBlock  UUID REFERENCES LibraryBlocks(Id),
     Lifecycle  ApplicationLifecycle DEFAULT 'created',
     BuildLog   text,
-    Derivative text
+    Derivative text,
+    Owner       UUID REFERENCES UserIdentities(Id),
+    OwnerGroup  text
 );
 
 CREATE TABLE InstanceBlocks (
@@ -467,7 +471,9 @@ CREATE TABLE DeployedApplications (
     Application UUID REFERENCES Applications(Id),
     Van         UUID REFERENCES ApplicationNetworks(Id),
     Lifecycle   DeploymentLifecycle DEFAULT 'created',
-    DeployLog   text
+    DeployLog   text,
+    Owner       UUID REFERENCES UserIdentities(Id),
+    OwnerGroup  text
 );
 
 --
@@ -516,7 +522,7 @@ INSERT INTO InterfaceRoles (Name) VALUES
 CREATE OR REPLACE FUNCTION is_admin()
 RETURNS boolean AS $$
 BEGIN
-    RETURN current_setting('app.is_admin', true)::boolean;
+    RETURN current_setting('session.is_admin', true)::boolean;
 END;
 $$ LANGUAGE plpgsql STABLE;
 
@@ -553,8 +559,59 @@ USING (
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
+CREATE POLICY user_access_library_blocks_policy
+ON LibraryBlocks
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_library_blocks_policy
+ON LibraryBlocks
+FOR ALL
+USING (
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
+);
+
+CREATE POLICY user_access_applications_policy
+ON Applications
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_applications_policy
+ON Applications
+FOR ALL
+USING (
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
+);
+
+CREATE POLICY user_access_deployed_applications_policy
+ON DeployedApplications
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_deployed_applications_policy
+ON DeployedApplications
+FOR ALL
+USING (
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
+);
+
 ALTER TABLE Backbones ENABLE ROW LEVEL SECURITY;
 ALTER TABLE ApplicationNetworks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE LibraryBlocks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE Applications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE DeployedApplications ENABLE ROW LEVEL SECURITY;
 
 -- Grant permissions to roles
 -- app_user gets standard permissions (subject to RLS)
@@ -578,6 +635,12 @@ CREATE INDEX idx_backbones_owner ON Backbones (Owner);
 CREATE INDEX idx_backbones_ownergroup ON Backbones (OwnerGroup);
 CREATE INDEX idx_application_networks_owner ON ApplicationNetworks (Owner);
 CREATE INDEX idx_application_networks_ownergroup ON ApplicationNetworks (OwnerGroup);
+CREATE INDEX idx_library_blocks_owner ON LibraryBlocks (Owner);
+CREATE INDEX idx_library_blocks_ownergroup ON LibraryBlocks (OwnerGroup);
+CREATE INDEX idx_applications_owner ON Applications (Owner);
+CREATE INDEX idx_applications_ownergroup ON Applications (OwnerGroup);
+CREATE INDEX idx_deployed_applications_owner ON DeployedApplications (Owner);
+CREATE INDEX idx_deployed_applications_ownergroup ON DeployedApplications (OwnerGroup);
 
 /*
 Notes:

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -190,7 +190,9 @@ CREATE TABLE InteriorSites (
     FirstActiveTime timestamptz,
     LastHeartbeat timestamptz,
 
-    Backbone UUID REFERENCES Backbones
+    Backbone UUID REFERENCES Backbones,
+    Owner UUID REFERENCES Users,
+    OwnerGroup text
 );
 
 --
@@ -210,7 +212,9 @@ CREATE TABLE BackboneAccessPoints (
     Kind AccessPointType,
     BindHost text DEFAULT '',
     InteriorSite UUID REFERENCES InteriorSites ON DELETE CASCADE,
-    GlobalAccess UUID REFERENCES BackboneAccessPoints
+    GlobalAccess UUID REFERENCES BackboneAccessPoints,
+    Owner UUID REFERENCES Users,
+    OwnerGroup text
 );
 
 --
@@ -220,7 +224,9 @@ CREATE TABLE InterRouterLinks (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     AccessPoint UUID REFERENCES BackboneAccessPoints ON DELETE CASCADE,
     ConnectingInteriorSite UUID REFERENCES InteriorSites ON DELETE CASCADE,
-    Cost integer DEFAULT 1
+    Cost integer DEFAULT 1,
+    Owner UUID REFERENCES Users,
+    OwnerGroup text
 );
 
 --
@@ -598,11 +604,62 @@ USING (
     OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
 );
 
+CREATE POLICY user_access_backbone_access_points_policy
+ON BackboneAccessPoints
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_backbone_access_points_policy
+ON BackboneAccessPoints
+FOR ALL
+USING (
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
+);
+
+CREATE POLICY user_access_interior_sites_policy
+ON InteriorSites
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_interior_sites_policy
+ON InteriorSites
+FOR ALL
+USING (
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
+);
+
+CREATE POLICY user_access_inter_router_links_policy
+ON InterRouterLinks
+FOR ALL
+USING (
+    Owner = NULLIF(current_setting('session.user_id', true), '')::uuid 
+    OR 
+    is_admin()
+);
+
+CREATE POLICY group_access_inter_router_links_policy
+ON InterRouterLinks
+FOR ALL
+USING (
+    OwnerGroup = ANY(current_setting('session.user_groups', true)::text[])
+);
+
 ALTER TABLE Backbones ENABLE ROW LEVEL SECURITY;
 ALTER TABLE ApplicationNetworks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE LibraryBlocks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE Applications ENABLE ROW LEVEL SECURITY;
 ALTER TABLE DeployedApplications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE BackboneAccessPoints ENABLE ROW LEVEL SECURITY;
+ALTER TABLE InteriorSites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE InterRouterLinks ENABLE ROW LEVEL SECURITY;
 
 -- Grant permissions to roles
 -- app_user gets standard permissions (subject to RLS)
@@ -632,6 +689,12 @@ CREATE INDEX idx_applications_owner ON Applications (Owner);
 CREATE INDEX idx_applications_ownergroup ON Applications (OwnerGroup);
 CREATE INDEX idx_deployed_applications_owner ON DeployedApplications (Owner);
 CREATE INDEX idx_deployed_applications_ownergroup ON DeployedApplications (OwnerGroup);
+CREATE INDEX idx_backbone_access_points_owner ON BackboneAccessPoints (Owner);
+CREATE INDEX idx_backbone_access_points_ownergroup ON BackboneAccessPoints (OwnerGroup);
+CREATE INDEX idx_interior_sites_owner ON InteriorSites (Owner);
+CREATE INDEX idx_interior_sites_ownergroup ON InteriorSites (OwnerGroup);
+CREATE INDEX idx_inter_router_links_owner ON InterRouterLinks (Owner);
+CREATE INDEX idx_inter_router_links_ownergroup ON InterRouterLinks (OwnerGroup);
 
 /*
 Notes:

--- a/scripts/drop.sql
+++ b/scripts/drop.sql
@@ -37,6 +37,7 @@ DROP TABLE TlsCertificates;
 DROP TABLE WebSessions;
 DROP TABLE Users;
 DROP TABLE Configuration;
+DROP TABLE UserIdentities;
 
 DROP TYPE BlockAllocation;
 DROP TYPE BlockBodyStyle;

--- a/scripts/drop.sql
+++ b/scripts/drop.sql
@@ -47,4 +47,11 @@ DROP TYPE AccessPointType;
 DROP TYPE CertificateRequestType;
 DROP TYPE LifecycleType;
 DROP TYPE DeploymentStateType;
-DROP TYPE ApplicationNetworkType;
+DROP TYPE ApplicationNetworkType;;
+
+DROP OWNED BY app_user;
+DROP ROLE app_user;
+DROP OWNED BY app_system;
+DROP ROLE app_system;
+
+DROP FUNCTION is_admin;

--- a/scripts/drop.sql
+++ b/scripts/drop.sql
@@ -37,7 +37,6 @@ DROP TABLE TlsCertificates;
 DROP TABLE WebSessions;
 DROP TABLE Users;
 DROP TABLE Configuration;
-DROP TABLE UserIdentities;
 
 DROP TYPE BlockAllocation;
 DROP TYPE BlockBodyStyle;


### PR DESCRIPTION
Current changes:

- initialized keycloak to enforce user authentication to use the console and block certain api endpoints to only allow specific realm roles
- enforce RLS on certain database tables (currently backbones and applicationnetworks) to allow users to access only rows they either created or someone in one of their groups created
- added wrapper function for database queries to always set necessary postgres session variables in order to use tables with RLS enabled
- created new user table to map keycloak user id's to postgres user uuids (postgres uuids are used for RLS enforcement)
- added system user in the postgres database to allow for the app to still make database queries outside the context of the api and RLS


Some thoughts about where to go from here:
- looking into switching from using a system user for these system calls to creating a separate database role that can bypass RLS and using separate connection pools for system generated database queries vs user generated queries
- will need to discuss how to properly configure keycloak and postgres RLS policies to properly allow users to access resources created by their group without accidentally accessing something created by someone in multiple groups that happens to overlap
- make some efficiency improvements (adding where clauses to queries so were not solely relying on RLS to filter returned rows, maybe cache user id for something like 5 minutes to limit number of queries)