### PR TITLE
Fixes #123 - Added a new data-change notification module

### DIFF
--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -25,8 +25,8 @@ import { SiteIngressChanged, LinkChanged, SiteDeleted } from './sync-management.
 import { Log } from '@skupperx/modules/log'
 import { ManageIngressAdded, LinkAddedOrDeleted, ManageIngressDeleted } from './site-deployment-state.js';
 import { ValidateAndNormalizeFields, IsValidUuid, UniquifyName } from '@skupperx/modules/util';
-import { WatchNotify } from './watch-server.js';
 import { processColoBackbones } from './colo-sync.js';
+import { NotifyTransaction } from './notify.js';
 
 const API_PREFIX   = '/api/v1alpha1/';
 const INGRESS_LIST = ['claim', 'peer', 'member', 'manage'];
@@ -43,30 +43,33 @@ const createBackbone = async function(req, res) {
         });
 
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
-            let backboneId = null;
-            let siteId = null;
-            let apId = null;
+            let backboneId;
+            let siteId;
             await queryWithContext(req, client, async (client, userInfo) => {
-                const result = await client.query("INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroup, CoLocatedNamespace) VALUES ($1, 'new', $2, $3, $4) RETURNING Id", [norm.name, userInfo.userId, norm.ownerGroup, norm.coLocatedNamespace]);
+                const result = await client.query(
+                    "INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroup, CoLocatedNamespace) " +
+                    "VALUES ($1, 'new', $2, $3, $4) RETURNING Id", [norm.name, userInfo.userId, norm.ownerGroup, norm.coLocatedNamespace]
+                );
                 backboneId = result.rows[0].id;
+                notify.add('Backbones', backboneId);
                 if (!!norm.coLocatedNamespace) {
                     const site_result = await client.query(`INSERT INTO InteriorSites(Name, TargetPlatform, CoLocated, Backbone, Owner, OwnerGroup) ` +
                     `VALUES ('co-located', 'sk2', true, $1, $2, $3) RETURNING Id`,
                     [backboneId, userInfo.userId, norm.ownerGroup]);
                     siteId = site_result.rows[0].id;
+                    notify.add('InteriorSites', siteId);
                     const ap_result = await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite, Owner, OwnerGroup, AccessType) ` +
                             `VALUES ('manage', 'manage', $1, $2, $3, 'local') RETURNING Id`,
                             [siteId, userInfo.userId, norm.ownerGroup]);
-                    apId = ap_result.rows[0].id;
+                    notify.add('BackboneAccessPoints', ap_result.rows[0].id);
                 }
             });
+            await notify.commit();
             returnStatus = 201;
+            await processColoBackbones();
             res.status(returnStatus).json({id: backboneId});
-            await WatchNotify('Backbones', backboneId);
-            if (!!siteId) await WatchNotify('InteriorSites', siteId);
-            if (!!apId) await WatchNotify('BackboneAccessPoints', apId);
-            await processColoBackbones()
         } catch (error) {
             returnStatus = 500;
             res.status(returnStatus).send(error.message);
@@ -99,12 +102,13 @@ const createBackboneSite = async function(req, res) {
         });
 
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
             let extraCols = "";
             let extraVals = "";
 
             const siteId = await queryWithContext(req, client, async (client, userInfo) => {
-                 //
+                //
                 // If the name is not unique within the backbone, modify it to be unique.
                 //
                 const namesResult = await client.query("SELECT Name FROM InteriorSites WHERE Backbone = $1", [bid]);
@@ -126,16 +130,19 @@ const createBackboneSite = async function(req, res) {
                 //
                 // Create the site
                 //
-                const result = await client.query(`INSERT INTO InteriorSites(Name, TargetPlatform, Backbone${extraCols}, Owner, OwnerGroup) VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`,
-                                                [uniqueName, norm.platform, bid, userInfo.userId, norm.ownerGroup]);
+                const result = await client.query(
+                    `INSERT INTO InteriorSites(Name, TargetPlatform, Backbone${extraCols}, Owner, OwnerGroup) ` +
+                    `VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`,
+                    [uniqueName, norm.platform, bid, userInfo.userId, norm.ownerGroup]
+                );
                 const site_id = result.rows[0].id;
-
+                notify.add('InteriorSites', site_id);
                 return site_id;
-            })
+            });
 
             returnStatus = 201;
             res.status(returnStatus).json({id: siteId});
-            await WatchNotify('InteriorSites', siteId);
+            await notify.commit();
         } catch (error) {
             returnStatus = 500
             res.status(returnStatus).send(error.message);
@@ -166,6 +173,7 @@ const updateBackboneSite = async function(req, res) {
         });
     
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
             let nameChanged   = false;
 
@@ -197,11 +205,13 @@ const updateBackboneSite = async function(req, res) {
                     if (norm.metadata != null && norm.metadata != site.metadata) {
                         await client.query("UPDATE InteriorSites SET Metadata = $1 WHERE Id = $2", [norm.metadata, sid]);
                     }
+
+                    notify.update('InteriorSites', sid);
                 }
-            })
+            });
 
             res.status(returnStatus).end();
-            await WatchNotify('InteriorSites', sid);
+            await notify.commit();
         } catch (error) {
             returnStatus = 500;
             res.status(returnStatus).send(error.message);
@@ -234,6 +244,7 @@ const createAccessPoint = async function(req, res) {
         });
 
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
             const result = await queryWithContext(req, client, async (client, userInfo) => {
                 const userId = userInfo.userId;
@@ -263,14 +274,20 @@ const createAccessPoint = async function(req, res) {
                 //
                 // Create the access point
                 //
-                return await client.query(`INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite${extraCols}, Owner, OwnerGroup) VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`, [name, norm.kind, sid, userId, norm.ownerGroup]);
-            })
+                const result = await client.query(
+                    `INSERT INTO BackboneAccessPoints(Name, Kind, InteriorSite${extraCols}, Owner, OwnerGroup) ` +
+                    `VALUES ($1, $2, $3${extraVals}, $4, $5) RETURNING Id`,
+                    [name, norm.kind, sid, userId, norm.ownerGroup]
+                );
+                notify.add('BackboneAccessPoints', result.rows[0].id);
+                return result;
+            });
             
             const apId = result.rows[0].id;
 
             returnStatus = 201;
             res.status(returnStatus).json({id: apId});
-            await WatchNotify('BackboneAccessPoints', apId);
+            await notify.commit();
 
             //
             // Alert the sync module that an access point changed on a site
@@ -314,6 +331,7 @@ const createBackboneLink = async function(req, res) {
         });
 
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
             const linkResult = await queryWithContext(req, client, async (client, userInfo) => {
                 const userId = userInfo.userId;
@@ -354,13 +372,19 @@ const createBackboneLink = async function(req, res) {
                 //
                 // Create the new link
                 //
-                return await client.query("INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost, Owner, OwnerGroup) VALUES ($1, $2, $3, $4, $5) RETURNING Id", [apid, norm.connectingsite, norm.cost, userId, norm.ownerGroup]);
+                const result = await client.query(
+                    "INSERT INTO InterRouterLinks(AccessPoint, ConnectingInteriorSite, Cost, Owner, OwnerGroup) " +
+                    "VALUES ($1, $2, $3, $4, $5) RETURNING Id",
+                    [apid, norm.connectingsite, norm.cost, userId, norm.ownerGroup]
+                );
+                notify.add('InterRouterLinks', result.rows[0].id);
+                return result;
             });
 
             const linkId = linkResult.rows[0].id;
             returnStatus = 201;
             res.status(returnStatus).json({id: linkId});
-            await WatchNotify('InterRouterLinks', linkId);
+            await notify.commit();
 
             //
             // Alert the sync and deployment-state modules that a new backbone link was added for the connecting site
@@ -401,6 +425,7 @@ const updateBackboneLink = async function(req, res) {
         });
 
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
             let linkChanged = null;
 
@@ -417,16 +442,16 @@ const updateBackboneLink = async function(req, res) {
                         returnStatus = 200;
                         linkChanged = link.connectinginteriorsite;
                     }
+                    notify.update('InterRouterLinks', lid);
                 }
-            })
-            
+            });
+            await notify.commit();
             res.status(returnStatus).end();
 
             //
             // Alert the sync module that a backbone link was modified for the connecting site
             //
             if (linkChanged) {
-                await WatchNotify('InterRouterLinks', lid);
                 await LinkChanged(linkChanged, lid);
             }
         } catch (error) {
@@ -448,6 +473,7 @@ const deleteBackbone = async function(req, res) {
     let returnStatus = 204;
     const bid = req.params.bid;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         if (!IsValidUuid(bid)) {
             throw new Error('Backbone-Id is not a valid uuid');
@@ -476,25 +502,32 @@ const deleteBackbone = async function(req, res) {
                     if (row.certificate) {
                         await client.query("UPDATE BackboneAccessPoints SET Certificate = NULL WHERE Id = $1", [row.id]);
                         await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                        // not needed: notify.update('BackboneAccessPoints', row.id);
+                        notify.delete('TlsCertificates', row.certificate);
                     }
                     await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1", [row.id]);
+                    notify.delete('BackboneAccessPoints', row.id);
                 }
                 await client.query("DELETE FROM InteriorSites WHERE Id = $1", [siteId]);
+                notify.delete('InteriorSites', siteId);
                 if (siteCertificate) {
                     await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [siteCertificate])
+                    notify.delete('TlsCertificates', siteCertificate);
                 }
             }
             const bbResult = await client.query("DELETE FROM Backbones WHERE Id = $1 RETURNING Certificate", [bid]);
+            notify.delete('Backbones', bid);
             if (bbResult.rowCount == 1) {
                 const row = bbResult.rows[0];
                 if (row.certificate) {
                     await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                    notify.delete('TlsCertificates', row.certificate);
                 }
             }
         });
         res.status(returnStatus).end();
-        await WatchNotify('Backbones', bid);
-        await processColoBackbones()
+        await notify.commit();
+        await processColoBackbones();
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.message);
@@ -509,6 +542,7 @@ const deleteBackboneSite = async function(req, res) {
     let returnStatus = 204;
     const sid = req.params.sid;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         if (!IsValidUuid(sid)) {
             throw new Error('Site-Id is not a valid uuid');
@@ -534,20 +568,25 @@ const deleteBackboneSite = async function(req, res) {
                 if (row.certificate) {
                     await client.query("UPDATE BackboneAccessPoints SET Certificate = NULL WHERE Id = $1", [row.id]);
                     await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                    // No notify for BackboneAccessPoints needed
+                    notify.delete('TlsCertificates', row.certificate);
                 }
                 await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1", [row.id]);
+                notify.delete('BackboneAccessPoints', row.id);
             }
 
                 //
                 // Delete the site.  Note that involved inter-router links will be automatically deleted by the database.
                 //
                 await client.query("DELETE FROM InteriorSites WHERE Id = $1", [sid]);
+                notify.delete('InteriorSites', sid);
 
                 //
                 // Delete the TLS certificate
                 //
                 if (row.certificate) {
                     await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate])
+                    notify.delete('TlsCertificates', row.certificate);
                 }
             }
         });
@@ -558,7 +597,7 @@ const deleteBackboneSite = async function(req, res) {
         SiteDeleted(sid);
 
         res.status(returnStatus).end();
-        await WatchNotify('InteriorSites', sid);
+        await notify.commit();
     } catch (error) {
         returnStatus = 400;
         res.status(returnStatus).send(error.stack);
@@ -575,6 +614,7 @@ const deleteAccessPoint = async function(req, res) {
     var siteId = undefined;
     var wasManage = false;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         if (!IsValidUuid(apid)) {
             throw new Error('AccessPoint-Id is not a valid uuid');
@@ -590,10 +630,12 @@ const deleteAccessPoint = async function(req, res) {
             }
 
             const apResult = await client.query("DELETE FROM BackboneAccessPoints WHERE Id = $1 Returning Certificate, Kind, InteriorSite", [apid]);
+            notify.delete('BackboneAccessPoints', apid);
             if (apResult.rowCount == 1) {
                 const row = apResult.rows[0];
                 if (row.certificate) {
                     await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                    notify.delete('TlsCertificates', row.certificate);
                 }
                 siteId = row.interiorsite;
                 if (row.kind == 'manage') {
@@ -603,7 +645,7 @@ const deleteAccessPoint = async function(req, res) {
         })
 
         res.status(returnStatus).end();
-        await WatchNotify('BackboneAccessPoints', apid);
+        await notify.commit();
 
         //
         // Alert the sync module that an access point changed on a site
@@ -628,6 +670,7 @@ const deleteBackboneLink = async function(req, res) {
     let returnStatus = 204;
     const lid = req.params.lid;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         let connectingSite = null;
         let accessPoint    = null;
@@ -636,15 +679,16 @@ const deleteBackboneLink = async function(req, res) {
         }
 
         const result = await queryWithContext(req, client, async (client) => {
+            notify.delete('InterRouterLinks', lid);
             return await client.query("DELETE FROM InterRouterLinks WHERE Id = $1 RETURNING ConnectingInteriorSite, AccessPoint", [lid]);
-        })
+        });
         if (result.rowCount == 1) {
             connectingSite = result.rows[0].connectinginteriorsite;
             accessPoint    = result.rows[0].accesspoint;
         }
         
         res.status(returnStatus).end();
-        await WatchNotify('InterRouterLinks', lid);
+        await notify.commit();
 
         //
         // Alert the sync and deployment-state modules that a backbone link was deleted for the connecting site

--- a/components/management-controller/src/api-user.js
+++ b/components/management-controller/src/api-user.js
@@ -24,6 +24,7 @@ import { ClientFromPool, queryWithContext } from './db.js';
 import { Log } from '@skupperx/modules/log'
 import { IsValidUuid, ValidateAndNormalizeFields, UniquifyName } from '@skupperx/modules/util'
 import { WatchNotify } from './watch-server.js';
+import { NotifyTransaction } from './notify.js';
 
 const API_PREFIX = '/api/v1alpha1/';
 
@@ -47,6 +48,7 @@ const createVan = async function(req, res) {
         });
 
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
             returnStatus = 500;
             
@@ -95,16 +97,18 @@ const createVan = async function(req, res) {
                     [uniqueName, norm.nettype, bid, userInfo.userId]
                 );
                 const vanId = result.rows[0].id;
+                notify.add('ApplicationNetworks', vanId);
                 
                 //
                 // Create network credentials for the VAN.
                 //
-                await client.query("INSERT INTO NetworkCredentials (Name, MemberOf) VALUES ($1, $2)", [uniqueName, vanId]);
+                const nc = await client.query("INSERT INTO NetworkCredentials (Name, MemberOf) VALUES ($1, $2) RETURNING Id", [uniqueName, vanId]);
+                notify.add('NetworkCredentials', nc.rows[0].id);
 
-                return vanId
+                return vanId;
             });
 
-            await WatchNotify('ApplicationNetworks', vanId);
+            await notify.commit();
             returnStatus = 201;
             res.status(returnStatus).json({id: vanId});
         } catch (error) {
@@ -144,6 +148,7 @@ const createInvitation = async function(req, res) {
         });
 
         const client = await ClientFromPool();
+        const notify = new NotifyTransaction();
         try {
 
             const invitationId = await queryWithContext(req, client, async (client) => {
@@ -189,18 +194,22 @@ const createInvitation = async function(req, res) {
                 const result = await client.query(`INSERT INTO MemberInvitations(Name, MemberOf, ClaimAccess, InteractiveClaim${extraCols}) ` +
                                                 `VALUES ($1, $2, $3, $4${extraVals}) RETURNING Id`, [uniqueName, vid, norm.claimaccess, norm.interactive]);
                 const invitationId = result.rows[0].id;
+                notify.add('MemberInvitations', invitationId);
 
-                await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 1)", [norm.primaryaccess, invitationId]);
+                const el = await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 1) RETURNING Id", [norm.primaryaccess, invitationId]);
+                notify.add('EdgeLinks', el.rows[0].id);
 
                 if (norm.secondaryaccess) {
-                    await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 2)", [norm.secondaryaccess, invitationId]);
+                    const el2 = await client.query("INSERT INTO EdgeLinks(AccessPoint, EdgeToken, Priority) VALUES ($1, $2, 2) RETURNING Id", [norm.secondaryaccess, invitationId]);
+                    notify.add('EdgeLinks', el2.rows[0].id);
                 }
 
                 return invitationId
-            })
+            });
 
             returnStatus = 201;
             res.status(returnStatus).json({id: invitationId});
+            await notify.commit();
         } catch (error) {
             returnStatus = 500
             res.status(returnStatus).send(error.message);
@@ -380,14 +389,17 @@ const deleteVan = async function(req, res) {
     const vid = req.params.vid;
     let returnStatus = 204;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         const result = await queryWithContext(req, client, async (client) => {
             const memberSiteId = await client.query("SELECT Id FROM MemberSites WHERE MemberOf = $1 LIMIT 1", [vid]);
             if (memberSiteId.rowCount == 0) {
                 const delResult = await client.query("DELETE FROM ApplicationNetworks WHERE Id = $1 RETURNING Certificate", [vid]);
+                notify.delete('ApplicationNetworks', vid);
                 if (delResult.rowCount == 1) {
                     if (delResult.rows[0].certificate) {
                         await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [delResult.rows[0].certificate]);
+                        notify.delete('TlsCertificates', delResult.rows[0].certificate);
                     }
                     return { status: returnStatus, message: "Application network deleted" };
                 } else {
@@ -399,13 +411,14 @@ const deleteVan = async function(req, res) {
                 throw new Error('Cannot delete application network because is still has members');
             }
         });
-        await WatchNotify('ApplicationNetworks', vid);
+        await notify.commit();
         res.status(result.status).send(result.message);
     } catch (error) {
         // Only set 500 if returnStatus is still at default (204), preserving specific error codes
         if (returnStatus === 204) {
             returnStatus = 500;
         }
+        console.log(error.stack);
         res.status(returnStatus).send(error.message);
     } finally {
         client.release();
@@ -417,22 +430,26 @@ const deleteInvitation = async function(req, res) {
     const iid = req.params.iid;
     let returnStatus = 204;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         await queryWithContext(req, client, async (client) => {
             const result = await client.query("SELECT id FROM MemberSites WHERE Invitation = $1 LIMIT 1", [iid]);
             if (result.rowCount == 0) {
                 const invResult = await client.query("DELETE FROM MemberInvitations WHERE Id = $1 RETURNING Certificate", [iid]);
+                notify.delete('MemberInvitations', iid);
                 if (invResult.rowCount == 1) {
                     const row = invResult.rows[0];
                     if (row.certificate) {
                         await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [row.certificate]);
+                        notify.delete('TlsCertificates', row.certificate);
                     }
                 }
             } else {
                 returnStatus = 400;
                 throw new Error('Cannot delete invitation because members still exist that use the invitation');
             }
-        })
+        });
+        await notify.commit();
         res.status(returnStatus).end();
     } catch (error) {
         // Only set 500 if returnStatus is still at default (204), preserving specific error codes
@@ -450,14 +467,17 @@ const expireInvitation = async function(req, res) {
     const iid = req.params.iid;
     let returnStatus = 200;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         const result = await queryWithContext(req, client, async (client) => {
+            notify.update('MemberInvitations', iid);
             return await client.query("UPDATE MemberInvitations SET Lifecycle = 'expired', Failure = 'Expired via API' WHERE Id = $1 RETURNING Id", [iid]);
         })
         if (result.rowCount == 0) {
             returnStatus = 404;
         }
         res.status(returnStatus).end();
+        await notify.commit();
     } catch (error) {
         returnStatus = 500
         res.status(returnStatus).send(error.message);

--- a/components/management-controller/src/certs.js
+++ b/components/management-controller/src/certs.js
@@ -28,93 +28,89 @@ import { CompleteMember } from './claim-server.js';
 import { AccessPointCertReady, SiteLifecycleChanged_TX } from './site-deployment-state.js';
 import { META_ANNOTATION_SKUPPERX_CONTROLLED } from '@skupperx/modules/common'
 import { WatchNotify } from './watch-server.js';
+import { NotifyTransaction, RegisterNotification } from './notify.js';
 
-//
-// processNewManagementControllers
 //
 // When new management controllers are created, add a certificate request.
 //
-const processNewManagementControllers = async function() {
-    var reschedule_delay = 5000;
-    const client = await ClientFromPool('system');
-    try {
-        await client.query('BEGIN');
-        const result = await client.query("SELECT * FROM ManagementControllers WHERE Lifecycle = 'new' LIMIT 1");
-        if (result.rowCount == 1) {
-            const row = result.rows[0];
-            Log(`New Management Controller: ${row.name}`);
-            var duration_ms;
-            duration_ms = IntervalMilliseconds(BackboneExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ManagementController) VALUES(gen_random_uuid(), 'mgmtController', now(), now(), $1, $2)",
-                [duration_ms / 3600000, row.id]
-                );
-            await client.query("UPDATE ManagementControllers SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
+async function onManagementControllersChange(action, tableName, id) {
+    if (action != 'DELETE') {
+        const client = await ClientFromPool('system');
+        try {
+            await client.query('BEGIN');
+            const notify = new NotifyTransaction();
+            const result = await client.query("SELECT * FROM ManagementControllers WHERE Lifecycle = 'new' AND Id = $1", [id]);
+            if (result.rowCount == 1) {
+                const row = result.rows[0];
+                Log(`New Management Controller: ${row.name}`);
+                var duration_ms;
+                duration_ms = IntervalMilliseconds(BackboneExpiration());
+                const cert = await client.query(
+                    "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ManagementController) " +
+                    "VALUES(gen_random_uuid(), 'mgmtController', now(), now(), $1, $2) RETURNING Id",
+                    [duration_ms / 3600000, row.id]
+                    );
+                notify.add('CertificateRequests', cert.rows[0].id)
+                await client.query("UPDATE ManagementControllers SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
+                notify.update('ManagementControllers', row.id);
+            }
+            await client.query('COMMIT');
+            await notify.commit();
+        } catch (err) {
+            Log(`Rolling back new-management-controller transaction: ${err.stack}`);
+            await client.query('ROLLBACK');
+        } finally {
+            client.release();
         }
-        await client.query('COMMIT');
-    } catch (err) {
-        Log(`Rolling back new-management-controller transaction: ${err.stack}`);
-        await client.query('ROLLBACK');
-        reschedule_delay = 10000;
-    } finally {
-        client.release();
-        setTimeout(processNewManagementControllers, reschedule_delay);
     }
 }
 
-//
-// processNewBackbones
 //
 // When new backbones are created, add a certificate request to begin the full setup of the network.
 //
-const processNewBackbones = async function() {
-    let reschedule_delay = 2000;
+async function onBackbonesChange(action, tableName, id) {
     const client = await ClientFromPool('system');
     try {  
         await client.query('BEGIN');
-        const result = await client.query("SELECT * FROM Backbones WHERE Lifecycle = 'new' LIMIT 1");
-        let rowId;
+        const notify = new NotifyTransaction();
+        const result = await client.query("SELECT * FROM Backbones WHERE Lifecycle = 'new' AND id = $1", [id]);
         if (result.rowCount == 1) {
             const row = result.rows[0];
             Log(`New Backbone Network: ${row.name}`);
-            rowId = row.id;
             let duration_ms;
             duration_ms = IntervalMilliseconds(BackboneExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Backbone) VALUES(gen_random_uuid(), 'backboneCA', now(), now(), $1, $2)",
+            const cert = await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Backbone) " +
+                "VALUES(gen_random_uuid(), 'backboneCA', now(), now(), $1, $2) RETURNING Id",
                 [duration_ms / 3600000, row.id]
                 );
+            notify.add('CertificateRequests', cert.rows[0].id);
             await client.query("UPDATE Backbones SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
+            notify.update('Backbones', row.id);
         }
         await client.query('COMMIT');
-        if (rowId) {
-            await WatchNotify('Backbones', rowId);
-        }
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back new-backbone transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewBackbones, reschedule_delay);
     }
 }
 
 //
 //
 //
-const processNewAccessPoints = async function() {
-    let reschedule_delay = 2000;
+async function onAccessPointsChange(action, tableName, id) {
     const client = await ClientFromPool('system');
     try {
-        let rowId;
         await client.query('BEGIN');
+        const notify = new NotifyTransaction();
         const result = await client.query(
             "SELECT BackboneAccessPoints.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM BackboneAccessPoints " +
             "JOIN InteriorSites ON BackboneAccessPoints.InteriorSite = InteriorSites.Id " +
-            "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id WHERE BackboneAccessPoints.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+            "JOIN Backbones ON InteriorSites.Backbone = Backbones.Id " +
+            "WHERE BackboneAccessPoints.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' and BackboneAccessPoints.Id = $1", [id]
         );
         if (result.rowCount == 1) {
             const row = result.rows[0];
@@ -126,43 +122,37 @@ const processNewAccessPoints = async function() {
             } else {
                 duration_ms = IntervalMilliseconds(DefaultCaExpiration());
             }
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, AccessPoint, Issuer, Hostname) VALUES(gen_random_uuid(), 'accessPoint', now(), now(), $1, $2, $3, $4)",
+            const cert = await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, AccessPoint, Issuer, Hostname) " +
+                "VALUES(gen_random_uuid(), 'accessPoint', now(), now(), $1, $2, $3, $4) Returning Id",
                 [duration_ms / 3600000, row.id, row.bbca, row.hostname]
             );
+            notify.add('CertificateRequests', cert.rows[0].id);
             await client.query("UPDATE BackboneAccessPoints SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-            rowId = row.id;
+            notify.update('BackboneAccessPoints', row.id);
         } 
         await client.query('COMMIT');
-        if (rowId) {
-            await WatchNotify('BackboneAccessPoints', rowId);
-        }
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back new-access-point transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewAccessPoints, reschedule_delay);
     }
 }
 
 //
-// processNewNetworks
-//
 // When new networks are created, add a certificate request to begin the full setup of the network.
 //
-const processNewNetworks = async function() {
-    let reschedule_delay = 2000;
+async function onApplicationNetworksChange(action, tableName, id) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
-        let   rowId;
         await client.query('BEGIN');
         const result = await client.query(
             "SELECT ApplicationNetworks.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM ApplicationNetworks " + 
             "JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id " +
-            "WHERE ApplicationNetworks.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' LIMIT 1"
+            "WHERE ApplicationNetworks.Lifecycle = 'new' and Backbones.Lifecycle = 'ready' and ApplicationNetworks.Id = $1", [id]
         );
         if (result.rowCount == 1) {
             const row = result.rows[0];
@@ -176,36 +166,32 @@ const processNewNetworks = async function() {
             } else {
                 duration_ms = IntervalMilliseconds(DefaultCaExpiration());
             }
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ApplicationNetwork, Issuer) VALUES(gen_random_uuid(), 'vanCA', now(), $1, $2, $3, $4)",
+            const cert = await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, ApplicationNetwork, Issuer) " +
+                "VALUES(gen_random_uuid(), 'vanCA', now(), $1, $2, $3, $4) Returning Id",
                 [row.starttime, Math.trunc(duration_ms / 3600000), row.id, row.bbca]
             );
+            notify.add('CertificateRequests', cert.rows[0].id);
             await client.query("UPDATE ApplicationNetworks SET Lifecycle = 'skx_cr_created', VanId = $1 WHERE Id = $2", [van_id, row.id]);
-            reschedule_delay = 0;
-            rowId = row.id;
+            notify.update('ApplicationNetworks', row.id);
         }
         await client.query('COMMIT');
-        if (rowId) {
-            await WatchNotify('ApplicationNetworks', rowId);
-        }
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back new-network transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewNetworks, reschedule_delay);
     }
 }
 
 //
 // processNewInteriorSites
 //
-const processNewInteriorSites = async function() {
-    let reschedule_delay = 2000;
+async function onInteriorSitesChange(action, tableName, id) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
-        let rowId;
         await client.query('BEGIN');
         const result = await client.query(
             "SELECT InteriorSites.*, Backbones.Lifecycle as bblc, Backbones.Certificate as bbca FROM InteriorSites " + 
@@ -215,36 +201,32 @@ const processNewInteriorSites = async function() {
             const row = result.rows[0];
             Log(`New Interior Site: ${row.name}`);
             let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, InteriorSite, Issuer) VALUES(gen_random_uuid(), 'interiorRouter', now(), now(), $1, $2, $3)",
+            const cert = await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, InteriorSite, Issuer) " +
+                "VALUES(gen_random_uuid(), 'interiorRouter', now(), now(), $1, $2, $3) RETURNING Id",
                 [duration_ms / 3600000, row.id, row.bbca]
             );
+            notify.add('CertificateRequests', cert.rows[0].id);
             await client.query("UPDATE InteriorSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-            rowId = row.id;
+            notify.update('InteriorSites', row.id);
         }
         await client.query('COMMIT');
-        if (rowId) {
-            await WatchNotify('InteriorSites', rowId);
-        }
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back new-interior-site transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewInteriorSites, reschedule_delay);
     }
 }
 
 //
 // processNewInvitations
 //
-const processNewInvitations = async function() {
-    let reschedule_delay = 2000;
+const onInvitationsChange = async function(action, tableName, id) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
-        let rowId;
         await client.query('BEGIN');
         const result = await client.query(
             "SELECT MemberInvitations.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberInvitations " + 
@@ -254,36 +236,32 @@ const processNewInvitations = async function() {
             const row = result.rows[0];
             Log(`New Invitation: ${row.name}`);
             let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Invitation, Issuer) VALUES(gen_random_uuid(), 'memberClaim', now(), now(), $1, $2, $3)",
+            const cert = await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Invitation, Issuer) " +
+                "VALUES(gen_random_uuid(), 'memberClaim', now(), now(), $1, $2, $3) RETURNING Id",
                 [duration_ms / 3600000, row.id, row.vanca]
             );
+            notify.add('CertificateRequests', cert.rows[0].id);
             await client.query("UPDATE MemberInvitations SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-            rowId = row.id;
+            notify.update('MemberInvitations', row.id);
         }
         await client.query('COMMIT');
-        if (rowId) {
-            await WatchNotify('MemberInvitations', rowId);
-        }
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back new-invitation transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewInvitations, reschedule_delay);
     }
 }
 
 //
 // processNewMemberSites
 //
-const processNewMemberSites = async function() {
-    let reschedule_delay = 2000;
+async function onMemberSitesChange(action, tableName, id) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
-        let rowId;
         await client.query('BEGIN');
         const result = await client.query(
             "SELECT MemberSites.*, ApplicationNetworks.Lifecycle as vanlc, ApplicationNetworks.Certificate as vanca FROM MemberSites " + 
@@ -293,34 +271,30 @@ const processNewMemberSites = async function() {
             const row = result.rows[0];
             Log(`New Member Site: ${row.name}`);
             let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Site, Issuer) VALUES(gen_random_uuid(), 'vanSite', now(), now(), $1, $2, $3)",
+            const cert = await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, Site, Issuer) " +
+                "VALUES(gen_random_uuid(), 'vanSite', now(), now(), $1, $2, $3) RETURNING  Id",
                 [duration_ms / 3600000, row.id, row.vanca]
             );
+            notify.add('CertificateRequests', cert.rows[0].id);
             await client.query("UPDATE MemberSites SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-            rowId = row.id;
+            notify.update('MemberSites', row.id);
         }
         await client.query('COMMIT');
-        if (rowId) {
-            await WatchNotify('MemberSites', rowId);
-        }
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back new-member-site transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewMemberSites, reschedule_delay);
     }
 }
 
 
-const processNewNetworkCredentials = async function() {
-    let reschedule_delay = 2000;
+async function onNetworkCredentialsChange(action, tableName, id) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
-        let rowId;
         await client.query('BEGIN');
         const result = await client.query(
             "SELECT NetworkCredentials.*, ApplicationNetworks.Lifecycle as vanlc, Backbones.Certificate as vanca " +
@@ -333,25 +307,22 @@ const processNewNetworkCredentials = async function() {
             const row = result.rows[0];
             Log(`New Network Credential: ${row.name}`);
             let duration_ms = IntervalMilliseconds(DefaultCertExpiration());
-            await client.query(
-                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, NetworkCredential, Issuer) VALUES(gen_random_uuid(), 'vanCredential', now(), now(), $1, $2, $3)",
+            const cert = await client.query(
+                "INSERT INTO CertificateRequests(Id, RequestType, CreatedTime, RequestTime, DurationHours, NetworkCredential, Issuer) " +
+                "VALUES(gen_random_uuid(), 'vanCredential', now(), now(), $1, $2, $3) RETURNING Id",
                 [duration_ms / 3600000, row.id, row.vanca]
             );
+            notify.add('CertificateRequests', cert.rows[0].id);
             await client.query("UPDATE NetworkCredentials SET Lifecycle = 'skx_cr_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
-            rowId = row.id;
+            notify.update('NetworkCredentials', row.id);
         }      
         await client.query('COMMIT');
-        if (rowId) {
-            await WatchNotify('NetworkCredentials', rowId);
-        }
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back new-network-credential transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewNetworkCredentials, reschedule_delay);
     }
 }
 
@@ -360,9 +331,9 @@ const processNewNetworkCredentials = async function() {
 //
 // When new networks are created, add a certificate request to begin the full setup of the network.
 //
-const processNewCertificateRequests = async function() {
-    var reschedule_delay = 2000;
+async function onCertificateRequestsChange(action, tableName, id) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query('BEGIN');
         const result = await client.query("SELECT * FROM CertificateRequests WHERE RequestTime <= now() and Lifecycle = 'new' ORDER BY CreatedTime LIMIT 1");
@@ -440,16 +411,15 @@ const processNewCertificateRequests = async function() {
             var cert_obj = certificateObject(name, row.durationhours, is_ca, issuer_name, row.id, row.issuer ? row.issuer : 'root', extra_annotations, name, dns_name, usage);
             await ApplyObject(cert_obj);
             await client.query("UPDATE CertificateRequests SET Lifecycle = 'cm_cert_created' WHERE Id = $1", [row.id]);
-            reschedule_delay = 0;
+            notify.update('CertificateRequests', row.id);
         }
         await client.query('COMMIT');
+        await notify.commit();
     } catch (err) {
         Log(`Rolling back cert-request transaction: ${err.stack}`);
         await client.query('ROLLBACK');
-        reschedule_delay = 10000;
     } finally {
         client.release();
-        setTimeout(processNewCertificateRequests, reschedule_delay);
     }
 }
 
@@ -457,8 +427,9 @@ const processNewCertificateRequests = async function() {
 // A secret that is controlled by this controller and has a database link has been added.  Update the database
 // to register the completion of the creation of a certificate or a CA.
 //
-const secretAdded = async function(dblink, secret) {
+async function secretAdded(dblink, secret) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query('BEGIN');
         const result = await client.query("SELECT * FROM CertificateRequests WHERE Id = $1", [dblink]);
@@ -528,24 +499,28 @@ const secretAdded = async function(dblink, secret) {
                     "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label) VALUES ($1, $2, $3, $4, $5, $6)",
                     [dblink, is_ca, secret.metadata.name, expiration, renewal, label]
                 );
+                notify.add('TlsCertificates', dblink);
             } else {
                 await client.query(
                     "INSERT INTO TlsCertificates (Id, IsCA, ObjectName, Expiration, RenewalTime, Label, SignedBy) VALUES ($1, $2, $3, $4, $5, $6, $7)",
                     [dblink, is_ca, secret.metadata.name, expiration, renewal, label, signed_by]
                 );
+                notify.add('TlsCertificates', dblink);
             }
             await client.query(`UPDATE ${ref_table} SET Certificate = $1, Lifecycle = 'ready' WHERE Id = $2`, [dblink, ref_id]);
+            notify.update(ref_table, ref_id);
             await client.query('DELETE FROM CertificateRequests WHERE Id = $1', [dblink]);
+            notify.delete('CertificateRequests', dblink)
             if (is_ca) {
                 var issuer_obj = issuerObject(secret.metadata.name, secret.metadata.annotations['skupper.io/skx-dblink']);
                 await ApplyObject(issuer_obj);
             }
             Log(`Certificate${is_ca ? ' Authority' : ''} created: ${secret.metadata.name}`)
             if (alertSiteCertChanged) {
-                await SiteLifecycleChanged_TX(client, ref_id, 'ready');
+                await SiteLifecycleChanged_TX(client, notify, ref_id, 'ready');
             }
             await client.query('COMMIT');
-            await WatchNotify(ref_table, ref_id);
+            await notify.commit();
 
             //
             // Alert the sync module that changes have been made that require reconciliation with remote sites
@@ -609,14 +584,24 @@ const onCertificateWatch = async function(action, cert) {
         && cert.status
         && cert.status.notAfter
         && cert.status.renewalTime) {
+        const notify      = new NotifyTransaction();
         const client      = await ClientFromPool('system');
         const expiration  = new Date(cert.status.notAfter);
         const renewal     = new Date(cert.status.renewalTime);
-        await client.query(
-            "UPDATE TlsCertificates SET expiration = $1, renewalTime = $2 WHERE ObjectName = $3",
-            [expiration, renewal, cert.metadata.name]
-        );
-        client.release();
+        try {
+            const dbcert = await client.query(
+                "UPDATE TlsCertificates SET expiration = $1, renewalTime = $2 WHERE ObjectName = $3 RETURNING Id",
+                [expiration, renewal, cert.metadata.name]
+            );
+            for (const dbrow of dbcert.rows) {
+                notify.update('TlsCertificates', dbrow.id);
+            }
+            await notify.commit();
+        } catch (error) {
+            Log(`Exception in onCertificateWatch: ${error.stack}`);
+        } finally {
+            client.release();
+        }
     }
 }
 
@@ -730,15 +715,15 @@ const WatchCertManager = function() {
 
 export async function Start() {
     Log('[Certificate module starting]');
-    setTimeout(processNewManagementControllers, 1000);
-    setTimeout(processNewBackbones, 1000);
-    setTimeout(processNewAccessPoints, 1000);
-    setTimeout(processNewNetworks, 1000);
-    setTimeout(processNewNetworkCredentials, 1000);
-    setTimeout(processNewInteriorSites, 1000);
-    setTimeout(processNewInvitations, 1000);
-    setTimeout(processNewMemberSites, 1000);
-    setTimeout(processNewCertificateRequests, 1000);
+    RegisterNotification('ManagementControllers', onManagementControllersChange, true);
+    RegisterNotification('Backbones', onBackbonesChange, true);
+    RegisterNotification('BackboneAccessPoints', onAccessPointsChange, true);
+    RegisterNotification('ApplicationNetworks', onApplicationNetworksChange, true);
+    RegisterNotification('NetworkCredentials', onNetworkCredentialsChange, true);
+    RegisterNotification('InteriorSites', onInteriorSitesChange, true);
+    RegisterNotification('MemberInvitations', onInvitationsChange, true);
+    RegisterNotification('MemberSites', onMemberSitesChange, true);
+    RegisterNotification('CertificateRequests', onCertificateRequestsChange, true);
     
     await WatchCertManager();
     WatchSecrets(onSecretWatch);

--- a/components/management-controller/src/claim-server.js
+++ b/components/management-controller/src/claim-server.js
@@ -41,6 +41,7 @@ import { LoadSecret } from '@skupperx/modules/kube'
 import { DispatchMessage, AssertClaimResponseSuccess, ReponseFailure } from '@skupperx/modules/protocol'
 import { RegisterHandler } from './backbone-links.js';
 import { HashOfData } from './resource-templates.js';
+import { NotifyTransaction } from './notify.js';
 
 var backbones         = {};   // backboneId => {conn: AMQP-Connection, sender: anon-sender, receiver: claim-receiver}
 var memberCompletions = {};   // memberId   => {handler: completion-function, result: undefined || {}, error: undefined || ERROR }
@@ -158,6 +159,7 @@ const processClaim = async function(claimId, name) {
     var memberId;
 
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT * FROM MemberInvitations WHERE Id = $1 and (JoinDeadline IS NULL OR JoinDeadline > now())", [claimId]);
@@ -177,6 +179,7 @@ const processClaim = async function(claimId, name) {
         // Increment the instance count for the invitation
         //
         await client.query("UPDATE MemberInvitations SET InstanceCount = $1 WHERE Id = $2", [claim.instancecount + 1, claimId]);
+        notify.update('MemberInvitations', claimId);
 
         //
         // Create a new member from the invitation
@@ -184,6 +187,7 @@ const processClaim = async function(claimId, name) {
         const memberResult = await client.query("INSERT INTO MemberSites (Name, MemberOf, Invitation, SiteClasses, Metadata) VALUES ($1, $2, $3, $4, $5) RETURNING Id",
                                                 [name, claim.memberof, claim.id, claim.memberclasses, JSON.stringify({name: name})]);
         memberId = memberResult.rows[0].id;
+        notify.add('MemberSites', memberId);
 
         //
         // Set up the completion handler for this memberId (before the COMMIT!)
@@ -194,6 +198,7 @@ const processClaim = async function(claimId, name) {
             callback : undefined,
         };
         await client.query("COMMIT");
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`INFO:ClaimServer - Exception in claim processing for claim ${claimId}: ${error.message}`);

--- a/components/management-controller/src/external-vans.js
+++ b/components/management-controller/src/external-vans.js
@@ -30,7 +30,7 @@ import { Log } from '@skupperx/modules/log'
 import { ListAddresses, Start as RouterStart, NotifyApiReady } from '@skupperx/modules/router'
 import { RegisterHandler } from "./backbone-links.js";
 import { ClientFromPool } from './db.js';
-import { WatchNotify } from './watch-server.js';
+import { NotifyTransaction } from './notify.js';
 
 const getNetworkIds = async function() {
     const addresses   = await ListAddresses(['key']);
@@ -48,6 +48,7 @@ const getNetworkIds = async function() {
 const reconcileConnectedNetworks = async function() {
     let reschedule_delay = 5000;
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         let   pending_change = {};
@@ -73,10 +74,11 @@ const reconcileConnectedNetworks = async function() {
 
         for (const [vid, connected] of Object.entries(pending_change)) {
             await client.query("UPDATE ApplicationNetworks SET Connected = $2 WHERE Id = $1", [vid, connected]);
+            notify.update('ApplicationNetworks', vid);
         }
 
         await client.query("COMMIT");
-        await WatchNotify('ApplicationNetworks', vid);
+        await notify.commit();
     } catch (err) {
         await client.query("ROLLBACK");
         reschedule_delay = 10000;

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -41,6 +41,7 @@ import * as common     from '@skupperx/modules/common'
 import { StartWatchServer } from './watch-server.js';
 import ViteExpress from 'vite-express';
 import { createManagementOidcAuth } from './auth/management-oidc.js';
+import { NotifyTransaction } from './notify.js';
 
 const __dirname = import.meta.dirname;
 /** Deployed image: sources live in `/app/src`, console bundle in `/app/console/dist`. Monorepo dev: `components/console` (two levels up from `components/management-controller/src`). */
@@ -157,6 +158,7 @@ const fetchBackboneSiteSkupper2 = async function (req, res) {
                 throw new Error("Not permitted, site not ready for deployment");
             }
             const secret = await LoadSecret(site.objectname);
+            console.log(site.name, site.certificate, site.objectname);
             let output = [];
             output.push(resourceTemplates.ServiceAccount());
             output.push(resourceTemplates.BackboneRole());
@@ -399,6 +401,7 @@ const getCertDetail = async function(req, res) {
 export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
     let retval = 1;
     const client = await ClientFromPool();
+    const notify = new NotifyTransaction();
     try {
         await queryWithContext(req, client, async (client) => {
             const result = await client.query(`SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints WHERE Id = $1 AND InteriorSite = $2`, [apid, siteId]);
@@ -412,6 +415,7 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
                         throw new Error(`Referenced access (${access.access_ref}) has lifecycle ${access.lifecycle}, expected partial`);
                     }
                     await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3", [hostname, port, apid]);
+                    notify.update('BackboneAccessPoints', apid);
                 }
     
                 //
@@ -423,7 +427,8 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
             } else {
                 throw new Error(`Access point not found for site ${siteId} (${apid})`);
             }
-        })
+        });
+        await notify.commit();
     } catch (err) {
         Log(`Host add to AccessPoint failed: ${err.message}`);
         retval = 0;

--- a/components/management-controller/src/notify.js
+++ b/components/management-controller/src/notify.js
@@ -1,0 +1,116 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+"use strict";
+
+/**
+ * This module is the central clearinghouse for database change updates.
+ * Any module may register a handler for notification of data changes.
+ *
+ * The notification handler has the arguments: (action, tableName, id)
+ *   Where action is ADD, EXISTS, DELETE, UPDATE
+ *   tableName is the name of the database table that was modified
+ *   id is the unique key of the changed row in the database
+ *
+ * Triggering notifications mirrors the database transaction lifecycle.
+ * Start by allocating a NotifyTransaction.  In the body of the transaction,
+ * record adds, deletes, and updates of table rows.  After successfully committing
+ * the database transaction, commit the NotifyTransaction to cause the notification
+ * handlers to be called.
+ *
+ * const notify = new NotifyTransaction();
+ * await client.query('BEGIN');
+ * ...
+ * notify.[add,delete,update](tableName, rowId);
+ * ...
+ * await client.query('COMMIT');
+ * await notify.commit();
+ */
+
+import { Log }            from "@skupperx/modules/log";
+import { ClientFromPool } from "./db.js";
+import { WatchNotify }    from "./watch-server.js";
+
+const registeredHandlers   = {};  // {tableName => [List of handlers]}
+const INITIAL_NOTIFY_DELAY = 3000;
+
+export async function RegisterNotification(tableName, handler, initialNotification) {
+    if (!registeredHandlers[tableName]) {
+        registeredHandlers[tableName] = [];
+    }
+
+    registeredHandlers[tableName].push(handler);
+
+    if (initialNotification) {
+        setTimeout(async () => {
+            const client = await ClientFromPool('system');
+            try {
+                const rows = await client.query(`SELECT Id FROM ${tableName}`).then(result => result.rows);
+                for (const row of rows) {
+                    await handler('EXISTS', tableName, row.id);
+                }
+            } catch (error) {
+                Log(`Exception in initial notification: ${error.message}`);
+            } finally {
+                client.release();
+            }
+        }, INITIAL_NOTIFY_DELAY);
+    }
+}
+
+export class NotifyTransaction {
+    constructor() {
+        this.events = [];
+    }
+
+    add(tableName, id) {
+        this.events.push({
+            action    : 'ADD',
+            tableName : tableName,
+            id        : id,
+        });
+    }
+
+    delete(tableName, id) {
+        this.events.push({
+            action    : 'DELETE',
+            tableName : tableName,
+            id        : id,
+        });
+    }
+
+    update(tableName, id) {
+        this.events.push({
+            action    : 'UPDATE',
+            tableName : tableName,
+            id        : id,
+        });
+    }
+
+    async commit() {
+        for (const item of this.events) {
+            const handlers = registeredHandlers[item.tableName] || [];
+            for (const h of handlers) {
+//              Log(`Calling notify handler for table ${item.tableName}, id ${item.id}`);
+                await h(item.action, item.tableName, item.id);
+                await WatchNotify(item.tableName, item.id);
+            }
+        }
+    }
+}

--- a/components/management-controller/src/prune.js
+++ b/components/management-controller/src/prune.js
@@ -30,6 +30,7 @@ import {
 import { Log } from '@skupperx/modules/log'
 import { META_ANNOTATION_SKUPPERX_CONTROLLED } from '@skupperx/modules/common'
 import { ClientFromPool } from './db.js';
+import { NotifyTransaction } from './notify.js';
 
 const reconcileCertificates = async function() {
     const client = await ClientFromPool('system');
@@ -72,6 +73,7 @@ const reconcileCertificates = async function() {
 
 export async function DeleteOrphanCertificates() {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         let deleteMap = {};
@@ -109,23 +111,25 @@ export async function DeleteOrphanCertificates() {
             }
         }
 
-        const depthFirstDelete = async function(client, certId) {
+        const depthFirstDelete = async function(client, notify, certId) {
             const record = deleteMap[certId];
             for (const childId of record.children) {
-                await depthFirstDelete(client, childId);
+                await depthFirstDelete(client, notify, childId);
             }
             if (record.pleaseDelete) {
                 await client.query("DELETE FROM TlsCertificates WHERE Id = $1", [certId]);
+                notify.delete('TlsCertificates', certId);
                 Log(`Orphan TlsCertificate ${certId} to be deleted`);
                 record.pleaseDelete = false;
             }
         }
 
         for (const certId of Object.keys(deleteMap)) {
-            await depthFirstDelete(client, certId);
+            await depthFirstDelete(client, notify, certId);
         }
 
         await client.query("COMMIT");
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in DeleteOrphanCertificates: ${error.message}`);

--- a/components/management-controller/src/resource-templates.js
+++ b/components/management-controller/src/resource-templates.js
@@ -152,48 +152,6 @@ export function LinkCR(linkId, data, secret) {
     return link;
 }
 
-export function LinkConfigMap(linkId, data) {  // DEPRECATE
-    let link = {
-        apiVersion : 'v1',
-        kind       : 'ConfigMap',
-        metadata   : {
-            name : `skx-link-${linkId}`,
-            annotations : {
-                [META_ANNOTATION_SKUPPERX_CONTROLLED] : 'true',
-                [META_ANNOTATION_STATE_TYPE]          : STATE_TYPE_LINK,
-                [META_ANNOTATION_STATE_ID]            : linkId,
-                [META_ANNOTATION_STATE_DIR]           : 'remote',
-                [META_ANNOTATION_STATE_KEY]           : `link-${linkId}`,
-            },
-        },
-        data : data,
-    };
-
-    link.metadata.annotations[META_ANNOTATION_STATE_HASH] = HashOfConfigMap(link);
-    return link;
-}
-
-export function AccessPointConfigMap(apId, data) {  // DEPRECATE
-    let accessPoint = {
-        apiVersion : 'v1',
-        kind       : 'ConfigMap',
-        metadata   : {
-            name : `skx-access-${apId}`,
-            annotations : {
-                [META_ANNOTATION_SKUPPERX_CONTROLLED] : 'true',
-                [META_ANNOTATION_STATE_TYPE]          : STATE_TYPE_ACCESS_POINT,
-                [META_ANNOTATION_STATE_ID]            : apId,
-                [META_ANNOTATION_STATE_DIR]           : 'remote',
-                [META_ANNOTATION_STATE_KEY]           : `access-${apId}`,
-            },
-        },
-        data : data,
-    };
-
-    accessPoint.metadata.annotations[META_ANNOTATION_STATE_HASH] = HashOfConfigMap(accessPoint);
-    return accessPoint;
-}
-
 export function AccessPointCR(apId, data) {
     switch (data.kind) {
         case 'manage':

--- a/components/management-controller/src/site-deployment-state.js
+++ b/components/management-controller/src/site-deployment-state.js
@@ -26,8 +26,9 @@
 import { Log } from '@skupperx/modules/log'
 import { ClientFromPool } from './db.js';
 import { WatchNotify } from './watch-server.js';
+import { NotifyTransaction } from './notify.js';
 
-const evaluateSingleSite_TX = async function (client, site) {
+const evaluateSingleSite_TX = async function (client, notify, site) {
     let state = 'not-ready';
 
     if (site.lifecycle == 'active') {
@@ -61,15 +62,15 @@ const evaluateSingleSite_TX = async function (client, site) {
 
     if (state != site.deploymentstate) {
         await client.query("UPDATE InteriorSites SET DeploymentState = $1 WHERE Id = $2", [state, site.id]);
-        await WatchNotify('InteriorSites', site.id);
+        notify.update('InteriorSites', site.id);
     }
 }
 
-export async function SiteLifecycleChanged_TX(client, siteId, newState) {
+export async function SiteLifecycleChanged_TX(client, notify, siteId, newState) {
     const result = await client.query("SELECT Id, Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1", [siteId]);
     if (result.rowCount == 1) {
         const site = result.rows[0];
-        await evaluateSingleSite_TX(client, site);
+        await evaluateSingleSite_TX(client, notify, site);
         if (newState == 'active') {
             //
             // If this site became active, evaluate all sites connected to this site
@@ -80,7 +81,7 @@ export async function SiteLifecycleChanged_TX(client, siteId, newState) {
             for (const row of connected.rows) {
                 const siteResult = await client.query("SELECT Id, Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1", [row.connectinginteriorsite]);
                 if (siteResult.rowCount == 1) {
-                    await evaluateSingleSite_TX(client, siteResult.rows[0]);
+                    await evaluateSingleSite_TX(client, notify, siteResult.rows[0]);
                 }
             }
         }
@@ -89,6 +90,7 @@ export async function SiteLifecycleChanged_TX(client, siteId, newState) {
 
 export async function LinkAddedOrDeleted(connectingSiteId, accessPointId) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         //
@@ -100,10 +102,11 @@ export async function LinkAddedOrDeleted(connectingSiteId, accessPointId) {
         if (lResult.rowCount == 1 && lResult.rows[0].deploymentstate == 'deployed') {
             const cResult = await client.query("SELECT Id, Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1", [connectingSiteId]);
             if (cResult.rowCount == 1) {
-                await evaluateSingleSite_TX(client, cResult.rows[0]);
+                await evaluateSingleSite_TX(client, notify, cResult.rows[0]);
             }
         }
         await client.query("COMMIT");
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in LinkAddedOrDeleted: ${error.message}`);
@@ -115,16 +118,18 @@ export async function LinkAddedOrDeleted(connectingSiteId, accessPointId) {
 
 export async function ManageIngressAdded(siteId) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT Id, Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1", [siteId]);
         if (result.rowCount == 1) {
             const site = result.rows[0];
             if (site.deploymentstate == 'not-ready') {
-                await evaluateSingleSite_TX(client, site);
+                await evaluateSingleSite_TX(client, notify, site);
             }
         }
         await client.query("COMMIT");
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in ManageIngressAdded: ${error.message}`);
@@ -136,16 +141,18 @@ export async function ManageIngressAdded(siteId) {
 
 export async function ManageIngressDeleted(siteId) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT Id, Lifecycle, DeploymentState FROM InteriorSites WHERE Id = $1", [siteId]);
         if (result.rowCount == 1) {
             const site = result.rows[0];
             if (site.deploymentstate == 'ready-bootstrap') {
-                await evaluateSingleSite_TX(client, site);
+                await evaluateSingleSite_TX(client, notify, site);
             }
         }
         await client.query("COMMIT");
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in ManageIngressDeleted: ${error.message}`);
@@ -157,6 +164,7 @@ export async function ManageIngressDeleted(siteId) {
 
 export async function AccessPointCertReady(apId) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         const result = await client.query(
@@ -166,9 +174,10 @@ export async function AccessPointCertReady(apId) {
             [apId]
         );
         if (result.rowCount == 1) {
-            await evaluateSingleSite_TX(client, result.rows[0]);
+            await evaluateSingleSite_TX(client, notify, result.rows[0]);
         }
         await client.query("COMMIT");
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in AccessPointCertReady: ${error.message}`);
@@ -180,16 +189,18 @@ export async function AccessPointCertReady(apId) {
 
 export async function EvaluateAllSites() {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         const result = await client.query("SELECT * FROM InteriorSites");
         for (const site of result.rows) {
-            await evaluateSingleSite_TX(client, site);
+            await evaluateSingleSite_TX(client, notify, site);
         }
         await client.query("COMMIT");
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
-        Log(`Exception in EvaluateAllSites: ${error.message}`);
+        Log(`Exception in EvaluateAllSites: ${error.stack}`);
     } finally {
         client.release();
     }

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -35,7 +35,7 @@ import { onMewMember, StateRequest } from './sync-application.js';
 import { RegisterHandler } from './backbone-links.js';
 import { HashOfSecret, HashOfData } from './resource-templates.js';
 import { SiteLifecycleChanged_TX } from './site-deployment-state.js';
-import { WatchNotify } from './watch-server.js';
+import { NotifyTransaction } from './notify.js';
 
 var peers = {};  // {peerId: {pClass: <>, stuff}}
 
@@ -98,6 +98,7 @@ async function onNewBackboneSite(peerId) {
     var localState  = {};
     var remoteState = {};
     const client    = await ClientFromPool('system');
+    const notify    = new NotifyTransaction();
     try {
         await client.query("BEGIN");
 
@@ -163,13 +164,14 @@ async function onNewBackboneSite(peerId) {
         //
         if (site.lifecycle == 'ready') {
             await client.query("UPDATE InteriorSites SET FirstActiveTime = CURRENT_TIMESTAMP, LastHeartbeat = CURRENT_TIMESTAMP, LifeCycle = 'active' WHERE Id = $1", [peerId]);
-            await SiteLifecycleChanged_TX(client, peerId, 'active');
+            await SiteLifecycleChanged_TX(client, notify, peerId, 'active');
         } else {
             await client.query("UPDATE InteriorSites SET LastHeartbeat = CURRENT_TIMESTAMP WHERE Id = $1", [peerId]);
         }
+        notify.update('InteriorSites', peerId);
 
         await client.query("COMMIT");
-        await WatchNotify('InteriorSites', peerId);
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in onNewBackboneSite processing: ${error.message}`);
@@ -203,12 +205,14 @@ async function onStateChangeBackbone(peerId, stateKey, hash, data) {
 
         const accessId = stateKey.substring(13);
         const client = await ClientFromPool('system');
+        const notify = new NotifyTransaction();
         try {
             await client.query("BEGIN");
             await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port = $2, Lifecycle = 'new' " +
                                "WHERE Id = $3 AND Lifecycle = 'partial' AND InteriorSite = $4", [data.host, data.port, accessId, peerId]);
+            notify.update('BackboneAccessPoints', accessId);
             await client.query("COMMIT");
-            await WatchNotify('BackboneAccessPoints', accessId);
+            await notify.commit();
         } catch (error) {
             await client.query("ROLLBACK");
             Log(`Exception in onStateChangeBackbone processing: ${error.message}`);
@@ -418,6 +422,7 @@ async function onNewMember(peerId) {
     var localState  = {};
     var remoteState = {};
     const client    = await ClientFromPool('system');
+    const notify    = new NotifyTransaction();
     try {
         await client.query("BEGIN");
 
@@ -457,9 +462,10 @@ async function onNewMember(peerId) {
         } else {
             await client.query("UPDATE MemberSites SET LastHeartbeat = CURRENT_TIMESTAMP WHERE Id = $1", [peerId]);
         }
+        notify.update('MemberSites', peerId);
 
         await client.query("COMMIT");
-        await WatchNotify('MemberSites', peerId);
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in onNewMember processing: ${error.message}`);
@@ -559,20 +565,19 @@ async function onStateRequest(peerId, stateKey) {
 
 async function onPing(peerId) {
     const client = await ClientFromPool('system');
+    const notify = new NotifyTransaction();
     try {
         await client.query("BEGIN");
         const peer = peers[peerId];
         if (peer.pClass == CLASS_BACKBONE) {
             await client.query("UPDATE InteriorSites SET LastHeartbeat = CURRENT_TIMESTAMP WHERE Id = $1", [peerId]);
+            notify.update('InteriorSites', peerId);
         } else if (peer.pClass == CLASS_MEMBER) {
             await client.query("UPDATE MemberSites SET LastHeartbeat = CURRENT_TIMESTAMP WHERE Id = $1", [peerId]);
+            notify.update('MemberSites', peerId);
         }
         await client.query("COMMIT");
-        if (peer.pClass == CLASS_BACKBONE) {
-            await WatchNotify('InteriorSites', peerId, true);
-        } else if (peer.pClass == CLASS_MEMBER) {
-            await WatchNotify('MemberSites', peerId, true);
-        }
+        await notify.commit();
     } catch (error) {
         await client.query("ROLLBACK");
         Log(`Exception in onPing processing: ${error.message}`);


### PR DESCRIPTION
This PR introduces the new feature.  It does not remove all of the old custom notification calls that appear throughout the code base.  That will be left for a later PR.

This PR _does_ replace the time-based periodic processing of TLS certificates with a faster and more efficient use of the new notification utility.

Note that this feature is a prerequisite for completion of the colocated-site feature.

Note also that the new utility subsumes the Watch notification.  There is no longer a need to explicitly call WatchNotify after any database transactions.