### PR TITLE
Refactor site-controller API for testability and add unit tests.

### DIFF
--- a/components/site-controller/src/api-member.test.js
+++ b/components/site-controller/src/api-member.test.js
@@ -1,0 +1,104 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { buildSiteApiApp } from './test-helpers/build-site-api-app.js';
+
+let mockFormFields = {};
+
+vi.mock('formidable', () => ({
+    IncomingForm: class {
+        parse() {
+            return Promise.resolve([mockFormFields, {}]);
+        }
+    },
+}));
+
+vi.mock('@skupperx/modules/kube', () => ({
+    ApplyObject: vi.fn(),
+}));
+
+import { ApplyObject } from '@skupperx/modules/kube';
+
+describe('api-member', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('POST /listeners creates a listener config map', async () => {
+        mockFormFields = {
+            name: 'listener-a',
+            routingkey: 'app.frontend',
+            host: 'frontend.example.com',
+            port: '8080',
+        };
+
+        const { app } = await buildSiteApiApp({ backboneMode: true, includeMemberApi: true });
+
+        await request(app)
+            .post('/api/v1alpha1/listeners')
+            .expect(201);
+
+        expect(ApplyObject).toHaveBeenCalledWith(expect.objectContaining({
+            kind: 'ConfigMap',
+            metadata: expect.objectContaining({ name: 'listener-a' }),
+            data: expect.objectContaining({
+                'routing-key': 'app.frontend',
+                host: 'frontend.example.com',
+                port: '8080',
+            }),
+        }));
+    });
+
+    it('POST /connectors creates a connector config map', async () => {
+        mockFormFields = {
+            name: 'connector-a',
+            routingkey: 'app.backend',
+            port: '8080',
+            selector: 'app=backend',
+        };
+
+        const { app } = await buildSiteApiApp({ backboneMode: true, includeMemberApi: true });
+
+        await request(app)
+            .post('/api/v1alpha1/connectors')
+            .expect(201);
+
+        expect(ApplyObject).toHaveBeenCalledWith(expect.objectContaining({
+            kind: 'ConfigMap',
+            metadata: expect.objectContaining({ name: 'connector-a' }),
+            data: expect.objectContaining({
+                'routing-key': 'app.backend',
+                port: '8080',
+                selector: 'app=backend',
+            }),
+        }));
+    });
+
+    it('GET /listeners returns not implemented', async () => {
+        const { app } = await buildSiteApiApp({ backboneMode: true, includeMemberApi: true });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/listeners')
+            .expect(400);
+
+        expect(res.text).toBe('Not Implemented');
+    });
+});

--- a/components/site-controller/src/claim.test.js
+++ b/components/site-controller/src/claim.test.js
@@ -1,0 +1,64 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@skupperx/modules/kube', () => ({
+    ApplyObject: vi.fn(),
+    DeleteSecret: vi.fn(),
+    DeleteConfigmap: vi.fn(),
+    LoadConfigmap: vi.fn(),
+    Controlled: vi.fn(() => false),
+    LoadSecret: vi.fn(),
+}));
+
+vi.mock('@skupperx/modules/amqp', () => ({
+    OpenConnection: vi.fn(),
+    OpenSender: vi.fn(),
+    Request: vi.fn(),
+    CloseConnection: vi.fn(),
+}));
+
+describe('claim', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+    });
+
+    it('GetClaimState returns the initial awaiting-name state', async () => {
+        const { GetClaimState } = await import('./claim.js');
+        expect(GetClaimState()).toMatchObject({
+            interactive: true,
+            status: 'awaiting-name',
+            siteName: null,
+        });
+    });
+
+    it('SetInteractiveName stores the site name before claim processing fails', async () => {
+        const { SetInteractiveName, GetClaimState } = await import('./claim.js');
+        const kube = await import('@skupperx/modules/kube');
+
+        kube.LoadConfigmap.mockResolvedValue(null);
+
+        await expect(SetInteractiveName('member-site')).rejects.toThrow();
+
+        expect(GetClaimState().siteName).toBe('member-site');
+        expect(GetClaimState().status).toBe('failed');
+    });
+});

--- a/components/site-controller/src/hash.test.js
+++ b/components/site-controller/src/hash.test.js
@@ -1,0 +1,40 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect } from 'vitest';
+import { HashOfData, HashOfSecret, HashOfConfigMap } from './hash.js';
+
+describe('hash', () => {
+    it('HashOfData is stable regardless of key order', () => {
+        const a = HashOfData({ z: '2', a: '1' });
+        const b = HashOfData({ a: '1', z: '2' });
+        expect(a).toBe(b);
+        expect(a).toMatch(/^[a-f0-9]{40}$/);
+    });
+
+    it('HashOfSecret hashes secret data', () => {
+        const secret = { data: { 'tls.crt': 'abc', 'tls.key': 'def' } };
+        expect(HashOfSecret(secret)).toBe(HashOfData(secret.data));
+    });
+
+    it('HashOfConfigMap hashes configmap data', () => {
+        const cm = { data: { outgoing: '{}' } };
+        expect(HashOfConfigMap(cm)).toBe(HashOfData(cm.data));
+    });
+});

--- a/components/site-controller/src/ingress-v2.test.js
+++ b/components/site-controller/src/ingress-v2.test.js
@@ -1,0 +1,149 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    META_ANNOTATION_STATE_ID,
+} from '@skupperx/modules/common';
+
+let accessHandler;
+
+vi.mock('@skupperx/modules/kube', () => ({
+    Controlled: (obj) => obj?.metadata?.annotations?.['skupper.io/skupperx-controlled'] === 'true',
+    Annotation: (obj, key) => obj?.metadata?.annotations?.[key],
+    startWatchRouterAccesses: vi.fn((handler) => {
+        accessHandler = handler;
+    }),
+    WatchNetworkAccesses: vi.fn(),
+}));
+
+vi.mock('./sync-site-kube.js', () => ({
+    UpdateLocalState: vi.fn(),
+}));
+
+import { GetRouterAccessRole } from './ingress-v2.js';
+
+describe('GetRouterAccessRole', () => {
+    it('maps access point kinds to router roles', () => {
+        expect(GetRouterAccessRole('manage')).toBe('normal');
+        expect(GetRouterAccessRole('claim')).toBe('normal');
+        expect(GetRouterAccessRole('peer')).toBe('inter-router');
+        expect(GetRouterAccessRole('member')).toBe('edge');
+    });
+
+    it('throws for unknown kinds', () => {
+        expect(() => GetRouterAccessRole('unknown')).toThrow('Unknown kind: unknown');
+    });
+});
+
+describe('ingress bundles', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+    });
+
+    it('returns empty bundles before any access points are tracked', async () => {
+        const {
+            GetAccessPointKind,
+            GetIngressBundle,
+            GetIngressBundleV2,
+            GetInitialState,
+        } = await import('./ingress-v2.js');
+
+        expect(GetAccessPointKind('missing-ap')).toBeNull();
+        expect(GetIngressBundle()).toEqual({});
+        expect(GetIngressBundleV2()).toEqual({});
+        await expect(GetInitialState()).resolves.toEqual({});
+    });
+});
+
+describe('access point watcher', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        vi.resetModules();
+        accessHandler = undefined;
+        const ingress = await import('./ingress-v2.js');
+        await ingress.Start();
+    });
+
+    it('records router access endpoints and syncs local state', async () => {
+        const { GetAccessPointKind, GetIngressBundleV2 } = await import('./ingress-v2.js');
+        const { UpdateLocalState } = await import('./sync-site-kube.js');
+
+        await accessHandler('ADDED', {
+            kind: 'RouterAccess',
+            metadata: {
+                name: 'peer-router-access',
+                annotations: {
+                    'skupper.io/skupperx-controlled': 'true',
+                    [META_ANNOTATION_STATE_ID]: 'ap-1',
+                },
+            },
+            status: {
+                endpoints: [{
+                    group: 'skupper-router',
+                    host: 'router.example.com',
+                    port: 9090,
+                }],
+            },
+        });
+
+        expect(GetAccessPointKind('ap-1')).toBe('peer');
+        expect(GetIngressBundleV2()).toEqual({
+            'ap-1': {
+                host: 'router.example.com',
+                port: 9090,
+            },
+        });
+        expect(UpdateLocalState).toHaveBeenCalledWith(
+            'accessstatus-ap-1',
+            expect.any(String),
+            { host: 'router.example.com', port: 9090 },
+        );
+    });
+
+    it('removes access points on delete', async () => {
+        const { GetIngressBundleV2 } = await import('./ingress-v2.js');
+        const { UpdateLocalState } = await import('./sync-site-kube.js');
+
+        const access = {
+            kind: 'RouterAccess',
+            metadata: {
+                name: 'peer-router-access',
+                annotations: {
+                    'skupper.io/skupperx-controlled': 'true',
+                    [META_ANNOTATION_STATE_ID]: 'ap-2',
+                },
+            },
+            status: {
+                endpoints: [{
+                    group: 'skupper-router',
+                    host: 'router.example.com',
+                    port: 9091,
+                }],
+            },
+        };
+
+        await accessHandler('ADDED', access);
+        await accessHandler('DELETED', access);
+
+        expect(GetIngressBundleV2()).toEqual({});
+        expect(UpdateLocalState).toHaveBeenLastCalledWith('accessstatus-ap-2', null, {});
+    });
+});

--- a/components/site-controller/src/router-port.test.js
+++ b/components/site-controller/src/router-port.test.js
@@ -1,0 +1,55 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('router-port', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    it('GetApiPort returns the fixed site-controller API port', async () => {
+        const { GetApiPort } = await import('./router-port.js');
+        expect(GetApiPort()).toBe(1040);
+    });
+
+    it('AllocatePort skips reserved ports and reuses freed ports', async () => {
+        const { AllocatePort, FreePort, TakePort } = await import('./router-port.js');
+
+        expect(AllocatePort()).toBe(1050);
+        const freed = AllocatePort();
+        expect(freed).toBe(1051);
+
+        FreePort(freed);
+        TakePort(5672);
+        TakePort(9090);
+
+        expect(AllocatePort()).toBe(freed);
+        expect(AllocatePort()).toBe(1052);
+        expect(AllocatePort()).toBe(1053);
+    });
+
+    it('FreePort ignores ports below the ephemeral range', async () => {
+        const { AllocatePort, FreePort } = await import('./router-port.js');
+
+        const first = AllocatePort();
+        FreePort(80);
+        expect(AllocatePort()).toBe(first + 1);
+    });
+});

--- a/components/site-controller/src/sc-apiserver.js
+++ b/components/site-controller/src/sc-apiserver.js
@@ -26,7 +26,7 @@ import { GetIngressBundleV2 } from './ingress-v2.js';
 import { GetClaimState, SetInteractiveName } from './claim.js';
 import { ValidateAndNormalizeFields } from '@skupperx/modules/util'
 import { Log } from '@skupperx/modules/log'
-import { Initialize } from './api-member.js';
+import { Initialize as initializeMemberApi } from './api-member.js';
 import { GetApiPort } from './router-port.js';
 
 const API_PREFIX = '/api/v1alpha1/';
@@ -68,31 +68,46 @@ const apiLog = function(req, status) {
     Log(`SiteAPI: ${req.ip} - (${status}) ${req.method} ${req.originalUrl}`);
 }
 
-export async function Start(backboneMode, platform) {
-    Log('[API Server module started]');
-    api = express();
-    api.use(cors());
+export function createApiApp() {
+    const app = express();
+    app.use(cors());
+    return app;
+}
 
-    api.get('/healthz', (req, res) => {
+/**
+ * Register site-controller HTTP routes on an Express app (no port binding).
+ * @param {import('express').Express} app
+ * @param {{ backboneMode?: boolean, includeMemberApi?: boolean }} [options]
+ */
+export async function Initialize(app, { backboneMode = false, includeMemberApi = true } = {}) {
+    app.get('/healthz', (req, res) => {
         res.send('OK');
         res.status(200).end();
     });
 
     if (backboneMode) {
-        api.get(API_PREFIX + 'hostnames', (req, res) => {
+        app.get(API_PREFIX + 'hostnames', (req, res) => {
             apiLog(req, getHostnames(res));
         });
     } else {
-        api.get(API_PREFIX + 'site/status', (req, res) => {
+        app.get(API_PREFIX + 'site/status', (req, res) => {
             apiLog(req, getSiteStatus(res));
         });
 
-        api.put(API_PREFIX + 'site/start', async (req, res) => {
+        app.put(API_PREFIX + 'site/start', async (req, res) => {
             apiLog(req, await startClaim(req, res));
         });
     }
 
-    Initialize(api);
+    if (includeMemberApi) {
+        await initializeMemberApi(app);
+    }
+}
+
+export async function Start(backboneMode, platform) {
+    Log('[API Server module started]');
+    api = createApiApp();
+    await Initialize(api, { backboneMode, includeMemberApi: true });
 
     let server = api.listen(GetApiPort(), () => {
         let host = server.address().address;

--- a/components/site-controller/src/sc-apiserver.test.js
+++ b/components/site-controller/src/sc-apiserver.test.js
@@ -1,0 +1,102 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { buildSiteApiApp } from './test-helpers/build-site-api-app.js';
+
+let mockFormFields = {};
+
+vi.mock('formidable', () => ({
+    IncomingForm: class {
+        parse() {
+            return Promise.resolve([mockFormFields, {}]);
+        }
+    },
+}));
+
+vi.mock('./ingress-v2.js', () => ({
+    GetIngressBundleV2: vi.fn(() => ({
+        'ap-1': { host: 'ingress.example.com', port: 9090 },
+    })),
+}));
+
+vi.mock('./claim.js', () => ({
+    GetClaimState: vi.fn(() => ({
+        interactive: true,
+        status: 'awaiting-name',
+        siteName: null,
+    })),
+    SetInteractiveName: vi.fn(async (name) => name),
+}));
+
+import { GetIngressBundleV2 } from './ingress-v2.js';
+import { GetClaimState, SetInteractiveName } from './claim.js';
+
+describe('sc-apiserver routes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('GET /healthz returns OK', async () => {
+        const { app } = await buildSiteApiApp({ backboneMode: true, includeMemberApi: false });
+
+        const res = await request(app)
+            .get('/healthz')
+            .expect(200);
+
+        expect(res.text).toBe('OK');
+    });
+
+    it('GET /hostnames returns the ingress bundle in backbone mode', async () => {
+        const { app } = await buildSiteApiApp({ backboneMode: true, includeMemberApi: false });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/hostnames')
+            .expect(200);
+
+        expect(res.body).toEqual({
+            'ap-1': { host: 'ingress.example.com', port: 9090 },
+        });
+        expect(GetIngressBundleV2).toHaveBeenCalled();
+    });
+
+    it('GET /site/status returns claim state in member mode', async () => {
+        const { app } = await buildSiteApiApp({ backboneMode: false, includeMemberApi: false });
+
+        const res = await request(app)
+            .get('/api/v1alpha1/site/status')
+            .expect(200);
+
+        expect(res.body.status).toBe('awaiting-name');
+        expect(GetClaimState).toHaveBeenCalled();
+    });
+
+    it('PUT /site/start sets the interactive site name', async () => {
+        mockFormFields = { name: 'member-site' };
+        const { app } = await buildSiteApiApp({ backboneMode: false, includeMemberApi: false });
+
+        const res = await request(app)
+            .put('/api/v1alpha1/site/start')
+            .expect(201);
+
+        expect(res.body).toEqual({ name: 'member-site' });
+        expect(SetInteractiveName).toHaveBeenCalledWith('member-site');
+    });
+});

--- a/components/site-controller/src/sync-site-kube.test.js
+++ b/components/site-controller/src/sync-site-kube.test.js
@@ -1,0 +1,261 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    INJECT_TYPE_SITE,
+    META_ANNOTATION_SKUPPERX_CONTROLLED,
+    META_ANNOTATION_TLS_INJECT,
+} from '@skupperx/modules/common';
+
+/** @type {Record<string, Function>} */
+const stateSyncCallbacks = {};
+
+vi.mock('@skupperx/modules/state-sync', () => ({
+    UpdateLocalState: vi.fn(),
+    Start: vi.fn((_siteClass, _siteId, _address, onNewPeer, onPeerLost, onStateChange, onStateRequest, onPing) => {
+        stateSyncCallbacks.onNewPeer = onNewPeer;
+        stateSyncCallbacks.onPeerLost = onPeerLost;
+        stateSyncCallbacks.onStateChange = onStateChange;
+        stateSyncCallbacks.onStateRequest = onStateRequest;
+        stateSyncCallbacks.onPing = onPing;
+    }),
+    CLASS_BACKBONE: 'backbone',
+    CLASS_MEMBER: 'member',
+    AddTarget: vi.fn(),
+    AddConnection: vi.fn(),
+}));
+
+vi.mock('@skupperx/modules/kube', () => ({
+    Annotation: vi.fn((obj, key) => obj?.metadata?.annotations?.[key]),
+    GetSecrets: vi.fn(async () => []),
+    GetConfigmaps: vi.fn(async () => []),
+    GetDeployments: vi.fn(async () => []),
+    GetPods: vi.fn(async () => []),
+    GetListeners: vi.fn(async () => []),
+    ApplyObject: vi.fn(),
+    DeleteSecret: vi.fn(),
+    DeleteConfigmap: vi.fn(),
+    DeleteDeployment: vi.fn(),
+    LoadSecret: vi.fn(),
+    LoadConfigmap: vi.fn(),
+    UpdateLink: vi.fn(),
+    UpdateNetworkAccess: vi.fn(),
+    UpdateRouterAccess: vi.fn(),
+    LoadLink: vi.fn(async () => undefined),
+    DeleteLink: vi.fn(),
+    Controlled: vi.fn((obj) => obj?.metadata?.annotations?.[META_ANNOTATION_SKUPPERX_CONTROLLED] === 'true'),
+    DeleteRouterAccess: vi.fn(),
+    DeleteNetworkAccess: vi.fn(),
+    LoadRouterAccess: vi.fn(async () => undefined),
+    LoadNetworkAccess: vi.fn(async () => undefined),
+    LoadListener: vi.fn(async () => undefined),
+    DeleteListener: vi.fn(),
+}));
+
+vi.mock('./ingress-v2.js', () => ({
+    GetInitialState: vi.fn(async () => ({})),
+    GetRouterAccessRole: vi.fn((kind) => {
+        const roles = { manage: 'normal', peer: 'inter-router', member: 'edge', van: 'edge' };
+        return roles[kind] ?? 'normal';
+    }),
+    GetAccessPointKind: vi.fn(() => 'member'),
+}));
+
+import { UpdateLocalState as StateSyncUpdateLocalState } from '@skupperx/modules/state-sync';
+import {
+    ApplyObject,
+    Controlled,
+    DeleteLink,
+    GetSecrets,
+    UpdateLink,
+} from '@skupperx/modules/kube';
+import { Start, UpdateLocalState } from './sync-site-kube.js';
+
+describe('UpdateLocalState', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        for (const key of Object.keys(stateSyncCallbacks)) {
+            delete stateSyncCallbacks[key];
+        }
+        await Start('site-1', { id: 'conn' }, false, 'sk2');
+    });
+
+    it('stores access point state without syncing when no peer is connected', async () => {
+        await UpdateLocalState('accessstatus-ap-1', 'hash-1', {
+            host: 'router.example.com',
+            port: 9090,
+        });
+
+        expect(StateSyncUpdateLocalState).not.toHaveBeenCalled();
+    });
+
+    it('clears local state when hash is null', async () => {
+        await UpdateLocalState('accessstatus-ap-1', 'hash-1', {
+            host: 'router.example.com',
+            port: 9090,
+        });
+        await UpdateLocalState('accessstatus-ap-1', null, {});
+
+        expect(StateSyncUpdateLocalState).not.toHaveBeenCalled();
+    });
+
+    it('forwards local state updates to the connected peer', async () => {
+        GetSecrets.mockResolvedValue([]);
+        await stateSyncCallbacks.onNewPeer('mgmt-peer', 'management');
+
+        await UpdateLocalState('accessstatus-ap-1', 'hash-1', {
+            host: 'router.example.com',
+            port: 9090,
+        });
+
+        expect(StateSyncUpdateLocalState).toHaveBeenCalledWith(
+            'mgmt-peer',
+            'accessstatus-ap-1',
+            'hash-1',
+        );
+    });
+});
+
+describe('onStateChange', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        for (const key of Object.keys(stateSyncCallbacks)) {
+            delete stateSyncCallbacks[key];
+        }
+        await Start('site-1', { id: 'conn' }, true, 'sk2');
+        GetSecrets.mockResolvedValue([]);
+        await stateSyncCallbacks.onNewPeer('mgmt-peer', 'management');
+    });
+
+    it('creates a Link resource from remote state', async () => {
+        GetSecrets.mockResolvedValue([{
+            metadata: {
+                name: 'site-client-secret',
+                annotations: {
+                    [META_ANNOTATION_SKUPPERX_CONTROLLED]: 'true',
+                    [META_ANNOTATION_TLS_INJECT]: INJECT_TYPE_SITE,
+                },
+            },
+        }]);
+        Controlled.mockReturnValue(true);
+
+        await stateSyncCallbacks.onStateChange('mgmt-peer', 'link-link-1', 'hash-link-1', {
+            host: 'router.example.com',
+            port: '443',
+            cost: '2',
+        });
+
+        expect(ApplyObject).toHaveBeenCalledWith(expect.objectContaining({
+            kind: 'Link',
+            metadata: expect.objectContaining({
+                name: expect.stringContaining('link'),
+                annotations: expect.objectContaining({
+                    'skx/state-key': 'link-link-1',
+                }),
+            }),
+            spec: expect.objectContaining({
+                cost: 2,
+                endpoints: [expect.objectContaining({
+                    host: 'router.example.com',
+                    port: '443',
+                })],
+            }),
+        }));
+    });
+
+    it('deletes Link resources when remote hash is cleared', async () => {
+        await stateSyncCallbacks.onStateChange('mgmt-peer', 'link-link-2', null, {});
+
+        expect(DeleteLink).toHaveBeenCalled();
+    });
+
+    it('updates an existing Link when hash changes', async () => {
+        GetSecrets.mockResolvedValue([{
+            metadata: {
+                name: 'site-client-secret',
+                annotations: {
+                    [META_ANNOTATION_SKUPPERX_CONTROLLED]: 'true',
+                    [META_ANNOTATION_TLS_INJECT]: INJECT_TYPE_SITE,
+                },
+            },
+        }]);
+        Controlled.mockReturnValue(true);
+        UpdateLink.mockResolvedValue({});
+
+        const existingLink = {
+            apiVersion: 'skupper.io/v2alpha1',
+            kind: 'Link',
+            metadata: {
+                name: 'link-link-3',
+                annotations: {
+                    'skx/state-hash': 'old-hash',
+                    'skx/state-key': 'link-link-3',
+                    'skx/state-dir': 'remote',
+                },
+            },
+            spec: {},
+        };
+        const { LoadLink } = await import('@skupperx/modules/kube');
+        LoadLink.mockResolvedValue(existingLink);
+
+        await stateSyncCallbacks.onStateChange('mgmt-peer', 'link-link-3', 'new-hash', {
+            host: 'router.example.com',
+            port: '5671',
+            cost: '1',
+        });
+
+        expect(UpdateLink).toHaveBeenCalledWith(expect.objectContaining({
+            kind: 'Link',
+            metadata: expect.objectContaining({
+                annotations: expect.objectContaining({
+                    'skx/state-hash': 'new-hash',
+                }),
+            }),
+        }));
+        expect(ApplyObject).not.toHaveBeenCalled();
+    });
+});
+
+describe('onStateRequest', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        for (const key of Object.keys(stateSyncCallbacks)) {
+            delete stateSyncCallbacks[key];
+        }
+        await Start('site-1', { id: 'conn' }, false, 'sk2');
+        GetSecrets.mockResolvedValue([]);
+        await stateSyncCallbacks.onNewPeer('mgmt-peer', 'management');
+    });
+
+    it('returns in-memory access point state for local keys', async () => {
+        await UpdateLocalState('accessstatus-ap-9', 'hash-ap-9', {
+            host: 'ingress.example.com',
+            port: 8443,
+        });
+
+        const [hash, data] = await stateSyncCallbacks.onStateRequest('mgmt-peer', 'accessstatus-ap-9');
+
+        expect(hash).toBe('hash-ap-9');
+        expect(data).toEqual({
+            host: 'ingress.example.com',
+            port: 8443,
+        });
+    });
+});

--- a/components/site-controller/src/test-helpers/build-site-api-app.js
+++ b/components/site-controller/src/test-helpers/build-site-api-app.js
@@ -1,0 +1,29 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+import { createApiApp, Initialize } from '../sc-apiserver.js';
+
+/**
+ * Build an Express app with site-controller routes mounted (no port binding).
+ */
+export async function buildSiteApiApp({ backboneMode = false, includeMemberApi = true } = {}) {
+    const app = createApiApp();
+    await Initialize(app, { backboneMode, includeMemberApi });
+    return { app };
+}


### PR DESCRIPTION
Extract createApiApp/Initialize from Start and add site-controller unit tests.

Changes to production code:
- Refactor site-controller API setup into createApiApp / Initialize so unit tests can mount production routes without listening on a port; runtime behavior of Start() is unchanged.

Testing:
- run `pnpm install && pnpm test:unit`

Part of #126 