### PR TITLE
Refactor management-controller for testability and add unit tests

### DIFF
--- a/components/management-controller/src/api-admin.test.js
+++ b/components/management-controller/src/api-admin.test.js
@@ -1,0 +1,187 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createMockClient, TEST_UUIDS } from './test-helpers/mock-db.js';
+import { buildApiApp } from './test-helpers/build-api-app.js';
+
+const mockClient = createMockClient();
+let mockFormFields = {};
+
+vi.mock('formidable', () => ({
+    IncomingForm: class {
+        parse() {
+            return Promise.resolve([mockFormFields, {}]);
+        }
+    },
+}));
+
+vi.mock('./watch-server.js', () => ({
+    WatchNotify: vi.fn(),
+}));
+
+vi.mock('./sync-management.js', () => ({
+    SiteDeleted: vi.fn(),
+    SiteIngressChanged: vi.fn(),
+    LinkChanged: vi.fn(),
+}));
+
+vi.mock('./site-deployment-state.js', () => ({
+    ManageIngressAdded: vi.fn(),
+    LinkAddedOrDeleted: vi.fn(),
+    ManageIngressDeleted: vi.fn(),
+}));
+
+vi.mock('./db.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        ClientFromPool: vi.fn(async () => mockClient),
+    };
+});
+
+describe('api-admin', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('INSERT INTO Users')) {
+                return { rows: [{ id: 'internal-user-1' }] };
+            }
+            if (sql.includes('set_config')) {
+                return {};
+            }
+            if (sql.includes('SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones WHERE Id')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: TEST_UUIDS.backbone,
+                        name: 'backbone-a',
+                        lifecycle: 'ready',
+                        failure: null,
+                        ownergroup: '',
+                    }],
+                };
+            }
+            if (sql.includes('SELECT Id, Name, Lifecycle, Failure, OwnerGroup FROM Backbones')) {
+                return {
+                    rows: [{
+                        id: TEST_UUIDS.backbone,
+                        name: 'backbone-a',
+                        lifecycle: 'ready',
+                        failure: null,
+                        ownergroup: '',
+                    }],
+                };
+            }
+            return { rows: [], rowCount: 0 };
+        });
+    });
+
+    it('GET /backbones returns backbone list when authenticated', async () => {
+        const { app } = await buildApiApp({ includeUser: false });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/backbones')
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body).toEqual([{
+            id: TEST_UUIDS.backbone,
+            name: 'backbone-a',
+            lifecycle: 'ready',
+            failure: null,
+            ownergroup: '',
+        }]);
+    });
+
+    it('GET /backbones/:bid returns a single backbone', async () => {
+        const { app } = await buildApiApp({ includeUser: false });
+
+        const res = await request(app)
+            .get(`/api/v1alpha1/backbones/${TEST_UUIDS.backbone}`)
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body.id).toBe(TEST_UUIDS.backbone);
+    });
+
+    it('GET /backbones/:bid rejects malformed ids', async () => {
+        const { app } = await buildApiApp({ includeUser: false });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/backbones/not-a-uuid')
+            .set('x-test-auth', '1')
+            .expect(400);
+
+        expect(res.text).toContain('not a valid uuid');
+    });
+
+    it('GET /backbones returns 401 without authentication', async () => {
+        const { app } = await buildApiApp({ includeUser: false });
+
+        await request(app)
+            .get('/api/v1alpha1/backbones')
+            .expect(401);
+    });
+
+    it('GET /backbones returns 403 without list role', async () => {
+        const { app } = await buildApiApp({
+            includeUser: false,
+            roles: ['viewer'],
+        });
+
+        await request(app)
+            .get('/api/v1alpha1/backbones')
+            .set('x-test-auth', '1')
+            .expect(403);
+    });
+
+    it('POST /backbones creates a backbone', async () => {
+        mockFormFields = { name: 'new-backbone' };
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('INSERT INTO Users')) {
+                return { rows: [{ id: 'internal-user-1' }] };
+            }
+            if (sql.includes('set_config')) {
+                return {};
+            }
+            if (sql.includes('INSERT INTO Backbones')) {
+                return { rows: [{ id: TEST_UUIDS.backbone }] };
+            }
+            return { rows: [], rowCount: 0 };
+        });
+
+        const { app } = await buildApiApp({ includeUser: false });
+
+        const res = await request(app)
+            .post('/api/v1alpha1/backbones')
+            .set('x-test-auth', '1')
+            .field('name', 'new-backbone')
+            .expect(201);
+
+        expect(res.body).toEqual({ id: TEST_UUIDS.backbone });
+    });
+});

--- a/components/management-controller/src/api-user.test.js
+++ b/components/management-controller/src/api-user.test.js
@@ -1,0 +1,174 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createMockClient, TEST_UUIDS } from './test-helpers/mock-db.js';
+import { buildApiApp } from './test-helpers/build-api-app.js';
+
+const mockClient = createMockClient();
+
+vi.mock('./watch-server.js', () => ({
+    WatchNotify: vi.fn(),
+}));
+
+vi.mock('./db.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        ClientFromPool: vi.fn(async () => mockClient),
+    };
+});
+
+describe('api-user', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('INSERT INTO Users')) {
+                return { rows: [{ id: 'internal-user-1' }] };
+            }
+            if (sql.includes('set_config')) {
+                return {};
+            }
+            if (sql.includes('FROM ApplicationNetworks WHERE Backbone')) {
+                return {
+                    rows: [{
+                        id: TEST_UUIDS.van,
+                        name: 'van-a',
+                        lifecycle: 'ready',
+                        failure: null,
+                        starttime: null,
+                        endtime: null,
+                        deletedelay: null,
+                        networktype: 'standard',
+                        connected: false,
+                    }],
+                };
+            }
+            if (sql.includes('JOIN Backbones ON Backbones.Id = Backbone')) {
+                return {
+                    rows: [{
+                        id: TEST_UUIDS.van,
+                        backbone: TEST_UUIDS.backbone,
+                        backbonename: 'backbone-a',
+                        name: 'van-a',
+                        networktype: 'standard',
+                        lifecycle: 'ready',
+                        failure: null,
+                        starttime: null,
+                        endtime: null,
+                        deletedelay: null,
+                        connected: false,
+                    }],
+                };
+            }
+            if (sql.includes('JOIN Backbones ON ApplicationNetworks.Backbone = Backbones.Id WHERE ApplicationNetworks.Id')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: TEST_UUIDS.van,
+                        name: 'van-a',
+                        backboneid: TEST_UUIDS.backbone,
+                        backbonename: 'backbone-a',
+                    }],
+                };
+            }
+            return { rows: [], rowCount: 0 };
+        });
+    });
+
+    it('GET /backbones/:bid/vans lists vans for a backbone', async () => {
+        const { app } = await buildApiApp({ includeAdmin: false });
+
+        const res = await request(app)
+            .get(`/api/v1alpha1/backbones/${TEST_UUIDS.backbone}/vans`)
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body).toHaveLength(1);
+        expect(res.body[0].name).toBe('van-a');
+    });
+
+    it('GET /vans lists all vans', async () => {
+        const { app } = await buildApiApp({ includeAdmin: false });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/vans')
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body[0].backbonename).toBe('backbone-a');
+    });
+
+    it('GET /vans/:vid returns a single van', async () => {
+        const { app } = await buildApiApp({ includeAdmin: false });
+
+        const res = await request(app)
+            .get(`/api/v1alpha1/vans/${TEST_UUIDS.van}`)
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body.id).toBe(TEST_UUIDS.van);
+    });
+
+    it('GET /vans/:vid returns 400 when van is missing', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('INSERT INTO Users')) {
+                return { rows: [{ id: 'internal-user-1' }] };
+            }
+            if (sql.includes('set_config')) {
+                return {};
+            }
+            return { rowCount: 0, rows: [] };
+        });
+
+        const { app } = await buildApiApp({ includeAdmin: false });
+
+        await request(app)
+            .get(`/api/v1alpha1/vans/${TEST_UUIDS.van}`)
+            .set('x-test-auth', '1')
+            .expect(400);
+    });
+
+    it('GET /vans returns 401 without authentication', async () => {
+        const { app } = await buildApiApp({ includeAdmin: false });
+
+        await request(app)
+            .get('/api/v1alpha1/vans')
+            .expect(401);
+    });
+
+    it('GET /vans returns 403 without can-list-vans role', async () => {
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            roles: ['van-owner'],
+        });
+
+        await request(app)
+            .get('/api/v1alpha1/vans')
+            .set('x-test-auth', '1')
+            .expect(403);
+    });
+});

--- a/components/management-controller/src/auth/management-oidc.js
+++ b/components/management-controller/src/auth/management-oidc.js
@@ -80,6 +80,20 @@ function realmIssuerHref(adapter) {
 }
 
 /**
+ * Whether HTTP is allowed for OIDC discovery and subsequent client requests.
+ * Keycloak adapter `ssl-required: none` is used for local/test IdPs; production uses HTTPS.
+ * @param {object} adapter Parsed Keycloak adapter config
+ * @param {URL} issuerUrl Realm issuer URL
+ * @returns {boolean}
+ */
+function allowsInsecureOidcRequests(adapter, issuerUrl) {
+    if (adapter["ssl-required"] === "none") {
+        return true;
+    }
+    return issuerUrl.protocol === "http:";
+}
+
+/**
  * Extract a Bearer access token from the `Authorization` header, if present.
  * @param {import('express').Request} req
  * @returns {string | null} Raw JWT string without the `Bearer ` prefix
@@ -252,7 +266,17 @@ export async function createManagementOidcAuth(options = {}) {
     const issuerHref = realmIssuerHref(adapter);
     const issuerUrl = new URL(issuerHref);
 
-    const configuration = await client.discovery(issuerUrl, clientId, clientSecret);
+    const discoveryOptions = allowsInsecureOidcRequests(adapter, issuerUrl)
+        ? { execute: [client.allowInsecureRequests] }
+        : undefined;
+
+    const configuration = await client.discovery(
+        issuerUrl,
+        clientId,
+        clientSecret,
+        undefined,
+        discoveryOptions,
+    );
 
     const issuerFromAs = normalizeIssuer(configuration.serverMetadata().issuer ?? issuerHref);
     const jwksUrl = new URL(`${issuerFromAs}/protocol/openid-connect/certs`);
@@ -485,3 +509,6 @@ export async function createManagementOidcAuth(options = {}) {
         _clientId: clientId,
     };
 }
+
+/** @internal Exported for unit tests */
+export { allowsInsecureOidcRequests, realmIssuerHref, isApiStyleRequest, tokenMatchesClient };

--- a/components/management-controller/src/auth/management-oidc.test.js
+++ b/components/management-controller/src/auth/management-oidc.test.js
@@ -1,0 +1,270 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as client from 'openid-client';
+import * as jose from 'jose';
+
+vi.mock('openid-client', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        discovery: vi.fn(),
+    };
+});
+
+vi.mock('jose', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        createRemoteJWKSet: vi.fn(() => ({})),
+        jwtVerify: vi.fn(),
+    };
+});
+
+import {
+    allowsInsecureOidcRequests,
+    realmIssuerHref,
+    isApiStyleRequest,
+    tokenMatchesClient,
+    createManagementOidcAuth,
+} from './management-oidc.js';
+
+function writeKeycloakConfig(dir, overrides = {}) {
+    const config = {
+        realm: 'test-realm',
+        'auth-server-url': 'http://mock-oidc:8080',
+        'ssl-required': 'none',
+        resource: 'vms-test-client',
+        credentials: { secret: 'test-secret' },
+        ...overrides,
+    };
+    const configPath = path.join(dir, 'keycloak.json');
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    return configPath;
+}
+
+describe('allowsInsecureOidcRequests', () => {
+    it('returns true when ssl-required is none', () => {
+        const adapter = { 'ssl-required': 'none', 'auth-server-url': 'https://idp.example', realm: 'r' };
+        expect(allowsInsecureOidcRequests(adapter, new URL('https://idp.example/realms/r'))).toBe(true);
+    });
+
+    it('returns true for http issuer when ssl-required is not none', () => {
+        const adapter = { 'auth-server-url': 'http://mock-oidc:8080', realm: 'r' };
+        expect(allowsInsecureOidcRequests(adapter, new URL('http://mock-oidc:8080/realms/r'))).toBe(true);
+    });
+
+    it('returns false for https issuer without ssl-required none', () => {
+        const adapter = { 'auth-server-url': 'https://idp.example', realm: 'r' };
+        expect(allowsInsecureOidcRequests(adapter, new URL('https://idp.example/realms/r'))).toBe(false);
+    });
+});
+
+describe('realmIssuerHref', () => {
+    it('builds realm issuer URL without trailing slash on auth-server-url', () => {
+        expect(realmIssuerHref({
+            realm: 'vms-test',
+            'auth-server-url': 'http://mock-oidc:8080/',
+        })).toBe('http://mock-oidc:8080/realms/vms-test');
+    });
+});
+
+describe('isApiStyleRequest', () => {
+    it('treats /api paths as API style', () => {
+        expect(isApiStyleRequest({ path: '/api/v1alpha1/backbones', headers: {} })).toBe(true);
+    });
+
+    it('treats Accept application/json as API style', () => {
+        expect(isApiStyleRequest({
+            path: '/',
+            headers: { accept: 'application/json' },
+        })).toBe(true);
+    });
+});
+
+describe('tokenMatchesClient', () => {
+    it('matches azp claim', () => {
+        expect(tokenMatchesClient({ azp: 'my-client' }, 'my-client')).toBe(true);
+    });
+
+    it('matches aud array', () => {
+        expect(tokenMatchesClient({ aud: ['other', 'my-client'] }, 'my-client')).toBe(true);
+    });
+});
+
+describe('createManagementOidcAuth', () => {
+    /** @type {string} */
+    let tmpDir;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oidc-test-'));
+        vi.mocked(client.discovery).mockResolvedValue({
+            serverMetadata: () => ({ issuer: 'http://mock-oidc:8080/realms/test-realm' }),
+        });
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.clearAllMocks();
+    });
+
+    it('throws when keycloak.json has no client secret', async () => {
+        const configPath = writeKeycloakConfig(tmpDir, { credentials: {} });
+        await expect(createManagementOidcAuth({ configPath })).rejects.toThrow(
+            'keycloak.json must include credentials.secret',
+        );
+    });
+
+    it('passes allowInsecureRequests to discovery for http test IdP', async () => {
+        const configPath = writeKeycloakConfig(tmpDir);
+        await createManagementOidcAuth({ configPath });
+
+        expect(client.discovery).toHaveBeenCalledWith(
+            new URL('http://mock-oidc:8080/realms/test-realm'),
+            'vms-test-client',
+            'test-secret',
+            undefined,
+            { execute: [client.allowInsecureRequests] },
+        );
+    });
+
+    it('omits insecure discovery options for https production IdP', async () => {
+        const configPath = writeKeycloakConfig(tmpDir, {
+            'auth-server-url': 'https://idp.example.com',
+            'ssl-required': 'external',
+        });
+        vi.mocked(client.discovery).mockResolvedValue({
+            serverMetadata: () => ({ issuer: 'https://idp.example.com/realms/test-realm' }),
+        });
+
+        await createManagementOidcAuth({ configPath });
+
+        expect(client.discovery).toHaveBeenCalledWith(
+            new URL('https://idp.example.com/realms/test-realm'),
+            'vms-test-client',
+            'test-secret',
+            undefined,
+            undefined,
+        );
+    });
+
+    it('protect returns 401 for unauthenticated API requests', async () => {
+        const configPath = writeKeycloakConfig(tmpDir);
+        const auth = await createManagementOidcAuth({ configPath });
+
+        const req = { path: '/api/v1alpha1/', headers: { accept: 'application/json' } };
+        const res = { status: vi.fn().mockReturnThis(), send: vi.fn() };
+        const next = vi.fn();
+
+        await auth.protect()(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.send).toHaveBeenCalledWith('Unauthorized');
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('creates remote JWKS for token verification', async () => {
+        const configPath = writeKeycloakConfig(tmpDir);
+        await createManagementOidcAuth({ configPath });
+
+        expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
+            new URL('http://mock-oidc:8080/realms/test-realm/protocol/openid-connect/certs'),
+        );
+    });
+
+    it('middleware attaches kauth from a valid bearer token', async () => {
+        const configPath = writeKeycloakConfig(tmpDir);
+        vi.mocked(jose.jwtVerify).mockResolvedValue({
+            payload: {
+                sub: 'user-1',
+                azp: 'vms-test-client',
+                realm_access: { roles: ['admin'] },
+            },
+        });
+
+        const auth = await createManagementOidcAuth({ configPath });
+        const req = {
+            headers: { authorization: 'Bearer test.jwt.token' },
+        };
+        const next = vi.fn();
+
+        await auth.middleware(req, {}, next);
+
+        expect(jose.jwtVerify).toHaveBeenCalled();
+        expect(req.kauth.grant.access_token.content.sub).toBe('user-1');
+        expect(next).toHaveBeenCalled();
+    });
+
+    it('protect returns 403 when required realm role is missing', async () => {
+        const configPath = writeKeycloakConfig(tmpDir);
+        const auth = await createManagementOidcAuth({ configPath });
+
+        const req = {
+            path: '/api/v1alpha1/backbones',
+            headers: { accept: 'application/json' },
+            kauth: {
+                grant: {
+                    access_token: {
+                        content: {
+                            sub: 'user-1',
+                            realm_access: { roles: ['viewer'] },
+                        },
+                    },
+                },
+            },
+        };
+        const res = { status: vi.fn().mockReturnThis(), send: vi.fn() };
+        const next = vi.fn();
+
+        await auth.protect('realm:admin')(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.send).toHaveBeenCalledWith('Forbidden');
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('protect allows access when required realm role is present', async () => {
+        const configPath = writeKeycloakConfig(tmpDir);
+        const auth = await createManagementOidcAuth({ configPath });
+
+        const req = {
+            kauth: {
+                grant: {
+                    access_token: {
+                        content: {
+                            sub: 'user-1',
+                            realm_access: { roles: ['admin', 'viewer'] },
+                        },
+                    },
+                },
+            },
+        };
+        const res = { status: vi.fn().mockReturnThis(), send: vi.fn() };
+        const next = vi.fn();
+
+        await auth.protect('realm:admin')(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+    });
+});

--- a/components/management-controller/src/backbone-links.test.js
+++ b/components/management-controller/src/backbone-links.test.js
@@ -1,0 +1,269 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockClient = {
+    query: vi.fn(),
+    release: vi.fn(),
+};
+
+vi.mock('@skupperx/modules/kube', () => ({
+    LoadSecret: vi.fn(),
+}));
+
+vi.mock('@skupperx/modules/amqp', () => ({
+    OpenConnection: vi.fn(() => ({ id: 'mock-conn' })),
+    CloseConnection: vi.fn(),
+}));
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(async () => mockClient),
+}));
+
+vi.mock('./notify.js', () => ({
+    NotifyTransaction: class {
+        add() {}
+        async commit() {}
+    },
+    RegisterNotification: vi.fn(),
+}));
+
+import { LoadSecret } from '@skupperx/modules/kube';
+import { OpenConnection } from '@skupperx/modules/amqp';
+import { RegisterNotification } from './notify.js';
+
+describe('RegisterHandler', () => {
+    let Start;
+    let RegisterHandler;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        vi.resetModules();
+        ({ Start, RegisterHandler } = await import('./backbone-links.js'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('notifies registered handlers for existing and new backbone connections', async () => {
+        const onAdded = vi.fn();
+        const onDeleted = vi.fn();
+
+        LoadSecret.mockResolvedValue({
+            data: {
+                'ca.crt': Buffer.from('ca').toString('base64'),
+                'tls.crt': Buffer.from('cert').toString('base64'),
+                'tls.key': Buffer.from('key').toString('base64'),
+            },
+        });
+
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('SELECT * FROM ManagementControllers WHERE Name = $1 and LifeCycle')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ name: 'test-controller', certificate: 'cert-1' }],
+                };
+            }
+            if (sql.includes('SELECT * FROM ManagementControllers WHERE Name')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ name: 'test-controller', certificate: 'cert-1' }],
+                };
+            }
+            if (sql.includes('SELECT ObjectName FROM TlsCertificates')) {
+                return { rowCount: 1, rows: [{ objectname: 'tls-secret' }] };
+            }
+            if (sql.includes('BackboneAccessPoints AS ap')) {
+                return {
+                    rows: [{
+                        id: 'ap-1',
+                        hostname: 'router.example.com',
+                        port: 5671,
+                        colocated: false,
+                    }],
+                };
+            }
+            return { rows: [] };
+        });
+
+        await Start('test-controller');
+        await vi.runOnlyPendingTimersAsync();
+        await vi.runOnlyPendingTimersAsync();
+
+        await RegisterHandler(onAdded, onDeleted);
+
+        expect(onAdded).toHaveBeenCalledWith(
+            'ap-1',
+            expect.objectContaining({ id: 'mock-conn' }),
+        );
+        expect(onDeleted).not.toHaveBeenCalled();
+    });
+});
+
+describe('resolveControllerRecord (via Start)', () => {
+    let Start;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        vi.resetModules();
+        ({ Start } = await import('./backbone-links.js'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('inserts a management controller record when none exists', async () => {
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('SELECT * FROM ManagementControllers WHERE Name')) {
+                return { rowCount: 0, rows: [] };
+            }
+            if (sql.includes('INSERT INTO ManagementControllers')) {
+                expect(params).toEqual(['test-controller']);
+                return { rows: [{ id: 'mc-id-1' }] };
+            }
+            return {};
+        });
+
+        await Start('test-controller');
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            'INSERT INTO ManagementControllers (Name) VALUES ($1) RETURNING Id',
+            ['test-controller'],
+        );
+        expect(mockClient.release).toHaveBeenCalled();
+        expect(RegisterNotification).toHaveBeenCalledWith('BackboneAccessPoints', expect.any(Function), false);
+        expect(vi.getTimerCount()).toBe(2);
+    });
+
+    it('schedules TLS resolution immediately when controller record exists', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('SELECT * FROM ManagementControllers WHERE Name')) {
+                return { rowCount: 1, rows: [{ name: 'test-controller', certificate: 'cert-1' }] };
+            }
+            return {};
+        });
+
+        await Start('test-controller');
+
+        expect(mockClient.query).not.toHaveBeenCalledWith(
+            'INSERT INTO ManagementControllers (Name) VALUES ($1) RETURNING Id',
+            expect.anything(),
+        );
+        expect(mockClient.release).toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(2);
+    });
+
+    it('reschedules on error and rolls back the transaction', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN') {
+                return {};
+            }
+            if (sql.includes('SELECT * FROM ManagementControllers WHERE Name')) {
+                throw new Error('database unavailable');
+            }
+            if (sql === 'ROLLBACK') {
+                return {};
+            }
+            return {};
+        });
+
+        await Start('test-controller');
+
+        expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+        expect(mockClient.release).toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(2);
+
+        await vi.advanceTimersByTimeAsync(10000);
+        expect(mockClient.query).toHaveBeenCalledWith('BEGIN');
+    });
+
+    it('chains through resolveTLSData and reconcileBackboneConnections', async () => {
+        LoadSecret.mockResolvedValue({
+            data: {
+                'ca.crt': Buffer.from('ca').toString('base64'),
+                'tls.crt': Buffer.from('cert').toString('base64'),
+                'tls.key': Buffer.from('key').toString('base64'),
+            },
+        });
+
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('SELECT * FROM ManagementControllers WHERE Name = $1 and LifeCycle')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ name: 'test-controller', certificate: 'cert-1' }],
+                };
+            }
+            if (sql.includes('SELECT * FROM ManagementControllers WHERE Name')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ name: 'test-controller', certificate: 'cert-1' }],
+                };
+            }
+            if (sql.includes('SELECT ObjectName FROM TlsCertificates')) {
+                return { rowCount: 1, rows: [{ objectname: 'tls-secret' }] };
+            }
+            if (sql.includes('BackboneAccessPoints AS ap')) {
+                return {
+                    rows: [{
+                        id: 'ap-1',
+                        hostname: 'router.example.com',
+                        port: 5671,
+                        colocated: false,
+                    }],
+                };
+            }
+            return { rows: [] };
+        });
+
+        await Start('test-controller');
+        await vi.runOnlyPendingTimersAsync();
+        await vi.runOnlyPendingTimersAsync();
+
+        expect(LoadSecret).toHaveBeenCalledWith('tls-secret');
+        expect(OpenConnection).toHaveBeenCalledWith(
+            'Backbone-management-ap-1',
+            'router.example.com',
+            5671,
+            'tls',
+            expect.any(Buffer),
+            expect.any(Buffer),
+            expect.any(Buffer),
+        );
+        expect(vi.getTimerCount()).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/components/management-controller/src/certs.test.js
+++ b/components/management-controller/src/certs.test.js
@@ -1,0 +1,541 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockClient = {
+    query: vi.fn(),
+    release: vi.fn(),
+};
+
+/** @type {Record<string, Function>} */
+const notificationHandlers = {};
+
+/** @type {Array<{ method: string, table: string, id: string }>} */
+const notifyEvents = [];
+
+vi.mock('@skupperx/modules/kube', () => ({
+    ApplyObject: vi.fn(),
+    LoadCertificate: vi.fn(),
+    WatchSecrets: vi.fn(),
+    WatchCertificates: vi.fn(),
+    GetIssuers: vi.fn(async () => []),
+}));
+
+vi.mock('./config.js', () => ({
+    BackboneExpiration: vi.fn(() => ({ years: 1 })),
+    DefaultCaExpiration: vi.fn(() => ({ days: 30 })),
+    DefaultCertExpiration: vi.fn(() => ({ days: 7 })),
+    SiteControllerImage: vi.fn(() => 'quay.io/skupper/vms-site-controller:latest'),
+    RootIssuer: vi.fn(() => 'skupperx-root'),
+    CertOrganization: vi.fn(() => 'enterprise.com'),
+}));
+
+vi.mock('./sync-management.js', () => ({
+    SiteCertificateChanged: vi.fn(),
+    AccessCertificateChanged: vi.fn(),
+}));
+
+vi.mock('./claim-server.js', () => ({
+    CompleteMember: vi.fn(),
+}));
+
+vi.mock('./site-deployment-state.js', () => ({
+    AccessPointCertReady: vi.fn(),
+    SiteLifecycleChanged_TX: vi.fn(),
+}));
+
+vi.mock('./watch-server.js', () => ({
+    WatchNotify: vi.fn(),
+}));
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(async () => mockClient),
+    IntervalMilliseconds: vi.fn(() => 3600000),
+}));
+
+vi.mock('./notify.js', () => ({
+    RegisterNotification: vi.fn((tableName, handler) => {
+        notificationHandlers[tableName] = handler;
+    }),
+    NotifyTransaction: class {
+        add(table, id) {
+            notifyEvents.push({ method: 'add', table, id });
+        }
+        update(table, id) {
+            notifyEvents.push({ method: 'update', table, id });
+        }
+        delete(table, id) {
+            notifyEvents.push({ method: 'delete', table, id });
+        }
+        async commit() {}
+    },
+}));
+
+import { Start } from './certs.js';
+import { RegisterNotification } from './notify.js';
+import { ApplyObject } from '@skupperx/modules/kube';
+
+function transactionSql(sql) {
+    return sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK';
+}
+
+describe('certs Start', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        notifyEvents.length = 0;
+        for (const key of Object.keys(notificationHandlers)) {
+            delete notificationHandlers[key];
+        }
+    });
+
+    it('registers notification handlers for certificate lifecycle tables', async () => {
+        await Start();
+
+        expect(RegisterNotification).toHaveBeenCalledWith(
+            'ManagementControllers',
+            expect.any(Function),
+            true,
+        );
+        expect(RegisterNotification).toHaveBeenCalledWith('Backbones', expect.any(Function), true);
+        expect(RegisterNotification).toHaveBeenCalledWith(
+            'BackboneAccessPoints',
+            expect.any(Function),
+            true,
+        );
+        expect(RegisterNotification).toHaveBeenCalledWith(
+            'ApplicationNetworks',
+            expect.any(Function),
+            true,
+        );
+        expect(RegisterNotification).toHaveBeenCalledWith(
+            'NetworkCredentials',
+            expect.any(Function),
+            true,
+        );
+        expect(RegisterNotification).toHaveBeenCalledWith('InteriorSites', expect.any(Function), true);
+        expect(RegisterNotification).toHaveBeenCalledWith(
+            'MemberInvitations',
+            expect.any(Function),
+            true,
+        );
+        expect(RegisterNotification).toHaveBeenCalledWith('MemberSites', expect.any(Function), true);
+        expect(RegisterNotification).toHaveBeenCalledWith(
+            'CertificateRequests',
+            expect.any(Function),
+            false,
+        );
+    });
+});
+
+describe('onManagementControllersChange', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        notifyEvents.length = 0;
+        for (const key of Object.keys(notificationHandlers)) {
+            delete notificationHandlers[key];
+        }
+        await Start();
+    });
+
+    it('creates mgmtController certificate request for new controller rows', async () => {
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes("FROM ManagementControllers WHERE Lifecycle = 'new'")) {
+                return {
+                    rowCount: 1,
+                    rows: [{ id: 'mc-uuid-1', name: 'management-server-abc' }],
+                };
+            }
+            if (sql.includes('INSERT INTO CertificateRequests')) {
+                expect(params[1]).toBe('mc-uuid-1');
+                return { rows: [{ id: 'cert-req-1' }] };
+            }
+            if (sql.includes("UPDATE ManagementControllers SET Lifecycle = 'skx_cr_created'")) {
+                expect(params).toEqual(['mc-uuid-1']);
+                return {};
+            }
+            return {};
+        });
+
+        await notificationHandlers.ManagementControllers('UPDATE', 'mc-uuid-1');
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining("'mgmtController'"),
+            expect.arrayContaining(['mc-uuid-1']),
+        );
+        expect(notifyEvents).toContainEqual({
+            method: 'add',
+            table: 'CertificateRequests',
+            id: 'cert-req-1',
+        });
+        expect(notifyEvents).toContainEqual({
+            method: 'update',
+            table: 'ManagementControllers',
+            id: 'mc-uuid-1',
+        });
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('ignores DELETE actions', async () => {
+        await notificationHandlers.ManagementControllers('DELETE', 'mc-uuid-1');
+        expect(mockClient.query).not.toHaveBeenCalled();
+    });
+});
+
+describe('onBackbonesChange', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        notifyEvents.length = 0;
+        for (const key of Object.keys(notificationHandlers)) {
+            delete notificationHandlers[key];
+        }
+        await Start();
+    });
+
+    it('creates backboneCA certificate request for new backbone rows', async () => {
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes('FROM Backbones WHERE id = $1')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ id: 'bb-uuid-1', name: 'backbone-a', lifecycle: 'new' }],
+                };
+            }
+            if (sql.includes('INSERT INTO CertificateRequests')) {
+                expect(params[1]).toBe('bb-uuid-1');
+                return { rows: [{ id: 'cert-req-2' }] };
+            }
+            if (sql.includes("UPDATE Backbones SET Lifecycle = 'skx_cr_created'")) {
+                return {};
+            }
+            return {};
+        });
+
+        await notificationHandlers.Backbones('UPDATE', 'bb-uuid-1');
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining("'backboneCA'"),
+            expect.arrayContaining(['bb-uuid-1']),
+        );
+        expect(notifyEvents).toContainEqual({
+            method: 'add',
+            table: 'CertificateRequests',
+            id: 'cert-req-2',
+        });
+        expect(notifyEvents).toContainEqual({
+            method: 'update',
+            table: 'Backbones',
+            id: 'bb-uuid-1',
+        });
+    });
+
+    it('notifies dependents when backbone lifecycle is ready', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes('FROM Backbones WHERE id = $1')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ id: 'bb-uuid-1', name: 'backbone-a', lifecycle: 'ready' }],
+                };
+            }
+            if (sql.includes('FROM BackboneAccessPoints AS ap')) {
+                return { rows: [{ id: 'ap-1' }] };
+            }
+            if (sql.includes('FROM ApplicationNetworks WHERE Backbone = $1')) {
+                return { rows: [{ id: 'van-1' }] };
+            }
+            if (sql.includes('FROM InteriorSites WHERE Backbone = $1')) {
+                return { rows: [{ id: 'site-1' }] };
+            }
+            if (sql.includes('FROM NetworkCredentials AS cred')) {
+                return { rows: [{ id: 'cred-1' }] };
+            }
+            return {};
+        });
+
+        await notificationHandlers.Backbones('UPDATE', 'bb-uuid-1');
+
+        expect(mockClient.query).not.toHaveBeenCalledWith(
+            expect.stringContaining('INSERT INTO CertificateRequests'),
+            expect.anything(),
+        );
+        expect(notifyEvents).toEqual([
+            { method: 'update', table: 'BackboneAccessPoints', id: 'ap-1' },
+            { method: 'update', table: 'ApplicationNetworks', id: 'van-1' },
+            { method: 'update', table: 'InteriorSites', id: 'site-1' },
+            { method: 'update', table: 'NetworkCredentials', id: 'cred-1' },
+        ]);
+    });
+});
+
+describe('onCertificateRequestsChange', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        notifyEvents.length = 0;
+        for (const key of Object.keys(notificationHandlers)) {
+            delete notificationHandlers[key];
+        }
+        await Start();
+    });
+
+    it('processes due certificate requests on ADD', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes('FROM CertificateRequests WHERE RequestTime')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: 'cert-req-3',
+                        requesttype: 'mgmtController',
+                        durationhours: 8760,
+                    }],
+                };
+            }
+            if (sql.includes("UPDATE CertificateRequests SET Lifecycle = 'cm_cert_created'")) {
+                return {};
+            }
+            return {};
+        });
+
+        await notificationHandlers.CertificateRequests('ADD', 'cert-req-3');
+
+        expect(ApplyObject).toHaveBeenCalledWith(
+            expect.objectContaining({
+                kind: 'Certificate',
+                metadata: expect.objectContaining({
+                    name: 'skx-mgmt-controller-cert-req-3',
+                }),
+            }),
+        );
+        expect(notifyEvents).toContainEqual({
+            method: 'update',
+            table: 'CertificateRequests',
+            id: 'cert-req-3',
+        });
+    });
+
+    it('ignores non-ADD actions', async () => {
+        await notificationHandlers.CertificateRequests('UPDATE', 'cert-req-3');
+        expect(mockClient.query).not.toHaveBeenCalled();
+        expect(ApplyObject).not.toHaveBeenCalled();
+    });
+});
+
+describe('onBackboneAccessPointsChange', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        notifyEvents.length = 0;
+        for (const key of Object.keys(notificationHandlers)) {
+            delete notificationHandlers[key];
+        }
+        await Start();
+    });
+
+    it('creates accessPoint certificate request for new access points on ready backbones', async () => {
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes('FROM BackboneAccessPoints') && sql.includes("Lifecycle = 'new'")) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: 'ap-uuid-1',
+                        name: 'manage-ap',
+                        hostname: 'router.example.com',
+                        starttime: null,
+                        endtime: null,
+                        deletedelay: null,
+                    }],
+                };
+            }
+            if (sql.includes('INSERT INTO CertificateRequests')) {
+                expect(params[1]).toBe('ap-uuid-1');
+                return { rows: [{ id: 'cert-req-ap-1' }] };
+            }
+            if (sql.includes("UPDATE BackboneAccessPoints SET Lifecycle = 'skx_cr_created'")) {
+                return {};
+            }
+            return {};
+        });
+
+        await notificationHandlers.BackboneAccessPoints('UPDATE', 'ap-uuid-1');
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining("'accessPoint'"),
+            expect.arrayContaining(['ap-uuid-1']),
+        );
+        expect(notifyEvents).toContainEqual({
+            method: 'add',
+            table: 'CertificateRequests',
+            id: 'cert-req-ap-1',
+        });
+    });
+});
+
+describe('onApplicationNetworksChange', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        notifyEvents.length = 0;
+        for (const key of Object.keys(notificationHandlers)) {
+            delete notificationHandlers[key];
+        }
+        await Start();
+    });
+
+    it('creates vanCA certificate request for new application networks', async () => {
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes('FROM ApplicationNetworks') && sql.includes('Backbones.Lifecycle')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: 'van-uuid-1',
+                        name: 'van-a',
+                        lifecycle: 'new',
+                        starttime: new Date('2026-01-01T00:00:00Z'),
+                        endtime: null,
+                        deletedelay: null,
+                        bbca: 'bb-ca-1',
+                    }],
+                };
+            }
+            if (sql.includes('INSERT INTO CertificateRequests')) {
+                expect(params[2]).toBe('van-uuid-1');
+                return { rows: [{ id: 'cert-req-van-1' }] };
+            }
+            if (sql.includes("UPDATE ApplicationNetworks SET Lifecycle = 'skx_cr_created'")) {
+                return {};
+            }
+            return {};
+        });
+
+        await notificationHandlers.ApplicationNetworks('UPDATE', 'van-uuid-1');
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining("'vanCA'"),
+            expect.arrayContaining(['van-uuid-1']),
+        );
+        expect(notifyEvents).toContainEqual({
+            method: 'add',
+            table: 'CertificateRequests',
+            id: 'cert-req-van-1',
+        });
+    });
+
+    it('notifies member invitations and sites when network becomes ready', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes('FROM ApplicationNetworks') && sql.includes('Backbones.Lifecycle')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: 'van-uuid-2',
+                        name: 'van-b',
+                        lifecycle: 'ready',
+                        bbca: 'bb-ca-1',
+                    }],
+                };
+            }
+            if (sql.includes('FROM MemberInvitations WHERE MemberOf')) {
+                return { rows: [{ id: 'invite-1' }] };
+            }
+            if (sql.includes('FROM MemberSites WHERE MemberOf')) {
+                return { rows: [{ id: 'member-1' }] };
+            }
+            return {};
+        });
+
+        await notificationHandlers.ApplicationNetworks('UPDATE', 'van-uuid-2');
+
+        expect(notifyEvents).toEqual([
+            { method: 'update', table: 'MemberInvitations', id: 'invite-1' },
+            { method: 'update', table: 'MemberSites', id: 'member-1' },
+        ]);
+    });
+});
+
+describe('onInteriorSitesChange', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        notifyEvents.length = 0;
+        for (const key of Object.keys(notificationHandlers)) {
+            delete notificationHandlers[key];
+        }
+        await Start();
+    });
+
+    it('creates interiorRouter certificate request for new interior sites', async () => {
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (transactionSql(sql)) {
+                return {};
+            }
+            if (sql.includes('FROM InteriorSites') && sql.includes("Lifecycle = 'new'")) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: 'site-uuid-1',
+                        name: 'backbone-site-a',
+                        bbca: 'bb-ca-1',
+                    }],
+                };
+            }
+            if (sql.includes('INSERT INTO CertificateRequests')) {
+                expect(params[1]).toBe('site-uuid-1');
+                return { rows: [{ id: 'cert-req-site-1' }] };
+            }
+            if (sql.includes("UPDATE InteriorSites SET Lifecycle = 'skx_cr_created'")) {
+                return {};
+            }
+            return {};
+        });
+
+        await notificationHandlers.InteriorSites('UPDATE', 'site-uuid-1');
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining("'interiorRouter'"),
+            expect.arrayContaining(['site-uuid-1']),
+        );
+        expect(notifyEvents).toContainEqual({
+            method: 'add',
+            table: 'CertificateRequests',
+            id: 'cert-req-site-1',
+        });
+    });
+});

--- a/components/management-controller/src/claim-server.js
+++ b/components/management-controller/src/claim-server.js
@@ -303,3 +303,12 @@ export async function Start() {
     Log('[Claim-Server module starting]');
     await RegisterHandler(onLinkAdded, onLinkDeleted, false, true);
 }
+
+/** @internal Exported for unit tests */
+export function _registerMemberCompletionForTest(memberId, { callback } = {}) {
+    memberCompletions[memberId] = {
+        result: undefined,
+        error: undefined,
+        callback,
+    };
+}

--- a/components/management-controller/src/claim-server.test.js
+++ b/components/management-controller/src/claim-server.test.js
@@ -1,0 +1,96 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest';
+import { createMockClient } from './test-helpers/mock-db.js';
+
+const mockClient = createMockClient();
+
+vi.mock('@skupperx/modules/kube', () => ({
+    LoadSecret: vi.fn(),
+}));
+
+vi.mock('@skupperx/modules/amqp', () => ({
+    OpenReceiver: vi.fn(),
+    OpenSender: vi.fn(),
+}));
+
+vi.mock('./backbone-links.js', () => ({
+    RegisterHandler: vi.fn(),
+}));
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(async () => mockClient),
+}));
+
+vi.mock('./notify.js', () => ({
+    NotifyTransaction: class {
+        add() {}
+        update() {}
+        delete() {}
+        async commit() {}
+    },
+}));
+
+import { LoadSecret } from '@skupperx/modules/kube';
+import { CompleteMember, _registerMemberCompletionForTest } from './claim-server.js';
+
+describe('CompleteMember', () => {
+    it('handles unknown member id without throwing', async () => {
+        await expect(CompleteMember('unknown-member-id')).resolves.toBeUndefined();
+    });
+
+    it('stores completion result and invokes callback for pending member', async () => {
+        const callback = vi.fn();
+        _registerMemberCompletionForTest('member-1', { callback });
+
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('FROM MemberSites')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        certificate: 'cert-1',
+                        invitation: 'inv-1',
+                        objectname: 'tls-secret',
+                    }],
+                };
+            }
+            if (sql.includes('FROM EdgeLinks')) {
+                return { rows: [] };
+            }
+            return { rows: [] };
+        });
+
+        LoadSecret.mockResolvedValue({
+            data: {
+                'tls.crt': Buffer.from('cert').toString('base64'),
+                'tls.key': Buffer.from('key').toString('base64'),
+            },
+        });
+
+        await CompleteMember('member-1');
+
+        expect(callback).toHaveBeenCalled();
+        expect(LoadSecret).toHaveBeenCalledWith('tls-secret');
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+});

--- a/components/management-controller/src/colo-sync.test.js
+++ b/components/management-controller/src/colo-sync.test.js
@@ -1,0 +1,68 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@skupperx/modules/kube', () => ({
+    GetNamespaces: vi.fn(async () => []),
+    createNamespace: vi.fn(),
+    deleteNamespace: vi.fn(),
+    LoadSecret: vi.fn(),
+    ApplyObject: vi.fn(),
+}));
+
+vi.mock('./notify.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        RegisterNotification: vi.fn(actual.RegisterNotification),
+    };
+});
+
+import { Start } from './colo-sync.js';
+import { RegisterNotification } from './notify.js';
+import { GetNamespaces } from '@skupperx/modules/kube';
+
+describe('colo-sync Start', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('loads namespaces and registers change handlers', async () => {
+        GetNamespaces.mockResolvedValue([{
+            metadata: {
+                name: 'colo-ns-1',
+                annotations: { 'skupper.io/skupperx-controlled': 'true' },
+            },
+        }]);
+
+        await Start();
+
+        expect(GetNamespaces).toHaveBeenCalled();
+        expect(RegisterNotification).toHaveBeenCalledWith('Backbones', expect.any(Function), true);
+        expect(RegisterNotification).toHaveBeenCalledWith('InteriorSites', expect.any(Function), false);
+        expect(RegisterNotification).toHaveBeenCalledWith('BackboneAccessPoints', expect.any(Function), false);
+        expect(vi.getTimerCount()).toBe(2);
+    });
+});

--- a/components/management-controller/src/config.test.js
+++ b/components/management-controller/src/config.test.js
@@ -1,0 +1,73 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockConfig = {
+    rootissuer: 'test-root-issuer',
+    defaultcaexpiration: { days: 365 },
+    defaultcertexpiration: { days: 90 },
+    certorganization: 'Skupper Test Org',
+    backbonecaexpiration: { years: 1 },
+    sitecontrollerimage: 'quay.io/skupper/vms-site-controller:test',
+};
+
+vi.mock('./db.js', () => ({
+    QueryConfig: vi.fn(async () => mockConfig),
+}));
+
+import {
+    Start,
+    RootIssuer,
+    DefaultCaExpiration,
+    DefaultCertExpiration,
+    CertOrganization,
+    BackboneExpiration,
+    SiteControllerImage,
+} from './config.js';
+
+describe('config getters', () => {
+    beforeEach(async () => {
+        await Start();
+    });
+
+    it('RootIssuer returns configured value', () => {
+        expect(RootIssuer()).toBe('test-root-issuer');
+    });
+
+    it('DefaultCaExpiration returns configured value', () => {
+        expect(DefaultCaExpiration()).toEqual({ days: 365 });
+    });
+
+    it('DefaultCertExpiration returns configured value', () => {
+        expect(DefaultCertExpiration()).toEqual({ days: 90 });
+    });
+
+    it('CertOrganization returns configured value', () => {
+        expect(CertOrganization()).toBe('Skupper Test Org');
+    });
+
+    it('BackboneExpiration returns configured value', () => {
+        expect(BackboneExpiration()).toEqual({ years: 1 });
+    });
+
+    it('SiteControllerImage returns configured value', () => {
+        expect(SiteControllerImage()).toBe('quay.io/skupper/vms-site-controller:test');
+    });
+});

--- a/components/management-controller/src/db.test.js
+++ b/components/management-controller/src/db.test.js
@@ -1,0 +1,213 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IntervalMilliseconds, isAdmin, extractUserInfo, queryWithContext } from './db.js';
+
+describe('IntervalMilliseconds', () => {
+    it('converts interval to milliseconds (min 1 hour)', () => {
+        expect(IntervalMilliseconds({ years: 2 })).toBe(2 * (3600 * 24 * 365 * 1000));
+        expect(IntervalMilliseconds({ weeks: 3 })).toBe(3 * (3600 * 24 * 7 * 1000));
+        expect(IntervalMilliseconds({ days: 4 })).toBe(4 * (3600 * 24 * 1000));
+        expect(IntervalMilliseconds({ hours: 2 })).toBe(2 * (3600 * 1000));
+        expect(IntervalMilliseconds({ minutes: 65 })).toBe(65 * (60 * 1000));
+        expect(IntervalMilliseconds({ seconds: 5400 })).toBe(5400 * (1000));
+        expect(IntervalMilliseconds({ seconds: 1 })).toBe(3600000);
+    });
+});
+
+describe('isAdmin', () => {
+    it('detects admin role', () => {
+        expect(isAdmin(['viewer', 'admin'])).toBe(true);
+        expect(isAdmin(['viewer'])).toBe(false);
+    });
+});
+
+describe('extractUserInfo', () => {
+    it('reads OIDC token content', () => {
+        const req = {
+            kauth: {
+                grant: {
+                    access_token: {
+                        content: {
+                            sub: 'user-1',
+                            clientGroups: ['group-a'],
+                            realm_access: { roles: ['admin'] },
+                        },
+                    },
+                },
+            },
+        };
+        expect(extractUserInfo(req)).toEqual({
+            context: 'admin',
+            userId: 'user-1',
+            userGroups: ['group-a'],
+            isAdmin: true,
+        });
+    });
+
+    it('returns defaults when token is absent', () => {
+        expect(extractUserInfo({})).toEqual({
+            context: 'user',
+            userId: null,
+            userGroups: [],
+            isAdmin: false,
+        });
+    });
+});
+
+describe('queryWithContext', () => {
+    /** @type {{ query: ReturnType<typeof vi.fn> }} */
+    let mockClient;
+
+    beforeEach(() => {
+        mockClient = { query: vi.fn() };
+    });
+
+    async function runQueries(sql) {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+            return {};
+        }
+        if (sql.includes('INSERT INTO Users')) {
+            return { rows: [{ id: 'internal-user-1' }] };
+        }
+        if (sql.startsWith('SELECT set_config')) {
+            return {};
+        }
+        return {};
+    }
+
+    it('sets RLS session variables and commits for authenticated users', async () => {
+        mockClient.query.mockImplementation(runQueries);
+
+        const req = {
+            kauth: {
+                grant: {
+                    access_token: {
+                        content: {
+                            sub: 'keycloak-sub-1',
+                            clientGroups: ['team-a', 'team-b'],
+                            realm_access: { roles: ['viewer'] },
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = await queryWithContext(req, mockClient, async (_client, ctx) => {
+            expect(ctx.userId).toBe('internal-user-1');
+            expect(ctx.userGroups).toEqual(['team-a', 'team-b']);
+            return 'ok';
+        });
+
+        expect(result).toBe('ok');
+        expect(mockClient.query).toHaveBeenCalledWith('BEGIN');
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining('INSERT INTO Users'),
+            ['keycloak-sub-1', false],
+        );
+        expect(mockClient.query).toHaveBeenCalledWith(
+            "SELECT set_config('session.user_id', $1, true)",
+            ['internal-user-1'],
+        );
+        expect(mockClient.query).toHaveBeenCalledWith(
+            "SELECT set_config('session.user_groups', $1, true)",
+            [['team-a', 'team-b']],
+        );
+        expect(mockClient.query).toHaveBeenCalledWith(
+            "SELECT set_config('session.is_admin', $1, true)",
+            ['false'],
+        );
+        expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
+    });
+
+    it('sets is_admin true for admin users', async () => {
+        mockClient.query.mockImplementation(runQueries);
+
+        const req = {
+            kauth: {
+                grant: {
+                    access_token: {
+                        content: {
+                            sub: 'admin-sub',
+                            clientGroups: [],
+                            realm_access: { roles: ['admin'] },
+                        },
+                    },
+                },
+            },
+        };
+
+        await queryWithContext(req, mockClient, async () => 'done');
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining('INSERT INTO Users'),
+            ['admin-sub', true],
+        );
+        expect(mockClient.query).toHaveBeenCalledWith(
+            "SELECT set_config('session.is_admin', $1, true)",
+            ['true'],
+        );
+    });
+
+    it('skips user upsert when unauthenticated', async () => {
+        mockClient.query.mockImplementation(runQueries);
+
+        await queryWithContext({}, mockClient, async (_client, ctx) => {
+            expect(ctx.userId).toBeNull();
+            return null;
+        });
+
+        expect(mockClient.query).not.toHaveBeenCalledWith(
+            expect.stringContaining('INSERT INTO Users'),
+            expect.anything(),
+        );
+        expect(mockClient.query).not.toHaveBeenCalledWith(
+            expect.stringContaining('set_config'),
+            expect.anything(),
+        );
+        expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
+    });
+
+    it('rolls back when callback throws', async () => {
+        mockClient.query.mockImplementation(runQueries);
+
+        const req = {
+            kauth: {
+                grant: {
+                    access_token: {
+                        content: {
+                            sub: 'user-sub',
+                            realm_access: { roles: [] },
+                        },
+                    },
+                },
+            },
+        };
+
+        await expect(
+            queryWithContext(req, mockClient, async () => {
+                throw new Error('query failed');
+            }),
+        ).rejects.toThrow('query failed');
+
+        expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+        expect(mockClient.query).not.toHaveBeenCalledWith('COMMIT');
+    });
+});

--- a/components/management-controller/src/external-vans.test.js
+++ b/components/management-controller/src/external-vans.test.js
@@ -1,0 +1,195 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockClient = {
+    query: vi.fn(),
+    release: vi.fn(),
+};
+
+const mockListAddresses = vi.fn(async () => []);
+const mockRouterStart = vi.fn(async () => {});
+
+/** @type {Function | undefined} */
+let capturedLinkAdded;
+
+vi.mock('@skupperx/modules/router', () => ({
+    RouterManagement: vi.fn().mockImplementation(function RouterManagement(conn) {
+        this.conn = conn;
+        this.start = mockRouterStart;
+        this.listAddresses = mockListAddresses;
+    }),
+}));
+
+vi.mock('./backbone-links.js', () => ({
+    RegisterHandler: vi.fn((onAdded, onDeleted) => {
+        capturedLinkAdded = onAdded;
+        expect(onDeleted).toBeTypeOf('function');
+    }),
+}));
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(async () => mockClient),
+}));
+
+vi.mock('./notify.js', () => ({
+    NotifyTransaction: class {
+        update() {}
+        async commit() {}
+    },
+}));
+
+import { RouterManagement } from '@skupperx/modules/router';
+import { RegisterHandler } from './backbone-links.js';
+import { Start } from './external-vans.js';
+
+function mockNetworkQueries() {
+    mockClient.query.mockImplementation(async (sql, params) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+            return {};
+        }
+        if (sql.includes('FROM ApplicationNetworks')) {
+            return {
+                rows: [{
+                    id: 'net-uuid-1',
+                    name: 'external-van-a',
+                    vanid: 'van-network-1',
+                    connected: false,
+                }],
+            };
+        }
+        if (sql.includes('UPDATE ApplicationNetworks SET Connected')) {
+            expect(params).toEqual(['net-uuid-1', true]);
+            return {};
+        }
+        return { rows: [] };
+    });
+}
+
+describe('external-vans Start', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        capturedLinkAdded = undefined;
+        mockClient.query.mockReset();
+        mockListAddresses.mockResolvedValue([]);
+    });
+
+    it('registers link handlers with backbone-links', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('FROM ApplicationNetworks')) {
+                return { rows: [] };
+            }
+            return { rows: [] };
+        });
+
+        await Start();
+
+        expect(RegisterHandler).toHaveBeenCalledWith(
+            expect.any(Function),
+            expect.any(Function),
+        );
+        expect(capturedLinkAdded).toBeTypeOf('function');
+    });
+});
+
+describe('external VAN reconcile', () => {
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+        capturedLinkAdded = undefined;
+        mockListAddresses.mockResolvedValue([]);
+
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('FROM ApplicationNetworks')) {
+                return { rows: [] };
+            }
+            return { rows: [] };
+        });
+
+        await Start();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('starts a colocated router when a management link is added', async () => {
+        const conn = { id: 'mock-conn' };
+
+        await capturedLinkAdded('bb-1', conn, { colocated: true });
+
+        expect(RouterManagement).toHaveBeenCalledWith(conn);
+        expect(mockRouterStart).toHaveBeenCalled();
+    });
+
+    it('marks disconnected networks connected when router address appears', async () => {
+        mockNetworkQueries();
+        await capturedLinkAdded('bb-1', { id: 'conn' }, { colocated: true });
+        mockListAddresses.mockResolvedValue([{ key: 'Nvan-network-1' }]);
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            'UPDATE ApplicationNetworks SET Connected = $2 WHERE Id = $1',
+            ['net-uuid-1', true],
+        );
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('marks connected networks disconnected when router address disappears', async () => {
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('FROM ApplicationNetworks')) {
+                return {
+                    rows: [{
+                        id: 'net-uuid-2',
+                        name: 'external-van-b',
+                        vanid: 'van-network-2',
+                        connected: true,
+                    }],
+                };
+            }
+            if (sql.includes('UPDATE ApplicationNetworks SET Connected')) {
+                expect(params).toEqual(['net-uuid-2', false]);
+                return {};
+            }
+            return { rows: [] };
+        });
+
+        await capturedLinkAdded('bb-1', { id: 'conn' }, { colocated: true });
+        mockListAddresses.mockResolvedValue([]);
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            'UPDATE ApplicationNetworks SET Connected = $2 WHERE Id = $1',
+            ['net-uuid-2', false],
+        );
+    });
+});

--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -530,41 +530,7 @@ const getUserGroups = async function (req, res) {
     return returnStatus;
 }
 
-export async function Start(is_standalone) {
-    Log('[API Server module started]');
-    /**
-     * When NODE_ENV is set to "production", the static build files will be served (this can be done with a deployment or in standalone mode)
-     * When NODE_ENV is anything other than "production", the Vite development server will start and serve live updates to the browser using hmr over websockets
-     */
-    ViteExpress.config({
-        viteConfigFile: path.join(VITE_CONSOLE_ROOT, 'vite.config.js'),
-        inlineViteConfig: {
-            root: VITE_CONSOLE_ROOT,
-            base: '/',
-            build: { outDir: 'dist' },
-        },
-        ignorePaths: (pathname) =>
-            pathname.startsWith('/api') ||
-            pathname.startsWith('/auth'),
-    });
-    app.set('trust proxy', true );
-
-    const auth = await createManagementOidcAuth();
-
-    router.use(cors());
-    auth.registerOidcRoutes(router);
-    router.use(auth.middleware);
-
-    router.get('/', auth.protect());
-
-    morgan.token('ts', (req, res) => {
-        return new Date().toISOString();
-    });
-
-    router.use(morgan(':ts :remote-addr :remote-user :method :url :status :res[content-length] :response-time ms', {
-        skip: function(req, res) { return !!req._skip_log; }
-    }));
-
+export async function Initialize(router, auth) {
     router.get(API_PREFIX + 'invitations/:iid/kube', auth.protect('realm:van-owner'), async (req, res) => {
         await fetchInvitationKube(req, res);
     });
@@ -623,7 +589,45 @@ export async function Start(is_standalone) {
 
     router.get(API_PREFIX + 'user/groups', auth.protect(), async (req, res) => {
         await getUserGroups(req, res);
-    })
+    });
+}
+
+export async function Start(is_standalone) {
+    Log('[API Server module started]');
+    /**
+     * When NODE_ENV is set to "production", the static build files will be served (this can be done with a deployment or in standalone mode)
+     * When NODE_ENV is anything other than "production", the Vite development server will start and serve live updates to the browser using hmr over websockets
+     */
+    ViteExpress.config({
+        viteConfigFile: path.join(VITE_CONSOLE_ROOT, 'vite.config.js'),
+        inlineViteConfig: {
+            root: VITE_CONSOLE_ROOT,
+            base: '/',
+            build: { outDir: 'dist' },
+        },
+        ignorePaths: (pathname) =>
+            pathname.startsWith('/api') ||
+            pathname.startsWith('/auth'),
+    });
+    app.set('trust proxy', true );
+
+    const auth = await createManagementOidcAuth();
+
+    router.use(cors());
+    auth.registerOidcRoutes(router);
+    router.use(auth.middleware);
+
+    router.get('/', auth.protect());
+
+    morgan.token('ts', (req, res) => {
+        return new Date().toISOString();
+    });
+
+    router.use(morgan(':ts :remote-addr :remote-user :method :url :status :res[content-length] :response-time ms', {
+        skip: function(req, res) { return !!req._skip_log; }
+    }));
+
+    await Initialize(router, auth);
 
     router.use(bodyParser.text({ type: ['application/yaml'] }));
 

--- a/components/management-controller/src/mc-apiserver.test.js
+++ b/components/management-controller/src/mc-apiserver.test.js
@@ -1,0 +1,230 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createMockClient, TEST_UUIDS } from './test-helpers/mock-db.js';
+import { buildApiApp } from './test-helpers/build-api-app.js';
+
+const mockClient = createMockClient();
+let mockFormFields = {};
+
+vi.mock('formidable', () => {
+    class MockForm {
+        parse() {
+            return Promise.resolve([mockFormFields, {}]);
+        }
+    }
+    const formidable = () => new MockForm();
+    formidable.IncomingForm = MockForm;
+    return {
+        default: formidable,
+        IncomingForm: MockForm,
+    };
+});
+
+vi.mock('./watch-server.js', () => ({
+    WatchNotify: vi.fn(),
+}));
+
+vi.mock('./sync-management.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        NewIngressAvailable: vi.fn(),
+    };
+});
+
+vi.mock('./db.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        ClientFromPool: vi.fn(async () => mockClient),
+    };
+});
+
+describe('mc-apiserver routes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient.query.mockImplementation(async (sql, params) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('INSERT INTO Users')) {
+                return { rows: [{ id: 'internal-user-1' }] };
+            }
+            if (sql.includes('set_config')) {
+                return {};
+            }
+            if (sql.includes('SELECT ShortName, LongName FROM TargetPlatforms')) {
+                return {
+                    rows: [{ shortname: 'sk2', longname: 'Skupper 2' }],
+                };
+            }
+            if (sql.includes('SELECT VanId FROM ApplicationNetworks')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ vanid: 'van-network-id' }],
+                };
+            }
+            if (sql.includes('SELECT Id, Lifecycle, Hostname, Port, Kind FROM BackboneAccessPoints')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: TEST_UUIDS.accessPoint,
+                        lifecycle: 'partial',
+                        hostname: null,
+                        port: null,
+                        kind: 'peer',
+                    }],
+                };
+            }
+            if (sql.includes('UPDATE BackboneAccessPoints SET Hostname')) {
+                return { rowCount: 1 };
+            }
+            if (sql.includes('InterRouterLinks')) {
+                return {
+                    rows: [{
+                        id: 'link-1',
+                        hostname: 'router.example.com',
+                        port: 5671,
+                        cost: 1,
+                    }],
+                };
+            }
+            return { rows: [], rowCount: 0 };
+        });
+    });
+
+    it('GET /targetplatforms returns platform list', async () => {
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            includeUser: false,
+            includeMcRoutes: true,
+        });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/targetplatforms')
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body).toEqual([{ shortname: 'sk2', longname: 'Skupper 2' }]);
+    });
+
+    it('GET /user/profile returns authenticated user name', async () => {
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            includeUser: false,
+            includeMcRoutes: true,
+        });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/user/profile')
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body).toEqual({ name: 'Test User' });
+    });
+
+    it('GET /user/groups returns client groups', async () => {
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            includeUser: false,
+            includeMcRoutes: true,
+        });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/user/groups')
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.body).toEqual([{ id: 'group-a', name: 'group-a' }]);
+    });
+
+    it('GET /certs rejects malformed signedby query', async () => {
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            includeUser: false,
+            includeMcRoutes: true,
+        });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/certs')
+            .query({ signedby: 'not-a-uuid' })
+            .set('x-test-auth', '1')
+            .expect(400);
+
+        expect(res.text).toContain('Malformed signedby reference');
+    });
+
+    it('GET /vans/:vid/config/nonconnecting returns network yaml', async () => {
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            includeUser: false,
+            includeMcRoutes: true,
+        });
+
+        const res = await request(app)
+            .get(`/api/v1alpha1/vans/${TEST_UUIDS.van}/config/nonconnecting`)
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.text).toContain('van-network-id');
+    });
+
+    it('GET /backbonesite/:bsid/links/outgoing/kube returns outgoing links as a ConfigMap manifest', async () => {
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            includeUser: false,
+            includeMcRoutes: true,
+        });
+
+        const res = await request(app)
+            .get(`/api/v1alpha1/backbonesite/${TEST_UUIDS.site}/links/outgoing/kube`)
+            .set('x-test-auth', '1')
+            .expect(200);
+
+        expect(res.text).toContain('kind: ConfigMap');
+        expect(res.text).toContain('router.example.com');
+        expect(res.text).toContain('5671');
+    });
+
+    it('POST /backbonesite/:bsid/ingress updates partial access points', async () => {
+        mockFormFields = {
+            [TEST_UUIDS.accessPoint]: {
+                host: 'ingress.example.com',
+                port: '5671',
+            },
+        };
+        const { app } = await buildApiApp({
+            includeAdmin: false,
+            includeUser: false,
+            includeMcRoutes: true,
+        });
+        const { NewIngressAvailable } = await import('./sync-management.js');
+
+        const res = await request(app)
+            .post(`/api/v1alpha1/backbonesite/${TEST_UUIDS.site}/ingress`)
+            .set('x-test-auth', '1')
+            .expect(201);
+
+        expect(res.body).toEqual({ processed: 1 });
+        expect(NewIngressAvailable).toHaveBeenCalledWith(TEST_UUIDS.site);
+    });
+});

--- a/components/management-controller/src/notify.test.js
+++ b/components/management-controller/src/notify.test.js
@@ -1,0 +1,59 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./watch-server.js', () => ({
+    WatchNotify: vi.fn(),
+}));
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(),
+}));
+
+import { NotifyTransaction, RegisterNotification } from './notify.js';
+import { WatchNotify } from './watch-server.js';
+
+describe('NotifyTransaction', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('dispatches add, update, and delete events on commit', async () => {
+        const handler = vi.fn();
+        await RegisterNotification('TestTable', handler, false);
+
+        const notify = new NotifyTransaction();
+        notify.add('TestTable', 'row-1');
+        notify.update('TestTable', 'row-2');
+        notify.delete('TestTable', 'row-3');
+        await notify.commit();
+
+        expect(handler).toHaveBeenCalledWith('ADD', 'row-1', 'TestTable');
+        expect(handler).toHaveBeenCalledWith('UPDATE', 'row-2', 'TestTable');
+        expect(handler).toHaveBeenCalledWith('DELETE', 'row-3', 'TestTable');
+        expect(WatchNotify).toHaveBeenCalledTimes(3);
+    });
+
+    it('commit succeeds when no handlers are registered', async () => {
+        const notify = new NotifyTransaction();
+        notify.add('UnregisteredTable', 'row-1');
+        await expect(notify.commit()).resolves.toBeUndefined();
+    });
+});

--- a/components/management-controller/src/prune.test.js
+++ b/components/management-controller/src/prune.test.js
@@ -1,0 +1,69 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockClient = {
+    query: vi.fn(),
+    release: vi.fn(),
+};
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(async () => mockClient),
+}));
+
+vi.mock('./notify.js', () => ({
+    NotifyTransaction: class {
+        delete = vi.fn();
+        async commit() {}
+    },
+}));
+
+import { DeleteOrphanCertificates } from './prune.js';
+
+describe('DeleteOrphanCertificates', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('SELECT Id, SignedBy FROM TlsCertificates')) {
+                return { rows: [{ id: 'orphan-cert', signedby: null }] };
+            }
+            if (sql.includes('SELECT Id, Certificate FROM')) {
+                return { rows: [] };
+            }
+            if (sql.startsWith('DELETE FROM TlsCertificates')) {
+                return { rowCount: 1 };
+            }
+            return { rows: [] };
+        });
+    });
+
+    it('deletes tls certificates not referenced by other tables', async () => {
+        await DeleteOrphanCertificates();
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            'DELETE FROM TlsCertificates WHERE Id = $1',
+            ['orphan-cert'],
+        );
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+});

--- a/components/management-controller/src/resource-templates.js
+++ b/components/management-controller/src/resource-templates.js
@@ -385,7 +385,7 @@ export function RoleBinding() {
     };
 }
 
-export function Deployment(bsid, backboneMode, target) {
+export function Deployment(bsid, backboneMode, target, imageOverride) {
     const deployment = {
         apiVersion : 'apps/v1',
         kind       : 'Deployment',
@@ -426,8 +426,8 @@ export function Deployment(bsid, backboneMode, target) {
                 spec : {
                     containers : [
                         {
-                            image           : SiteControllerImage(),
-                            imagePullPolicy : 'Always',
+                            image           : imageOverride ?? SiteControllerImage(),
+                            imagePullPolicy : imageOverride ? 'IfNotPresent' : 'Always',
                             name            : 'controller',
                             env : [
                                 { name: 'SKUPPERX_SITE_ID', value: bsid },

--- a/components/management-controller/src/resource-templates.test.js
+++ b/components/management-controller/src/resource-templates.test.js
@@ -1,0 +1,120 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./config.js', () => ({
+    SiteControllerImage: () => 'quay.io/skupper/vms-site-controller:test',
+}));
+
+import {
+    HashOfData,
+    HashOfConfigMap,
+    HashOfObjectNoChildren,
+    BackboneSite,
+    NetworkCR,
+    NetworkLinkCR,
+    AccessPointCR,
+    Deployment,
+} from './resource-templates.js';
+
+describe('resource-templates', () => {
+    it('HashOfData is stable regardless of key order', () => {
+        const a = HashOfData({ b: '2', a: '1' });
+        const b = HashOfData({ a: '1', b: '2' });
+        expect(a).toBe(b);
+        expect(a).toMatch(/^[a-f0-9]{40}$/);
+    });
+
+    it('HashOfConfigMap hashes data map', () => {
+        const hash = HashOfConfigMap({ data: { key: 'value' } });
+        expect(hash).toBe(HashOfData({ key: 'value' }));
+    });
+
+    it('HashOfObjectNoChildren ignores nested objects', () => {
+        const hash = HashOfObjectNoChildren({ name: 'site', spec: { nested: true } });
+        expect(hash).toBe(HashOfData({ name: 'site' }));
+    });
+
+    it('BackboneSite produces expected CR shape', () => {
+        const site = BackboneSite('backbone-a', 'site-uuid-123');
+        expect(site.kind).toBe('Site');
+        expect(site.metadata.name).toBe('backbone-a');
+        expect(site.spec.linkAccess).toBe('none');
+    });
+
+    it('NetworkCR embeds network id', () => {
+        const cr = NetworkCR('van-network-id');
+        expect(cr.kind).toBe('Network');
+        expect(cr.spec.networkId).toBe('van-network-id');
+    });
+
+    it('NetworkLinkCR parses port as integer', () => {
+        const cr = NetworkLinkCR('router.example.com', '443', 'tls-secret');
+        expect(cr.spec.port).toBe(443);
+        expect(cr.spec.hostname).toBe('router.example.com');
+    });
+
+    it('AccessPointCR for van kind produces NetworkAccess', () => {
+        const cr = AccessPointCR('ap-1', { kind: 'van' });
+        expect(cr.kind).toBe('NetworkAccess');
+    });
+
+    it('AccessPointCR for member kind produces RouterAccess with edge role', () => {
+        const cr = AccessPointCR('ap-2', { kind: 'member' });
+        expect(cr.kind).toBe('RouterAccess');
+        expect(cr.spec.roles[0].name).toBe('edge');
+    });
+
+    it('Deployment uses SiteControllerImage and Always pull policy by default', () => {
+        const deployment = Deployment('site-uuid-1', true, 'sk2');
+
+        expect(deployment.kind).toBe('Deployment');
+        expect(deployment.spec.template.spec.containers[0].image).toBe(
+            'quay.io/skupper/vms-site-controller:test',
+        );
+        expect(deployment.spec.template.spec.containers[0].imagePullPolicy).toBe('Always');
+        expect(deployment.spec.template.spec.containers[0].env).toContainEqual({
+            name: 'SKUPPERX_SITE_ID',
+            value: 'site-uuid-1',
+        });
+        expect(deployment.spec.template.spec.containers[0].env).toContainEqual({
+            name: 'SKX_BACKBONE',
+            value: 'YES',
+        });
+    });
+
+    it('Deployment honors imageOverride with IfNotPresent pull policy', () => {
+        const deployment = Deployment(
+            'site-uuid-2',
+            false,
+            'sk2',
+            'localhost:5001/vms-site-controller:kind-test',
+        );
+
+        expect(deployment.spec.template.spec.containers[0].image).toBe(
+            'localhost:5001/vms-site-controller:kind-test',
+        );
+        expect(deployment.spec.template.spec.containers[0].imagePullPolicy).toBe('IfNotPresent');
+        expect(deployment.spec.template.spec.containers[0].env).toContainEqual({
+            name: 'SKX_BACKBONE',
+            value: 'NO',
+        });
+    });
+});

--- a/components/management-controller/src/site-deployment-state.test.js
+++ b/components/management-controller/src/site-deployment-state.test.js
@@ -1,0 +1,125 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest';
+import { SiteLifecycleChanged_TX } from './site-deployment-state.js';
+
+const SITE_SELECT = 'SELECT Id, Lifecycle, DeploymentState, CoLocated FROM InteriorSites WHERE Id = $1';
+
+describe('SiteLifecycleChanged_TX', () => {
+    it('sets deployment state to deployed when lifecycle is active', async () => {
+        const notify = { update: vi.fn() };
+        const client = {
+            query: vi.fn(async (sql) => {
+                if (sql === SITE_SELECT) {
+                    return {
+                        rowCount: 1,
+                        rows: [{
+                            id: 'site-1',
+                            lifecycle: 'active',
+                            deploymentstate: 'not-ready',
+                            colocated: false,
+                        }],
+                    };
+                }
+                if (sql.includes('UPDATE InteriorSites SET DeploymentState')) {
+                    return { rowCount: 1 };
+                }
+                return { rowCount: 0, rows: [] };
+            }),
+        };
+
+        await SiteLifecycleChanged_TX(client, notify, 'site-1', 'active');
+
+        expect(client.query).toHaveBeenCalledWith(
+            'UPDATE InteriorSites SET DeploymentState = $1 WHERE Id = $2',
+            ['deployed', 'site-1'],
+        );
+        expect(notify.update).toHaveBeenCalledWith('InteriorSites', 'site-1');
+    });
+
+    it('sets ready-bootstrap when lifecycle is ready with manage access points', async () => {
+        const notify = { update: vi.fn() };
+        const client = {
+            query: vi.fn(async (sql) => {
+                if (sql === SITE_SELECT) {
+                    return {
+                        rowCount: 1,
+                        rows: [{
+                            id: 'site-2',
+                            lifecycle: 'ready',
+                            deploymentstate: 'not-ready',
+                            colocated: false,
+                        }],
+                    };
+                }
+                if (sql.includes('InterRouterLinks.Id FROM InterRouterLinks')) {
+                    return { rowCount: 0, rows: [] };
+                }
+                if (sql.includes("Kind = 'manage'")) {
+                    return {
+                        rowCount: 1,
+                        rows: [{ id: 'ap-1', lifecycle: 'pending' }],
+                    };
+                }
+                if (sql.includes('UPDATE InteriorSites SET DeploymentState')) {
+                    return { rowCount: 1 };
+                }
+                return { rowCount: 0, rows: [] };
+            }),
+        };
+
+        await SiteLifecycleChanged_TX(client, notify, 'site-2', 'ready');
+
+        expect(client.query).toHaveBeenCalledWith(
+            'UPDATE InteriorSites SET DeploymentState = $1 WHERE Id = $2',
+            ['ready-bootstrap', 'site-2'],
+        );
+    });
+
+    it('sets colo-automatic when site is colocated', async () => {
+        const notify = { update: vi.fn() };
+        const client = {
+            query: vi.fn(async (sql) => {
+                if (sql === SITE_SELECT) {
+                    return {
+                        rowCount: 1,
+                        rows: [{
+                            id: 'site-3',
+                            lifecycle: 'ready',
+                            deploymentstate: 'not-ready',
+                            colocated: true,
+                        }],
+                    };
+                }
+                if (sql.includes('UPDATE InteriorSites SET DeploymentState')) {
+                    return { rowCount: 1 };
+                }
+                return { rowCount: 0, rows: [] };
+            }),
+        };
+
+        await SiteLifecycleChanged_TX(client, notify, 'site-3', 'ready');
+
+        expect(client.query).toHaveBeenCalledWith(
+            'UPDATE InteriorSites SET DeploymentState = $1 WHERE Id = $2',
+            ['colo-automatic', 'site-3'],
+        );
+    });
+});

--- a/components/management-controller/src/sync-application.test.js
+++ b/components/management-controller/src/sync-application.test.js
@@ -1,0 +1,144 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockClient = {
+    query: vi.fn(),
+    release: vi.fn(),
+};
+
+function mockMemberQueries({ withTemplates = false } = {}) {
+    mockClient.query.mockImplementation(async (sql) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+            return {};
+        }
+        if (sql.includes('MemberSites')) {
+            return { rowCount: 1, rows: [{ memberof: 'van-1', siteclasses: ['default'] }] };
+        }
+        if (sql.includes('ApplicationTemplates')) {
+            if (!withTemplates) {
+                return { rows: [] };
+            }
+            return { rows: [{ atid: 'at-1', name: 'app-a' }] };
+        }
+        if (sql.includes('FROM Components')) {
+            return {
+                rows: [{
+                    cid: 'comp-1',
+                    ctid: 'ct-1',
+                    name: 'frontend',
+                    format: 'json',
+                    spec: '{}',
+                }],
+            };
+        }
+        if (sql.includes('FROM Interfaces')) {
+            return {
+                rows: [{
+                    iid: 'iface-1',
+                    role: 'accept',
+                    hostnameused: 'frontend.example.com',
+                    actualport: 8080,
+                    defaultport: 8080,
+                    transportprotocol: 'tcp',
+                    applicationprotocol: 'http',
+                    bid: 'bind-1',
+                    distribution: 'single',
+                    scope: 'site',
+                    vanaddress: 'app.frontend',
+                }],
+            };
+        }
+        return { rows: [] };
+    });
+}
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(async () => mockClient),
+}));
+
+import { onMewMember, StateRequest } from './sync-application.js';
+
+describe('StateRequest', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockMemberQueries();
+    });
+
+    it('returns null hash and empty data for unknown state key', async () => {
+        const [hash, data] = await StateRequest('member-1', 'missing-key');
+
+        expect(hash).toBeNull();
+        expect(data).toEqual({});
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+});
+
+describe('onMewMember', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockMemberQueries();
+    });
+
+    it('returns local state unchanged when member has no application templates', async () => {
+        const localState = { existing: 'hash' };
+        const remoteState = {};
+
+        const [updatedLocal, updatedRemote] = await onMewMember('member-1', localState, remoteState);
+
+        expect(updatedLocal).toEqual({ existing: 'hash' });
+        expect(updatedRemote).toEqual({});
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('adds component and interface state hashes when templates exist', async () => {
+        mockMemberQueries({ withTemplates: true });
+        const localState = {};
+        const remoteState = {};
+
+        const [updatedLocal, updatedRemote] = await onMewMember('member-1', localState, remoteState);
+
+        expect(Object.keys(updatedLocal)).toEqual(
+            expect.arrayContaining(['component-comp-1', 'iface-accept-bind-1']),
+        );
+        expect(typeof updatedLocal['component-comp-1']).toBe('string');
+        expect(updatedRemote).toEqual({});
+    });
+});
+
+describe('StateRequest with cached application state', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns cached hash and data after onMewMember populates state', async () => {
+        mockMemberQueries({ withTemplates: true });
+
+        await onMewMember('member-1', {}, {});
+
+        const [hash, data] = await StateRequest('member-1', 'component-comp-1');
+
+        expect(hash).toMatch(/^[a-f0-9]{40}$/);
+        expect(data).toEqual(expect.objectContaining({
+            id: 'comp-1',
+            name: 'frontend',
+        }));
+    });
+});

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -831,3 +831,8 @@ export async function Start() {
     await RegisterHandler(onLinkAdded, onLinkDeleted);
     await RegisterNotification('ApplicationNetworks', onApplicationNetworkChange, false);
 }
+
+/** @internal Exported for unit tests */
+export function _registerPeerForTest(peerId, peerClass = CLASS_BACKBONE) {
+    peers[peerId] = { pClass: peerClass };
+}

--- a/components/management-controller/src/sync-management.test.js
+++ b/components/management-controller/src/sync-management.test.js
@@ -1,0 +1,266 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@skupperx/modules/state-sync', () => ({
+    DeletePeer: vi.fn(),
+    UpdateLocalState: vi.fn(),
+}));
+
+vi.mock('@skupperx/modules/kube', () => ({
+    LoadSecret: vi.fn(),
+}));
+
+vi.mock('./backbone-links.js', () => ({
+    RegisterHandler: vi.fn(),
+}));
+
+vi.mock('./sync-application.js', () => ({
+    onMewMember: vi.fn(),
+    StateRequest: vi.fn(),
+}));
+
+vi.mock('./notify.js', () => ({
+    RegisterNotification: vi.fn(),
+    NotifyTransaction: class {
+        update() {}
+        async commit() {}
+    },
+}));
+
+const mockClient = {
+    query: vi.fn(),
+    release: vi.fn(),
+};
+
+vi.mock('./db.js', () => ({
+    ClientFromPool: vi.fn(async () => mockClient),
+}));
+
+import {
+    GetBackboneLinks_TX,
+    GetBackboneAccessPoints_TX,
+    SiteDeleted,
+    SiteCertificateChanged,
+    SiteIngressChanged,
+    _registerPeerForTest,
+} from './sync-management.js';
+import { DeletePeer, UpdateLocalState } from '@skupperx/modules/state-sync';
+import { LoadSecret } from '@skupperx/modules/kube';
+
+describe('GetBackboneLinks_TX', () => {
+    it('returns links keyed by id with hostname', async () => {
+        const client = {
+            query: vi.fn(async () => ({
+                rows: [{
+                    id: 'link-1',
+                    hostname: 'router.example.com',
+                    port: 9090,
+                    cost: 2,
+                }],
+            })),
+        };
+
+        const links = await GetBackboneLinks_TX(client, 'site-1');
+
+        expect(links).toEqual({
+            'link-1': {
+                host: 'router.example.com',
+                port: 9090,
+                cost: '2',
+            },
+        });
+    });
+
+    it('omits links without hostname', async () => {
+        const client = {
+            query: vi.fn(async () => ({
+                rows: [{
+                    id: 'link-2',
+                    hostname: null,
+                    port: 9090,
+                    cost: 1,
+                }],
+            })),
+        };
+
+        const links = await GetBackboneLinks_TX(client, 'site-1');
+
+        expect(links).toEqual({});
+    });
+});
+
+describe('GetBackboneAccessPoints_TX', () => {
+    it('includes manage access points when initialOnly is true', async () => {
+        const client = {
+            query: vi.fn(async () => ({
+                rows: [{
+                    id: 'ap-manage',
+                    kind: 'manage',
+                    bindhost: '',
+                    accesstype: 'local',
+                    colocated: false,
+                }, {
+                    id: 'ap-van',
+                    kind: 'van',
+                    bindhost: '',
+                    accesstype: '',
+                    colocated: false,
+                }],
+            })),
+        };
+
+        const accessPoints = await GetBackboneAccessPoints_TX(client, 'site-1', true);
+
+        expect(Object.keys(accessPoints)).toEqual(['ap-manage']);
+        expect(accessPoints['ap-manage']).toEqual({ kind: 'manage', accessType: 'local' });
+    });
+
+    it('includes all access points when initialOnly is false', async () => {
+        const client = {
+            query: vi.fn(async () => ({
+                rows: [{
+                    id: 'ap-manage',
+                    kind: 'manage',
+                    bindhost: '0.0.0.0',
+                    accesstype: '',
+                    colocated: false,
+                }, {
+                    id: 'ap-van',
+                    kind: 'van',
+                    bindhost: '',
+                    accesstype: '',
+                    colocated: false,
+                }],
+            })),
+        };
+
+        const accessPoints = await GetBackboneAccessPoints_TX(client, 'site-1', false);
+
+        expect(Object.keys(accessPoints).sort((a, b) => a.localeCompare(b))).toEqual(['ap-manage', 'ap-van']);
+        expect(accessPoints['ap-manage'].bindhost).toBe('0.0.0.0');
+    });
+});
+
+describe('SiteDeleted', () => {
+    it('calls DeletePeer for the site id', async () => {
+        await SiteDeleted('site-1');
+
+        expect(DeletePeer).toHaveBeenCalledWith('site-1');
+    });
+});
+
+describe('SiteCertificateChanged', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+    });
+
+    it('updates tls-site state hash for connected backbone sites', async () => {
+        _registerPeerForTest('site-1', 'backbone');
+
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('FROM InteriorSites') && sql.includes('Certificate = $1')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ id: 'site-1', objectname: 'site-tls-secret' }],
+                };
+            }
+            return { rows: [] };
+        });
+
+        LoadSecret.mockResolvedValue({
+            data: { 'tls.crt': Buffer.from('cert').toString('base64') },
+        });
+
+        await SiteCertificateChanged('cert-1');
+
+        expect(LoadSecret).toHaveBeenCalledWith('site-tls-secret');
+        expect(UpdateLocalState).toHaveBeenCalledWith(
+            'site-1',
+            'tls-site-site-1',
+            expect.stringMatching(/^[a-f0-9]{40}$/),
+        );
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('skips update when site is not connected', async () => {
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('FROM InteriorSites') && sql.includes('Certificate = $1')) {
+                return {
+                    rowCount: 1,
+                    rows: [{ id: 'site-offline', objectname: 'site-tls-secret' }],
+                };
+            }
+            return { rows: [] };
+        });
+
+        await SiteCertificateChanged('cert-2');
+
+        expect(LoadSecret).not.toHaveBeenCalled();
+        expect(UpdateLocalState).not.toHaveBeenCalled();
+    });
+});
+
+describe('SiteIngressChanged', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockClient.query.mockReset();
+    });
+
+    it('updates access point hash for connected sites', async () => {
+        _registerPeerForTest('site-2', 'backbone');
+
+        mockClient.query.mockImplementation(async (sql) => {
+            if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+                return {};
+            }
+            if (sql.includes('FROM BackboneAccessPoints JOIN InteriorSites')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        kind: 'manage',
+                        bindhost: '0.0.0.0',
+                        accesstype: 'local',
+                        certificate: 'cert-ap',
+                        lifecycle: 'ready',
+                        colocated: false,
+                    }],
+                };
+            }
+            return { rows: [] };
+        });
+
+        await SiteIngressChanged('site-2', 'ap-1');
+
+        expect(UpdateLocalState).toHaveBeenCalledWith(
+            'site-2',
+            'access-ap-1',
+            expect.stringMatching(/^[a-f0-9]{40}$/),
+        );
+        expect(mockClient.release).toHaveBeenCalled();
+    });
+});

--- a/components/management-controller/src/test-helpers/build-api-app.js
+++ b/components/management-controller/src/test-helpers/build-api-app.js
@@ -1,0 +1,65 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import express from 'express';
+import bodyParser from 'body-parser';
+import { createMockAuth } from './mock-auth.js';
+
+const DEFAULT_ROLES = [
+    'admin',
+    'backbone-owner',
+    'can-list-backbones',
+    'can-list-accesspoints-backbone',
+    'van-owner',
+    'can-list-vans',
+    'certificate-manager',
+];
+
+/**
+ * Build an Express app with mocked OIDC auth and selected API routers mounted.
+ */
+export async function buildApiApp({
+    roles = DEFAULT_ROLES,
+    includeAdmin = true,
+    includeUser = true,
+    includeMcRoutes = false,
+} = {}) {
+    const app = express();
+    const router = express.Router();
+    const auth = createMockAuth({ roles });
+
+    router.use(auth.middleware);
+    router.use(bodyParser.text({ type: ['application/yaml'] }));
+
+    if (includeAdmin) {
+        const adminApi = await import('../api-admin.js');
+        await adminApi.Initialize(router, auth);
+    }
+    if (includeUser) {
+        const userApi = await import('../api-user.js');
+        await userApi.Initialize(router, auth);
+    }
+    if (includeMcRoutes) {
+        const mcApi = await import('../mc-apiserver.js');
+        await mcApi.Initialize(router, auth);
+    }
+
+    app.use(router);
+    return { app, auth };
+}

--- a/components/management-controller/src/test-helpers/mock-auth.js
+++ b/components/management-controller/src/test-helpers/mock-auth.js
@@ -1,0 +1,69 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+/**
+ * Minimal auth double for API tests. Set `x-test-auth: 1` to authenticate;
+ * optional `x-test-roles` comma-separated realm roles.
+ */
+export function createMockAuth(defaultUser = {}) {
+    const middleware = (req, res, next) => {
+        if (req.headers['x-test-auth']) {
+            const roleHeader = req.headers['x-test-roles'];
+            const roles = roleHeader
+                ? roleHeader.split(',').map((r) => r.trim()).filter(Boolean)
+                : (defaultUser.roles || ['admin']);
+            req.kauth = {
+                grant: {
+                    access_token: {
+                        content: {
+                            sub: defaultUser.sub || 'test-user-sub',
+                            given_name: defaultUser.given_name || 'Test',
+                            family_name: defaultUser.family_name || 'User',
+                            clientGroups: defaultUser.groups || ['group-a'],
+                            realm_access: { roles },
+                        },
+                    },
+                },
+            };
+        }
+        next();
+    };
+
+    const protect = (requiredRealmRole) => {
+        return (req, res, next) => {
+            if (!req.kauth?.grant?.access_token?.content) {
+                return res.status(401).send('Unauthorized');
+            }
+            if (requiredRealmRole) {
+                const roleName = requiredRealmRole.replace(/^realm:/, '');
+                const roles = req.kauth.grant.access_token.content.realm_access?.roles || [];
+                if (!roles.includes(roleName)) {
+                    return res.status(403).send('Forbidden');
+                }
+            }
+            return next();
+        };
+    }
+
+    return {
+        middleware,
+        protect,
+        registerOidcRoutes: () => {},
+    };
+}

--- a/components/management-controller/src/test-helpers/mock-db.js
+++ b/components/management-controller/src/test-helpers/mock-db.js
@@ -1,0 +1,56 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { vi } from 'vitest';
+
+const SYSTEM_QUERIES = new Set(['BEGIN', 'COMMIT', 'ROLLBACK']);
+
+/**
+ * Create a mock pg client whose `query` runs `handler` after session bootstrap queries.
+ */
+export function createMockClient(handler) {
+    return {
+        query: vi.fn(async (sql, params) => {
+            if (SYSTEM_QUERIES.has(sql)) {
+                return {};
+            }
+            if (sql.includes('INSERT INTO Users')) {
+                return { rows: [{ id: 'internal-user-1' }] };
+            }
+            if (sql.includes('set_config')) {
+                return {};
+            }
+            if (handler) {
+                return handler(sql, params);
+            }
+            return { rows: [], rowCount: 0 };
+        }),
+        release: vi.fn(),
+    };
+}
+
+export const TEST_UUIDS = {
+    backbone: '00000000-0000-4000-8000-000000000001',
+    van: '00000000-0000-4000-8000-000000000002',
+    site: '00000000-0000-4000-8000-000000000003',
+    accessPoint: '00000000-0000-4000-8000-000000000004',
+    invitation: '00000000-0000-4000-8000-000000000005',
+    member: '00000000-0000-4000-8000-000000000006',
+    cert: '00000000-0000-4000-8000-000000000007',
+};

--- a/components/management-controller/src/watch-server.js
+++ b/components/management-controller/src/watch-server.js
@@ -128,6 +128,8 @@ function pruneIndex() {
 //
 const mutex = new Mutex();
 
+let watchDispatch = sendUpdate;
+
 async function sendUpdate(watch, isInitial) {
     const release = await mutex.acquire();
     const url = watch.source.address;
@@ -227,11 +229,31 @@ export async function WatchNotify(tableName, id, holdoff) {
         }
 
         for (const watch of watches) {
-            sendUpdate(watch, false);
+            watchDispatch(watch, false);
         }
 
         for (const watch of tableIndex.all) {
-            sendUpdate(watch, false);
+            watchDispatch(watch, false);
         }
     }
+}
+
+/** @internal Exported for unit tests */
+export function _registerWatchForTest(tableName, id, watch) {
+    if (!watchIndex[tableName]) {
+        watchIndex[tableName] = { all: [] };
+    }
+    if (id) {
+        if (!watchIndex[tableName][id]) {
+            watchIndex[tableName][id] = [];
+        }
+        watchIndex[tableName][id].push(watch);
+    } else {
+        watchIndex[tableName].all.push(watch);
+    }
+}
+
+/** @internal Exported for unit tests */
+export function _setWatchDispatchForTest(fn) {
+    watchDispatch = fn ?? sendUpdate;
 }

--- a/components/management-controller/src/watch-server.test.js
+++ b/components/management-controller/src/watch-server.test.js
@@ -1,0 +1,60 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    WatchNotify,
+    _registerWatchForTest,
+    _setWatchDispatchForTest,
+} from './watch-server.js';
+
+describe('WatchNotify', () => {
+    beforeEach(() => {
+        _setWatchDispatchForTest(vi.fn());
+    });
+
+    afterEach(() => {
+        _setWatchDispatchForTest(undefined);
+    });
+
+    it('does nothing when no watches are registered for the table', async () => {
+        const dispatch = vi.fn();
+        _setWatchDispatchForTest(dispatch);
+
+        await expect(WatchNotify('InteriorSites', 'site-1')).resolves.toBeUndefined();
+
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches updates to id-specific and table-wide watches', async () => {
+        const dispatch = vi.fn();
+        _setWatchDispatchForTest(dispatch);
+
+        const idWatch = { id: 'watch-by-id' };
+        const allWatch = { id: 'watch-all' };
+        _registerWatchForTest('InteriorSites', 'site-1', idWatch);
+        _registerWatchForTest('InteriorSites', null, allWatch);
+
+        await WatchNotify('InteriorSites', 'site-1');
+
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(idWatch, false);
+        expect(dispatch).toHaveBeenCalledWith(allWatch, false);
+    });
+});


### PR DESCRIPTION
Extract Initialize from Start, add internal test hooks, HTTP OIDC , imageOverride in resource templates, and broad MC unit test coverage

Changes to production code
- added configuration to allow insecure oidc requests in order to make adding unit tests feasible
- moved mc api routes to "Initialize" function, following same pattern as the other api files. This allows us to test the api routes without starting the vite server
- added override for site controller image and pull policy. This is in preparation for upcoming integration test PR. It is added here to be paired with the resource template unit tests.
- added "watchDispatch" variable as a reference to the sendUpdate function in watch-server.js. This allows the code to be unit-tested without starting the WebSocket watch server; production behavior should remain unchanged

Testing:
- run `pnpm install` in project root
- run `pnpm test:unit` to test the added management controller unit tests

Part of #126 