### PR TITLE
James colo sync

### DIFF
--- a/charts/helmfile/resources/db-setup.sql
+++ b/charts/helmfile/resources/db-setup.sql
@@ -216,7 +216,8 @@ CREATE TABLE BackboneAccessPoints (
     InteriorSite UUID REFERENCES InteriorSites ON DELETE CASCADE,
     GlobalAccess UUID REFERENCES BackboneAccessPoints,
     Owner UUID REFERENCES Users,
-    OwnerGroup text
+    OwnerGroup text,
+    AccessType text
 );
 
 --
@@ -753,4 +754,3 @@ Notes:
   - (DONE) Consider issuing a certificate per backbone-access point that contains the hostname of the access point.
 
 */
-

--- a/charts/management-server/templates/_helpers.tpl
+++ b/charts/management-server/templates/_helpers.tpl
@@ -60,3 +60,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+ClusterRole / ClusterRoleBinding name (<= 63 chars).
+*/}}
+{{- define "management-server.clusterRbacName" -}}
+{{- $fn := include "management-server.fullname" . | trunc 54 | trimSuffix "-" -}}
+{{- printf "%s-cluster" $fn -}}
+{{- end }}

--- a/charts/management-server/templates/rbac.yaml
+++ b/charts/management-server/templates/rbac.yaml
@@ -58,9 +58,7 @@ rules:
     resources:
       - namespaces
     verbs:
-      - get
       - list
-      - watch
       - create
       - delete
   - apiGroups:

--- a/charts/management-server/templates/rbac.yaml
+++ b/charts/management-server/templates/rbac.yaml
@@ -53,7 +53,6 @@ metadata:
     {{- include "management-server.labels" . | nindent 4 }}
     application: skupperx
 rules:
-  # Colocated namespaces (colo-sync)
   - apiGroups:
       - ""
     resources:
@@ -64,7 +63,6 @@ rules:
       - watch
       - create
       - delete
-  # Resources deployed into target namespaces (ApplyObject)
   - apiGroups:
       - ""
     resources:
@@ -92,7 +90,6 @@ rules:
       - update
       - patch
       - delete
-  # Required to create/update site Role / RoleBinding (escalation: hold ≥ granted verbs)
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -106,7 +103,6 @@ rules:
       - update
       - patch
       - delete
-  # Match BackboneRole() + Network CR (plural: networks) + NetworkAccess / RouterAccess
   - apiGroups:
       - skupper.io
     resources:

--- a/charts/management-server/templates/rbac.yaml
+++ b/charts/management-server/templates/rbac.yaml
@@ -44,3 +44,98 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "management-server.serviceAccountName" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "management-server.clusterRbacName" . }}
+  labels:
+    {{- include "management-server.labels" . | nindent 4 }}
+    application: skupperx
+rules:
+  # Colocated namespaces (colo-sync)
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  # Resources deployed into target namespaces (ApplyObject)
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - secrets
+      - configmaps
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Required to create/update site Role / RoleBinding (escalation: hold ≥ granted verbs)
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Match BackboneRole() + Network CR (plural: networks) + NetworkAccess / RouterAccess
+  - apiGroups:
+      - skupper.io
+    resources:
+      - sites
+      - links
+      - networks
+      - networkaccesses
+      - routeraccesses
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "management-server.clusterRbacName" . }}
+  labels:
+    {{- include "management-server.labels" . | nindent 4 }}
+    application: skupperx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "management-server.clusterRbacName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "management-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -26,6 +26,7 @@ import { Log } from '@skupperx/modules/log'
 import { ManageIngressAdded, LinkAddedOrDeleted, ManageIngressDeleted } from './site-deployment-state.js';
 import { ValidateAndNormalizeFields, IsValidUuid, UniquifyName } from '@skupperx/modules/util';
 import { WatchNotify } from './watch-server.js';
+import { processColoBackbones } from './colo-sync.js';
 
 const API_PREFIX   = '/api/v1alpha1/';
 const INGRESS_LIST = ['claim', 'peer', 'member', 'manage'];
@@ -54,8 +55,8 @@ const createBackbone = async function(req, res) {
                     `VALUES ('co-located', 'sk2', true, $1, $2, $3) RETURNING Id`,
                     [backboneId, userInfo.userId, norm.ownerGroup]);
                     siteId = site_result.rows[0].id;
-                    const ap_result = await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite, Owner, OwnerGroup) ` +
-                            `VALUES ('manage', 'manage', $1, $2, $3) RETURNING Id`,
+                    const ap_result = await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite, Owner, OwnerGroup, AccessType) ` +
+                            `VALUES ('manage', 'manage', $1, $2, $3, 'local') RETURNING Id`,
                             [siteId, userInfo.userId, norm.ownerGroup]);
                     apId = ap_result.rows[0].id;
                 }
@@ -65,6 +66,7 @@ const createBackbone = async function(req, res) {
             await WatchNotify('Backbones', backboneId);
             if (!!siteId) await WatchNotify('InteriorSites', siteId);
             if (!!apId) await WatchNotify('BackboneAccessPoints', apId);
+            await processColoBackbones()
         } catch (error) {
             returnStatus = 500;
             res.status(returnStatus).send(error.message);
@@ -492,6 +494,7 @@ const deleteBackbone = async function(req, res) {
         });
         res.status(returnStatus).end();
         await WatchNotify('Backbones', bid);
+        await processColoBackbones()
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.message);

--- a/components/management-controller/src/colo-sync.js
+++ b/components/management-controller/src/colo-sync.js
@@ -1,0 +1,186 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+/**
+ * This module is responsible for synchronizing the state of co-located namespaces and sites.
+ * The database is the source of truth for the state of the co-located namespaces and sites.
+ * The Kubernetes state will be reconciled with the database state if they are out of sync.
+ */
+
+import * as kube from "@skupperx/modules/kube"
+import { Log } from "@skupperx/modules/log"
+import { ClientFromPool } from "./db.js"
+import { META_ANNOTATION_SKUPPERX_CONTROLLED } from "@skupperx/modules/common"
+import yaml from 'js-yaml'
+import * as util from "@skupperx/modules/util"
+import * as resourceTemplates from "./resource-templates.js"
+import * as sync from "./sync-management.js"
+import * as common from "@skupperx/modules/common"
+
+let client
+
+/**
+ * Start the colo sync module
+ * @returns {Promise<void>}
+ */
+export async function Start() {
+    Log("[Colo Sync Module Started]")
+    client = await ClientFromPool('system')
+    // sync k8s state with database state on startup and every 60 seconds thereafter (additionally on backbone creation and deletion)
+    setInterval(async () => {
+        try {
+            await processColoBackbones()
+        } catch (err) {
+            Log(`[colo-sync] Error in scheduled colo backbone processing: ${err.stack || err}`)
+        }
+    }, 60000)
+}
+
+/**
+ * Process colo backbones and reconcile namespaces
+ * @returns {Promise<void>}
+ */
+export async function processColoBackbones() {
+    // get all backbones with colo namespaces
+    const coloBackbones = await client.query(`SELECT Id, CoLocatedNamespace FROM Backbones WHERE NULLIF(CoLocatedNamespace, '') IS NOT NULL`).then(res => res.rows)
+    // sync k8s state with database state
+    if (coloBackbones.length > 0) {
+        await reconcileNamespaces(coloBackbones)
+    }
+}
+
+
+/**
+ * Reconcile Kubernetes namespaces for the colo backbones
+ * @param {Array<Object>} coloBackbones - The colo backbones with their colo namespaces
+ * @returns {Promise<void>}
+ */
+async function reconcileNamespaces(coloBackbones) {
+    const existingNamespaces = await kube.GetNamespaces().then(namespace => namespace.items.map(ns => ({name: ns.metadata.name, annotations: ns.metadata.annotations})))
+    const coloNamespaces = new Set(coloBackbones.map(bb => bb.colocatednamespace))
+    // create colocated namespaces if they don't exist on the cluster
+    for (const bb of coloBackbones) {
+        if (!existingNamespaces.some(existingNs => existingNs.name === bb.colocatednamespace)) {
+            await deployColo(bb.id, bb.colocatednamespace)
+        }
+    }
+    
+    const vmsManagedNamespaces = existingNamespaces.filter(ns => ns.annotations?.[META_ANNOTATION_SKUPPERX_CONTROLLED] == "true").map(ns => ns.name)
+    // delete vms managed colocated namespaces if they are not in the database 
+    for (const ns of vmsManagedNamespaces) {
+        if (!coloNamespaces.has(ns)) {
+            Log(`[colo-sync] deleting namespace ${ns}`)
+            await kube.deleteNamespace(ns)
+        }
+    }
+}
+
+/**
+ * Deploy a colo namespace and site
+ * @param {string} ns - The namespace to deploy
+ * @returns {Promise<void>}
+ */
+async function deployColo(backboneId, ns) {
+    Log(`[colo-sync] deploying namespace ${ns}`)
+    await kube.createNamespace(ns)
+
+    Log(`[colo sync] deploying site in namespace ${ns}`)
+    await deploySite(backboneId, ns)
+}
+
+/**
+ * Deploy a site in the colo namespace
+ * @param {string} ns - The namespace to deploy the site in
+ * @returns {Promise<void>}
+ */
+async function deploySite(backboneId, ns) {
+    const siteId = await client.query(`SELECT Id FROM InteriorSites WHERE Backbone = $1 AND CoLocated = true`, [backboneId]).then(res => res.rows[0]?.id)
+    // Poll the db against the InteriorSites table for this siteId, waiting for lifecycle='ready'
+    // Poll with timeout (60 seconds max)
+    const maxWaitMs = 60000;
+    const pollIntervalMs = 1000;
+    let waitedMs = 0;
+    while (true) {
+        const pollResult = await client.query(
+            "SELECT Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1 LIMIT 1",
+            [siteId]
+        );
+        if (pollResult.rowCount === 0) {
+            throw new Error(`InteriorSite with id ${siteId} not found`);
+        }
+        if (pollResult.rows[0].lifecycle === 'ready' && pollResult.rows[0].deploymentstate !== 'not-ready') {
+            break;
+        }
+        if (waitedMs >= maxWaitMs) {
+            throw new Error(`Timeout: InteriorSite ${siteId} did not become ready after ${maxWaitMs / 1000} seconds.`);
+        }
+        // sleep for pollIntervalMs
+        await new Promise(res => setTimeout(res, pollIntervalMs));
+        waitedMs += pollIntervalMs;
+    }
+    const siteYamlObjects = await fetchSiteYaml(siteId);
+
+    // deploy site
+    for (const obj of siteYamlObjects) {
+        await kube.ApplyObject(obj, ns)
+    }
+}
+
+async function fetchSiteYaml(siteId) {
+    try {
+        const result = await client.query(
+            "SELECT Name, DeploymentState, Certificate, TlsCertificates.ObjectName " +
+            "FROM   InteriorSites " +
+            "JOIN   TlsCertificates ON Certificate = TlsCertificates.Id " +
+            "WHERE  Interiorsites.Id = $1", [siteId]);
+
+        if (result.rowCount != 1) {
+            throw new Error('Site secret not found');
+        }
+
+        const site = result.rows[0];
+        if (site.deploymentstate == 'deployed') {
+            throw new Error("Not permitted, site already deployed");
+        }
+        if (site.deploymentstate == 'not-ready') {
+            throw new Error("Not permitted, site not ready for deployment");
+        }
+        const secret = await kube.LoadSecret(site.objectname);
+        let output = [
+            resourceTemplates.ServiceAccount(),
+            resourceTemplates.BackboneRole(),
+            resourceTemplates.RoleBinding(),
+            resourceTemplates.Deployment(siteId, true, 'sk2'),
+            resourceTemplates.Secret(secret, `skx-site-${siteId}`, common.INJECT_TYPE_SITE, `tls-site-${siteId}`),
+            resourceTemplates.BackboneSite(site.name, siteId),
+            resourceTemplates.NetworkCR('mbone'),
+        ];
+        const links = await sync.GetBackboneLinks_TX(client, siteId);
+        for (const [linkId, linkData] of Object.entries(links)) {
+            output.push(resourceTemplates.LinkCR(linkId, linkData, `skx-site-${siteId}`));
+        }
+        const accessPoints = await sync.GetBackboneAccessPoints_TX(client, siteId, true);
+        for (const [apId, apData] of Object.entries(accessPoints)) {
+            output.push(resourceTemplates.AccessPointConfigMap(apId, apData));
+        }
+        return output;
+    } catch (err) {
+        throw new Error('Failed to fetch site yaml: ' + err.message);
+    }
+}

--- a/components/management-controller/src/colo-sync.js
+++ b/components/management-controller/src/colo-sync.js
@@ -54,12 +54,11 @@ export async function processColoBackbones() {
         if (coloBackbones.length > 0) {
             await reconcileNamespaces(coloBackbones)
         }
-        setTimeout(processColoBackbones, 60000)
     } catch (err) {
         Log(`[Colo-Sync] Error in colo backbone processing: ${err.stack || err}`)
-        setTimeout(processColoBackbones, 60000)
     } finally {
         client.release()
+        setTimeout(processColoBackbones, 60000)
     }
 }
 

--- a/components/management-controller/src/colo-sync.js
+++ b/components/management-controller/src/colo-sync.js
@@ -31,21 +31,14 @@ import * as resourceTemplates from "./resource-templates.js"
 import * as sync from "./sync-management.js"
 import * as common from "@skupperx/modules/common"
 
-let client
-
 /**
  * Start the colo sync module
  * @returns {Promise<void>}
  */
 export async function Start() {
     Log("[Colo-Sync Module Started]")
-    client = await ClientFromPool('system')
     // sync k8s state with database state on startup and every 60 seconds thereafter (additionally on backbone creation and deletion)
-    try {
-        await processColoBackbones()
-    } catch (err) {
-        Log(`[Colo-Sync] Error in colo backbone processing: ${err.stack || err}`)
-    } 
+    await processColoBackbones()
 }
 
 /**
@@ -53,13 +46,21 @@ export async function Start() {
  * @returns {Promise<void>}
  */
 export async function processColoBackbones() {
-    // get all backbones with colo namespaces
-    const coloBackbones = await client.query(`SELECT Id, CoLocatedNamespace FROM Backbones WHERE NULLIF(CoLocatedNamespace, '') IS NOT NULL`).then(res => res.rows)
-    // sync k8s state with database state
-    if (coloBackbones.length > 0) {
-        await reconcileNamespaces(coloBackbones)
+    const client = await ClientFromPool('system')
+    try {
+        // get all backbones with colo namespaces
+        const coloBackbones = await client.query(`SELECT Id, CoLocatedNamespace FROM Backbones WHERE CoLocatedNamespace IS NOT NULL`).then(res => res.rows)
+        // sync k8s state with database state
+        if (coloBackbones.length > 0) {
+            await reconcileNamespaces(coloBackbones)
+        }
+        setTimeout(processColoBackbones, 60000)
+    } catch (err) {
+        Log(`[Colo-Sync] Error in colo backbone processing: ${err.stack || err}`)
+        setTimeout(processColoBackbones, 60000)
+    } finally {
+        client.release()
     }
-    setTimeout(processColoBackbones, 60000)
 }
 
 
@@ -74,7 +75,7 @@ async function reconcileNamespaces(coloBackbones) {
     // create colocated namespaces if they don't exist on the cluster
     for (const bb of coloBackbones) {
         if (!existingNamespaces.some(existingNs => existingNs.name === bb.colocatednamespace)) {
-            await deployColo(bb.id, bb.colocatednamespace)
+            await deploySite(bb.id, bb.colocatednamespace)
         }
     }
     
@@ -89,57 +90,40 @@ async function reconcileNamespaces(coloBackbones) {
 }
 
 /**
- * Deploy a colo namespace and site
- * @param {string} ns - The namespace to deploy
- * @returns {Promise<void>}
- */
-async function deployColo(backboneId, ns) {
-    Log(`[Colo-Sync] deploying namespace ${ns}`)
-    await kube.createNamespace(ns)
-
-    Log(`[Colo-Sync] deploying site in namespace ${ns}`)
-    await deploySite(backboneId, ns)
-}
-
-/**
- * Deploy a site in the colo namespace
+ * If the colocated site is ready, create the colo namespace and deploy the site in it
+ * @param {string} backboneId - The backbone id
  * @param {string} ns - The namespace to deploy the site in
  * @returns {Promise<void>}
  */
 async function deploySite(backboneId, ns) {
-    const siteId = await client.query(`SELECT Id FROM InteriorSites WHERE Backbone = $1 AND CoLocated = true`, [backboneId]).then(res => res.rows[0]?.id)
-    // Poll the db against the InteriorSites table for this siteId, waiting for lifecycle='ready'
-    // Poll with timeout (60 seconds max)
-    const maxWaitMs = 60000;
-    const pollIntervalMs = 1000;
-    let waitedMs = 0;
-    while (true) {
-        const pollResult = await client.query(
-            "SELECT Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1 LIMIT 1",
-            [siteId]
-        );
-        if (pollResult.rowCount === 0) {
-            throw new Error(`InteriorSite with id ${siteId} not found`);
-        }
-        if (pollResult.rows[0].lifecycle === 'ready' && pollResult.rows[0].deploymentstate !== 'not-ready') {
-            break;
-        }
-        if (waitedMs >= maxWaitMs) {
-            throw new Error(`Timeout: InteriorSite ${siteId} did not become ready after ${maxWaitMs / 1000} seconds.`);
-        }
-        // sleep for pollIntervalMs
-        await new Promise(res => setTimeout(res, pollIntervalMs));
-        waitedMs += pollIntervalMs;
-    }
-    const siteYamlObjects = await fetchSiteYaml(siteId);
+    const client = await ClientFromPool('system')
+    try {
+        const siteId = await client.query(`SELECT Id FROM InteriorSites WHERE Backbone = $1 AND CoLocated = true AND Lifecycle = 'ready'`, [backboneId]).then(res => res.rows[0]?.id)
+        if (siteId) {
+            Log(`[Colo-Sync] deploying namespace ${ns}`)
+            await kube.createNamespace(ns)
 
-    // deploy site
-    for (const obj of siteYamlObjects) {
-        await kube.ApplyObject(obj, ns)
+            const siteYamlObjects = await fetchSiteYaml(siteId);
+        
+            Log(`[Colo-Sync] deploying site in namespace ${ns}`)
+            for (const obj of siteYamlObjects) {
+                await kube.ApplyObject(obj, ns)
+            }
+        }
+    } catch (err) {
+        Log(`[Colo-Sync] Error in deploying site in namespace ${ns}: ${err.stack || err}`)
+    } finally {
+        client.release()
     }
 }
 
+/**
+ * Fetch the site yaml objects for the colocatedsite
+ * @param {string} siteId - The site id
+ * @returns {Promise<Array<Object>>} - The site yaml objects
+ */
 async function fetchSiteYaml(siteId) {
+    const client = await ClientFromPool('system')
     try {
         const result = await client.query(
             "SELECT Name, DeploymentState, Certificate, TlsCertificates.ObjectName " +
@@ -152,9 +136,7 @@ async function fetchSiteYaml(siteId) {
         }
 
         const site = result.rows[0];
-        if (site.deploymentstate == 'deployed') {
-            throw new Error("Not permitted, site already deployed");
-        }
+        
         if (site.deploymentstate == 'not-ready') {
             throw new Error("Not permitted, site not ready for deployment");
         }
@@ -168,16 +150,17 @@ async function fetchSiteYaml(siteId) {
             resourceTemplates.BackboneSite(site.name, siteId),
             resourceTemplates.NetworkCR('mbone'),
         ];
-        const links = await sync.GetBackboneLinks_TX(client, siteId);
-        for (const [linkId, linkData] of Object.entries(links)) {
-            output.push(resourceTemplates.LinkCR(linkId, linkData, `skx-site-${siteId}`));
-        }
+        
         const accessPoints = await sync.GetBackboneAccessPoints_TX(client, siteId, true);
         for (const [apId, apData] of Object.entries(accessPoints)) {
-            output.push(resourceTemplates.AccessPointConfigMap(apId, apData));
+            if (apData.kind == 'manage') {
+                output.push(resourceTemplates.AccessPointConfigMap(apId, apData));
+            }
         }
         return output;
     } catch (err) {
         throw new Error('Failed to fetch site yaml: ' + err.message);
+    } finally {
+        client.release()
     }
 }

--- a/components/management-controller/src/colo-sync.js
+++ b/components/management-controller/src/colo-sync.js
@@ -27,8 +27,6 @@ import * as kube from "@skupperx/modules/kube"
 import { Log } from "@skupperx/modules/log"
 import { ClientFromPool } from "./db.js"
 import { META_ANNOTATION_SKUPPERX_CONTROLLED } from "@skupperx/modules/common"
-import yaml from 'js-yaml'
-import * as util from "@skupperx/modules/util"
 import * as resourceTemplates from "./resource-templates.js"
 import * as sync from "./sync-management.js"
 import * as common from "@skupperx/modules/common"
@@ -40,16 +38,14 @@ let client
  * @returns {Promise<void>}
  */
 export async function Start() {
-    Log("[Colo Sync Module Started]")
+    Log("[Colo-Sync Module Started]")
     client = await ClientFromPool('system')
     // sync k8s state with database state on startup and every 60 seconds thereafter (additionally on backbone creation and deletion)
-    setInterval(async () => {
-        try {
-            await processColoBackbones()
-        } catch (err) {
-            Log(`[colo-sync] Error in scheduled colo backbone processing: ${err.stack || err}`)
-        }
-    }, 60000)
+    try {
+        await processColoBackbones()
+    } catch (err) {
+        Log(`[Colo-Sync] Error in colo backbone processing: ${err.stack || err}`)
+    } 
 }
 
 /**
@@ -63,6 +59,7 @@ export async function processColoBackbones() {
     if (coloBackbones.length > 0) {
         await reconcileNamespaces(coloBackbones)
     }
+    setTimeout(processColoBackbones, 60000)
 }
 
 
@@ -85,7 +82,7 @@ async function reconcileNamespaces(coloBackbones) {
     // delete vms managed colocated namespaces if they are not in the database 
     for (const ns of vmsManagedNamespaces) {
         if (!coloNamespaces.has(ns)) {
-            Log(`[colo-sync] deleting namespace ${ns}`)
+            Log(`[Colo-Sync] deleting namespace ${ns}`)
             await kube.deleteNamespace(ns)
         }
     }
@@ -97,10 +94,10 @@ async function reconcileNamespaces(coloBackbones) {
  * @returns {Promise<void>}
  */
 async function deployColo(backboneId, ns) {
-    Log(`[colo-sync] deploying namespace ${ns}`)
+    Log(`[Colo-Sync] deploying namespace ${ns}`)
     await kube.createNamespace(ns)
 
-    Log(`[colo sync] deploying site in namespace ${ns}`)
+    Log(`[Colo-Sync] deploying site in namespace ${ns}`)
     await deploySite(backboneId, ns)
 }
 

--- a/components/management-controller/src/mc-main.js
+++ b/components/management-controller/src/mc-main.js
@@ -32,6 +32,7 @@ import * as kube from "@skupperx/modules/kube"
 import * as config from './config.js';
 import * as apiserver from "./mc-apiserver.js"
 import * as sync from './sync-management.js';
+import * as coloSync from './colo-sync.js'
 import * as amqp from "@skupperx/modules/amqp"
 import * as claims from './claim-server.js';
 import * as compose from './compose.js';
@@ -63,6 +64,7 @@ export async function Main() {
         await bbLinks.Start(CONTROLLER);
         await externalVans.Start();
         await sync.Start();
+        await coloSync.Start()
         await claims.Start();
         await compose.Start();
         await EvaluateAllSites();

--- a/components/management-controller/src/resource-templates.js
+++ b/components/management-controller/src/resource-templates.js
@@ -126,6 +126,10 @@ export function RouterAccess(accessPoint, tlsName) {
         routerAccess.spec.bindHost = accessPoint.bindhost;
     }
 
+    if (accessPoint.accessType) {
+        routerAccess.spec.accessType = accessPoint.accessType;
+    }
+
     return routerAccess;
 }
 
@@ -278,7 +282,7 @@ export function BackboneRole() {
             },
             {
                 apiGroups : ["skupper.io"],
-                resources : ["sites", "links", "networkaccesses", "routeraccesses"],
+                resources : ["sites", "links", "networks", "networkaccesses", "routeraccesses"],
                 verbs     : ["get", "list", "watch", "create", "update", "delete", "patch"],
             },
         ],

--- a/components/management-controller/src/resource-templates.js
+++ b/components/management-controller/src/resource-templates.js
@@ -282,7 +282,7 @@ export function BackboneRole() {
             },
             {
                 apiGroups : ["skupper.io"],
-                resources : ["sites", "links", "networks", "networkaccesses", "routeraccesses"],
+                resources : ["sites", "links", "networkaccesses", "routeraccesses"],
                 verbs     : ["get", "list", "watch", "create", "update", "delete", "patch"],
             },
         ],

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -661,7 +661,7 @@ export async function SiteIngressChanged(siteId, accessPointId) {
         try {
             await client.query("BEGIN");
             const result = await client.query(
-                "SELECT BackboneAccessPoints.Kind, BackboneAccessPoints.BindHost, BackboneAccessPoints.Certificate, BackboneAccessPoints.Lifecycle, InteriorSites.CoLocated " +
+                "SELECT BackboneAccessPoints.Kind, BackboneAccessPoints.BindHost, BackboneAccessPoints.AccessType, BackboneAccessPoints.Certificate, BackboneAccessPoints.Lifecycle,  InteriorSites.CoLocated " +
                 "FROM BackboneAccessPoints JOIN InteriorSites ON InteriorSites.Id = BackboneAccessPoints.InteriorSite WHERE BackboneAccessPoints.Id = $1",
                 [accessPointId]);
             if (result.rowCount == 1) {

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -39,7 +39,6 @@ import { WatchNotify } from './watch-server.js';
 
 var peers = {};  // {peerId: {pClass: <>, stuff}}
 
-
 export async function GetBackboneLinks_TX(client, siteId) {
     const result = await client.query(
         'SELECT InterRouterLinks.Id, InterRouterLinks.Cost, BackboneAccessPoints.Hostname, BackboneAccessPoints.Port FROM InterRouterLinks ' +
@@ -61,7 +60,8 @@ export async function GetBackboneLinks_TX(client, siteId) {
 export async function GetBackboneAccessPoints_TX(client, siteId, initialOnly = false) {
     let data = {};
     const result = await client.query(
-        'SELECT Id, Kind, BindHost FROM BackboneAccessPoints WHERE InteriorSite = $1', [siteId]);
+        'SELECT ap.Id, ap.Kind, ap.BindHost, ap.AccessType, s.CoLocated AS colocated FROM BackboneAccessPoints ap ' +
+        'JOIN InteriorSites s ON s.Id = ap.InteriorSite WHERE ap.InteriorSite = $1', [siteId]);
     for (const ap of result.rows) {
         if (!initialOnly || (ap.kind == 'manage')) {
             data[ap.id] = {
@@ -69,6 +69,9 @@ export async function GetBackboneAccessPoints_TX(client, siteId, initialOnly = f
             };
             if (ap.bindhost) {
                 data[ap.id].bindhost = ap.bindhost;
+            }
+            if (ap.accesstype) {
+                data[ap.id].accessType = ap.accesstype;
             }
         }
     }
@@ -85,7 +88,7 @@ async function onNewBackboneSite(peerId) {
     // Local state:
     //   - tls-site-<id>   - The client certificate/ca for the backbone router            [ id => Site ]
     //   - tls-server-<id> - Certificates/CAs for the backbone's access points            [ id => AccessPoint ]
-    //   - access-<id>     - Access point {kind: <>, bindHost: <>, tls: <server-tls-id>}  [ id => AccessPoint ]
+    //   - access-<id>     - Access point {kind: <>, bindHost?: <>, accessType?: <>, tls: <server-tls-id>}  [ id => AccessPoint ]
     //   - link-<id>       - Link {host: <>, port: <>, cost: <>}                          [ id => InterRouterLink ]
     //
     // Remote state:
@@ -101,11 +104,11 @@ async function onNewBackboneSite(peerId) {
         //
         // Query for the site's client certificate
         //
-        const siteResult = await client.query("SELECT Lifecycle, FirstActiveTime, Certificate, TlsCertificates.ObjectName FROM InteriorSites " +
+        const siteResult = await client.query("SELECT InteriorSites.Lifecycle, InteriorSites.FirstActiveTime, InteriorSites.Certificate, InteriorSites.CoLocated, TlsCertificates.ObjectName FROM InteriorSites " +
                                               "JOIN TlsCertificates ON TlsCertificates.Id = InteriorSites.Certificate " +
                                               "WHERE InteriorSites.Id = $1", [peerId]);
         if (siteResult.rowCount != 1) {
-            throw Error(`InteriorSite not found using id ${peerId}`);
+            throw new Error(`InteriorSite not found using id ${peerId}`);
         }
         const site = siteResult.rows[0];
         const secret = await LoadSecret(site.objectname);
@@ -115,7 +118,7 @@ async function onNewBackboneSite(peerId) {
         // Find all of the access points associated with this backbone site.
         // If the access point is 'ready', include its certificate and include remote state for its host/port.
         //
-        const accessResult = await client.query("SELECT Id, Lifecycle, Certificate, Kind, BindHost, Hostname, Port FROM BackboneAccessPoints WHERE InteriorSite = $1", [peerId]);
+        const accessResult = await client.query("SELECT Id, Lifecycle, Certificate, Kind, BindHost, AccessType, Hostname, Port FROM BackboneAccessPoints WHERE InteriorSite = $1", [peerId]);
         for (const accessPoint of accessResult.rows) {
             let apData = {
                 kind : accessPoint.kind,
@@ -123,10 +126,13 @@ async function onNewBackboneSite(peerId) {
             if (accessPoint.bindhost) {
                 apData.bindhost = accessPoint.bindhost;
             }
+            if (accessPoint.accesstype) {
+                apData.accessType = accessPoint.accesstype;
+            }
             if (accessPoint.lifecycle == 'ready') {
                 const tlsResult = await client.query("SELECT ObjectName FROM TlsCertificates WHERE Id = $1", [accessPoint.certificate]);
                 if (tlsResult.rowCount != 1) {
-                    throw Error(`Access point in ready state does not have a TlsCertificate - ${accessPoint.id}`);
+                    throw new Error(`Access point in ready state does not have a TlsCertificate - ${accessPoint.id}`);
                 }
                 const secret = await LoadSecret(tlsResult.rows[0].objectname);
                 localState[`tls-server-${accessPoint.id}`] = HashOfSecret(secret);
@@ -654,12 +660,18 @@ export async function SiteIngressChanged(siteId, accessPointId) {
         const client = await ClientFromPool('system');
         try {
             await client.query("BEGIN");
-            const result = await client.query("SELECT Kind, BindHost, Certificate, Lifecycle FROM BackboneAccessPoints WHERE Id = $1", [accessPointId]);
+            const result = await client.query(
+                "SELECT BackboneAccessPoints.Kind, BackboneAccessPoints.BindHost, BackboneAccessPoints.Certificate, BackboneAccessPoints.Lifecycle, InteriorSites.CoLocated " +
+                "FROM BackboneAccessPoints JOIN InteriorSites ON InteriorSites.Id = BackboneAccessPoints.InteriorSite WHERE BackboneAccessPoints.Id = $1",
+                [accessPointId]);
             if (result.rowCount == 1) {
                 const row = result.rows[0];
                 let ap = {kind : row.kind};
                 if (row.bindhost) {
                     ap.bindhost = row.bindhost;
+                }
+                if (row.accesstype) {
+                    ap.accessType = row.accesstype;
                 }
                 const hash = HashOfData(ap);
                 await UpdateLocalState(siteId, `access-${accessPointId}`, hash);

--- a/components/site-controller/src/ingress-v2.js
+++ b/components/site-controller/src/ingress-v2.js
@@ -28,6 +28,7 @@
 //     skx/state-id:   <The database ID of the source BackboneAccessPoint>
 //   data:
 //     kind: [claim|peer|member|manage|van]
+//     accessType: optional; e.g. 'local' for colocated manage (synced from management-controller)
 //
 // The output of this module:
 //   Skupper v2 RouterAccess and NetworkAccess resources
@@ -63,17 +64,18 @@ let reconcile_config_map_scheduled = false;
 let reconcile_accesses_scheduled = false;
 const accessPoints = {}; // APID => {kind, name, syncHash, syncData, toDelete}
 const META_ANNOTATION_ACCESSPOINT_KIND = "skx-accesspoint-kind";
-const new_access_point = function(apid, kind, name) {
+const new_access_point = function(apid, kind, name, accessType) {
     let value = {
         kind       : kind,
         name       : name,
+        accessType : accessType || null,
         syncHash   : null,
         syncData   : {},
         toDelete   : false,
     };
 
     if (accessPoints[apid]) {
-        throw Error(`accessPoint already exists for ${apid}`);
+        throw new Error(`accessPoint already exists for ${apid}`);
     }
     accessPoints[apid] = value;
 }
@@ -130,6 +132,9 @@ const backbone_routeraccess = function(apid) {
             }],
         },
     };
+    if (access.accessType) {
+        routerAccess.spec.accessType = access.accessType;
+    }
     return routerAccess;
 }
 
@@ -333,11 +338,12 @@ const do_reconcile_config_maps = async function() {
     // Un-condemn still-existing ingresses and create new ones.
     //
     for (const [apid, cm] of Object.entries(ingress_config_maps)) {
-        if (Object.keys(accessPoints).indexOf(apid) >= 0) {
+        if (Object.keys(accessPoints).includes(apid)) {
             accessPoints[apid].toDelete = false;
         } else {
             const kind = cm.data.kind;
-            new_access_point(apid, kind, cm.metadata.name);
+            const accessType = cm.data.accessType || null;
+            new_access_point(apid, kind, cm.metadata.name, accessType);
             need_service_sync = true;
         }
     }
@@ -407,7 +413,7 @@ export function GetIngressBundleV2() {
     return bundle;
 }
 
-export async function Start(siteId) {
+export async function Start() {
     Log('[Ingress Skupper v2 module started]');
     await do_reconcile_config_maps();
     await reconcile_access_resources();

--- a/components/site-controller/src/sc-main.js
+++ b/components/site-controller/src/sc-main.js
@@ -88,7 +88,7 @@ export async function Main() {
         }
         if (BACKBONE_MODE) {
             if (PLATFORM == 'sk2') {
-                await ingress_v2.Start(site_id);
+                await ingress_v2.Start();
             } else {
                 await ingress_v1.Start(site_id, PLATFORM);
             }

--- a/modules/src/kube.js
+++ b/modules/src/kube.js
@@ -214,6 +214,39 @@ export async function DeleteConfigmap(name) {
   await v1Api.deleteNamespacedConfigMap({ name: name, namespace: namespace })
 }
 
+export async function GetNamespaces() {
+  try {
+    return await v1Api.listNamespace()
+  } catch {
+    Log("Error listing namespaces")
+  }
+}
+
+export async function createNamespace(name) {
+  try {
+    await v1Api.createNamespace({
+      body: {
+        metadata: {
+          name: name,
+          annotations: {
+            [common.META_ANNOTATION_SKUPPERX_CONTROLLED]: "true"
+          }
+        },
+      }
+    })
+  } catch (err) {
+    Log(`Error creating namespace ${name}: ${err.message}`)
+  }
+}
+
+export async function deleteNamespace(name) {
+  try {
+    await v1Api.deleteNamespace({ name: name })
+  } catch (err) {
+    Log(`Error deleting namespace ${name}: ${err.message}`)
+  }
+}
+
 export async function GetPods() {
   let list = await v1Api.listNamespacedPod({ namespace: namespace })
   return list.items
@@ -656,14 +689,14 @@ export function WatchNetworkAccesses(callback) {
   }
 }
 
-export async function ApplyObject(obj) {
+export async function ApplyObject(obj, ns = "") {
   try {
     if (obj.metadata.annotations == undefined) {
       obj.metadata.annotations = {}
     }
     obj.metadata.annotations[common.META_ANNOTATION_SKUPPERX_CONTROLLED] =
       "true"
-    obj.metadata.namespace = namespace
+    obj.metadata.namespace = ns || namespace
     Log(`Creating resource: ${obj.kind} ${obj.metadata.name}`)
     return await client.create(obj)
   } catch (error) {


### PR DESCRIPTION
This module is responsible for managing the deployment and deletion of colocated namespaces/sites, tying their lifecycle to the lifecycle of the parent backbone network. It currently runs on MC startup, during backbone network creation and deletion, and is set to run every minute after startup to ensure up to date state reconciliation. Added a column on backboneaccesspoint to store routeraccess accesstype ('local' for colocated site's 'manage' accesspoint).

Fixes #91 