### PR TITLE
Co-located backbone sites are no longer optional

### DIFF
--- a/components/console/src/pages/Backbones/Backbones.jsx
+++ b/components/console/src/pages/Backbones/Backbones.jsx
@@ -33,8 +33,6 @@ const Backbones = () => {
   const [error, setError] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [backboneName, setBackboneName] = useState('');
-  const [coLocated, setCoLocated] = useState(false);
-  const [coLocatedNamespace, setCoLocatedNamespace] = useState('');
   const [ownerGroup, setOwnerGroup] = useState('');
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState(null);
@@ -84,7 +82,6 @@ const Backbones = () => {
         },
         body: JSON.stringify({
           name: backboneName.trim(),
-          coLocatedNamespace: coLocated ? coLocatedNamespace.trim() : null,
           ownerGroup,
         }),
       });
@@ -96,8 +93,6 @@ const Backbones = () => {
 
       // Reset form and close modal
       setBackboneName('');
-      setCoLocated(false);
-      setCoLocatedNamespace('');
       setOwnerGroup('');
       setIsModalOpen(false);
     } catch (err) {
@@ -328,8 +323,6 @@ const Backbones = () => {
         onRequestClose={() => {
           setIsModalOpen(false);
           setBackboneName('');
-          setCoLocated(false);
-          setCoLocatedNamespace('');
           setOwnerGroup('');
           setCreateError(null);
         }}
@@ -353,29 +346,11 @@ const Backbones = () => {
           value={backboneName}
           onChange={(e) => {
             setBackboneName(e.target.value);
-            let prefix = e.target.value.length > 0 ? "colo-" : "";
-            setCoLocatedNamespace(prefix + e.target.value)}}
+          }}
           disabled={isCreating}
           style={{ marginBottom: '1rem' }}
         />
 
-        <Checkbox
-          id="colocated"
-          labelText="Deploy a co-located backbone site"
-          checked={coLocated}
-          onChange={(e) => { setCoLocated(e.target.checked); }}
-          disabled={isCreating}
-        />
-
-        <TextInput
-          id="backbone-namespace"
-          labelText="Co-Located Namespace"
-          placeholder="Enter co-located backbone namespace"
-          value={coLocatedNamespace}
-          onChange={(e) => setCoLocatedNamespace(e.target.value)}
-          disabled={isCreating || !coLocated}
-          style={{ marginBottom: '1rem' }}
-        />
         <OwnerGroupSelect
           id="backbone-owner-group"
           labelText="Owner group"

--- a/components/console/src/pages/Backbones/Backbones.jsx
+++ b/components/console/src/pages/Backbones/Backbones.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
-  Checkbox,
   DataTable,
   Table,
   TableHead,

--- a/components/management-controller/src/api-admin.js
+++ b/components/management-controller/src/api-admin.js
@@ -36,11 +36,10 @@ const createBackbone = async function(req, res) {
     try {
         const [fields, files] = await form.parse(req);
         const norm = ValidateAndNormalizeFields(fields, {
-            'name' : {type: 'string', optional: false},
-            'coLocatedNamespace' : {type: 'dns-segment', optional: true, default: null},
+            'name' : {type: 'dns-segment', optional: false},
             'ownerGroup': {type: 'string', optional: true, default: ''},
         });
-
+        const coLocatedNamespace = `colo-${norm.name}`;
         const client = await ClientFromPool();
         const notify = new NotifyTransaction();
         try {
@@ -49,7 +48,7 @@ const createBackbone = async function(req, res) {
             await queryWithContext(req, client, async (client, userInfo) => {
                 const result = await client.query(
                     "INSERT INTO Backbones(Name, LifeCycle, Owner, OwnerGroup, CoLocatedNamespace) " +
-                    "VALUES ($1, 'new', $2, $3, $4) RETURNING Id", [norm.name, userInfo.userId, norm.ownerGroup, norm.coLocatedNamespace]
+                    "VALUES ($1, 'new', $2, $3, $4) RETURNING Id", [norm.name, userInfo.userId, norm.ownerGroup, coLocatedNamespace]
                 );
                 backboneId = result.rows[0].id;
                 notify.add('Backbones', backboneId);


### PR DESCRIPTION
Removes the checkbox to deploy a co-located backbone site. The co-located backbone site is always deployed and the namespace is automatically set to `colo-<backbone-name>`.

The validation for the backbone name field type, has also changed from `string` to `dns-segment`, as it is used to compose the namespace name, so the same validation that was applied to the former `coLocatedNamespace` field is now applied to the backbone name.

Fixes #129