### PR TITLE
push controller images on push to main

### DIFF
--- a/.github/workflows/publish-controller-images.yml
+++ b/.github/workflows/publish-controller-images.yml
@@ -38,11 +38,11 @@ jobs:
         with:
           context: .
           file: Containerfile
-          target: skupperx-management-controller
+          target: vms-management-controller
           push: true
           tags: |
-            ${{ env.IMAGE_PREFIX }}/skupperx-management-controller:latest
-            ${{ env.IMAGE_PREFIX }}/skupperx-management-controller:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}/vms-management-controller:latest
+            ${{ env.IMAGE_PREFIX }}/vms-management-controller:${{ github.sha }}
           cache-from: type=gha,scope=management-controller
           cache-to: type=gha,mode=max,scope=management-controller
 
@@ -51,10 +51,10 @@ jobs:
         with:
           context: .
           file: Containerfile
-          target: skupperx-site-controller
+          target: vms-site-controller
           push: true
           tags: |
-            ${{ env.IMAGE_PREFIX }}/skupperx-site-controller:latest
-            ${{ env.IMAGE_PREFIX }}/skupperx-site-controller:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}/vms-site-controller:latest
+            ${{ env.IMAGE_PREFIX }}/vms-site-controller:${{ github.sha }}
           cache-from: type=gha,scope=site-controller
           cache-to: type=gha,mode=max,scope=site-controller

--- a/.github/workflows/publish-controller-images.yml
+++ b/.github/workflows/publish-controller-images.yml
@@ -42,7 +42,6 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/vms-management-controller:latest
-            ${{ env.IMAGE_PREFIX }}/vms-management-controller:${{ github.sha }}
           cache-from: type=gha,scope=management-controller
           cache-to: type=gha,mode=max,scope=management-controller
 
@@ -55,6 +54,5 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/vms-site-controller:latest
-            ${{ env.IMAGE_PREFIX }}/vms-site-controller:${{ github.sha }}
           cache-from: type=gha,scope=site-controller
           cache-to: type=gha,mode=max,scope=site-controller

--- a/.github/workflows/publish-controller-images.yml
+++ b/.github/workflows/publish-controller-images.yml
@@ -1,0 +1,60 @@
+name: Publish controller images
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-controller-images-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_PREFIX: quay.io/skupper
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push management-controller
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile
+          target: skupperx-management-controller
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/skupperx-management-controller:latest
+            ${{ env.IMAGE_PREFIX }}/skupperx-management-controller:${{ github.sha }}
+          cache-from: type=gha,scope=management-controller
+          cache-to: type=gha,mode=max,scope=management-controller
+
+      - name: Build and push site-controller
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile
+          target: skupperx-site-controller
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/skupperx-site-controller:latest
+            ${{ env.IMAGE_PREFIX }}/skupperx-site-controller:${{ github.sha }}
+          cache-from: type=gha,scope=site-controller
+          cache-to: type=gha,mode=max,scope=site-controller

--- a/Containerfile
+++ b/Containerfile
@@ -68,7 +68,7 @@ RUN pnpm --filter "@skupperx/management-controller" deploy --legacy --prod /depl
 RUN cd components/vms-web-app && npm install && npm run build && cp -r ./build /deployed/vms-web-app
 
 # Production image - management-controller
-FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS skupperx-management-controller
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS vms-management-controller
 
 RUN microdnf -y install nodejs shadow-utils && \
     microdnf clean all
@@ -94,7 +94,7 @@ COPY components/site-controller/ ./components/site-controller/
 RUN pnpm --filter "@skupperx/site-controller" deploy --legacy --prod /deployed/site-controller
 
 # Production image - site-controller
-FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS skupperx-site-controller
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS vms-site-controller
 
 RUN microdnf -y install nodejs shadow-utils jq && \
     microdnf clean all

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -489,7 +489,7 @@ CREATE TABLE SiteData (
 -- Pre-populate the database with some test data.
 --
 INSERT INTO Configuration (Id, RootIssuer, DefaultCaExpiration, DefaultCertExpiration, BackboneCaExpiration, SiteDataplaneImage, SiteControllerImage, CertOrganization)
-    VALUES (0, 'skupperx-root', '30 days', '1 week', '1 year', 'quay.io/tedlross/skupper-router:multi-van', 'quay.io/tedlross/skupperx-site-controller:skx-0.2.0', 'enterprise.com');
+    VALUES (0, 'skupperx-root', '30 days', '1 week', '1 year', 'quay.io/tedlross/skupper-router:multi-van', 'quay.io/skupper/skupperx-site-controller:latest', 'enterprise.com');
 
 INSERT INTO TargetPlatforms (ShortName, LongName) VALUES
     ('sk2',      'Kubernetes/OpenShift'),

--- a/scripts/db-setup.sql
+++ b/scripts/db-setup.sql
@@ -489,7 +489,7 @@ CREATE TABLE SiteData (
 -- Pre-populate the database with some test data.
 --
 INSERT INTO Configuration (Id, RootIssuer, DefaultCaExpiration, DefaultCertExpiration, BackboneCaExpiration, SiteDataplaneImage, SiteControllerImage, CertOrganization)
-    VALUES (0, 'skupperx-root', '30 days', '1 week', '1 year', 'quay.io/tedlross/skupper-router:multi-van', 'quay.io/skupper/skupperx-site-controller:latest', 'enterprise.com');
+    VALUES (0, 'skupperx-root', '30 days', '1 week', '1 year', 'quay.io/tedlross/skupper-router:multi-van', 'quay.io/skupper/vms-site-controller:latest', 'enterprise.com');
 
 INSERT INTO TargetPlatforms (ShortName, LongName) VALUES
     ('sk2',      'Kubernetes/OpenShift'),

--- a/yaml/management-controller.yaml
+++ b/yaml/management-controller.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: skupperx-management-controller
       containers:
         - name: skupperx-management-controller
-          image: quay.io/skupper/skupperx-management-controller:latest
+          image: quay.io/skupper/vms-management-controller:latest
           imagePullPolicy: "Always"
           ports:
             - containerPort: 8085

--- a/yaml/management-controller.yaml
+++ b/yaml/management-controller.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: skupperx-management-controller
       containers:
         - name: skupperx-management-controller
-          image: quay.io/jpadovano/skupperx-management-controller:skx-0.3.0
+          image: quay.io/skupper/skupperx-management-controller:latest
           imagePullPolicy: "Always"
           ports:
             - containerPort: 8085


### PR DESCRIPTION
This is a Github workflow to build and push the management and site controller images to our quay.io/skupper org on push/pr merges into main. If this looks like the correct place to keep these images, we would need to create a quay robot account and store the credentials in a github secret in this repo as well as create those image repos in quay. It does not look like I currently have access to the quay skupper org, so I would either need to be added to that or have someone with org permissions add those. 