### PR TITLE
redirect all unauthenticated requests to keycloak login

### DIFF
--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -678,6 +678,9 @@ export async function Start(is_standalone) {
     userApi.Initialize(router, keycloak);
     compose.ApiInit(router, keycloak);
 
+    // route any unauthenticated requests to the login page (catches SPA navigation requests)
+    router.get('*', keycloak.protect());
+
     const server = app.listen(API_PORT, () => {
         let host = server.address().address;
         let port = server.address().port;


### PR DESCRIPTION
Route all SPA requests to keycloak login if user is unauthenticated

Fixes #81 