### PR TITLE
Fix sync issues between MC and SC

### DIFF
--- a/modules/src/amqp.js
+++ b/modules/src/amqp.js
@@ -67,7 +67,7 @@ const rhea_handlers = function () {
           sender.sendable = true
           if (conn.replyTo != undefined) {
             sender.notified = true
-            Log(`AMQP Sender '${sender.logName}' is now reachable`)
+            Log(`AMQP Sender '${sender.logName}' is now reachable at ${conn.replyTo}`)
             sender.onSendable(sender.context)
           }
         }

--- a/modules/src/state-sync.js
+++ b/modules/src/state-sync.js
@@ -130,6 +130,9 @@ async function onHeartbeat(connectionKey, peerClass, peerId, hashset, sequence, 
       hbTimer: null,
       lastSequence: undefined,
     }
+  } else if (!!address && peers[peerId].address != address) {
+    Log(`Peer address for ${peerId} updated from: ${peers[peerId].address}, to: ${address}`)
+    peers[peerId].address = address
   }
 
   if (sequence === peers[peerId].lastSequence) {
@@ -250,6 +253,7 @@ function onSendable(connectionKey) {
 
 function onAddress(connectionKey, address) {
   if (connectionKey == "net") {
+    Log(`Address to use to get messages from mc is: ${address}`)
     addressToUse = address
   } else {
     Log(`ERROR: onAddress invoked with connectionKey '${connectionKey}', expected 'net'`)


### PR DESCRIPTION
If the site-controller pod gets restarted, it was no longer consuming messages from MC, as the dynamic address set through onAddress is not updated on the MC side for the respective peer.

Fixes #110.