### PR TITLE
extend helmfile deployment for integration test environment

### DIFF
--- a/charts/helmfile/helmfile.yaml.gotmpl
+++ b/charts/helmfile/helmfile.yaml.gotmpl
@@ -2,14 +2,15 @@ environments:
   default:
     values:
       - ./values/common.yaml
+  kind:
+    values:
+      - ./values/common.yaml
+      - ../../tests/integration/kind/helmfile/values-kind.yaml
 ---
 {{- $deployCertManager := .Values.releases.certManager.enabled }}
 {{- $deployPostgresql := .Values.releases.postgresql.enabled }}
 {{- $deployManagementServer := .Values.releases.managementServer.enabled }}
-{{- $postgresqlNamespace := .Values.releases.postgresql.namespace }}
-{{- if ne $postgresqlNamespace "" }}
-{{- $postgresqlNamespace = printf "-n %s" $postgresqlNamespace }}
-{{- end }}
+{{- $pgNamespace := .Values.releases.postgresql.namespace }}
 
 repositories:
   - name: bitnami
@@ -28,6 +29,17 @@ releases:
       - crds:
           enabled: true
           keep: true
+    hooks:
+      - events: ["postsync"]
+        showlogs: true
+        command: sh
+        args:
+          - -c
+          - |
+            kubectl wait --for=condition=Established crd/certificates.cert-manager.io --timeout=300s
+            kubectl wait --for=condition=Established crd/issuers.cert-manager.io --timeout=300s
+            kubectl -n cert-manager rollout status deployment/cert-manager-webhook --timeout=300s
+            kubectl -n cert-manager wait pod -l app.kubernetes.io/component=webhook --for=condition=Ready --timeout=300s
   - name: postgresql
     {{- if ne .Values.releases.postgresql.namespace "" }}
     namespace: {{ .Values.releases.postgresql.namespace }}
@@ -47,11 +59,31 @@ releases:
         args:
           - -c
           - |
-            kubectl create configmap db-init-configmap {{ $postgresqlNamespace }} --from-file=./resources/db-setup.sql -o yaml --dry-run=client | kubectl apply -f -
+            kubectl create configmap db-init-configmap {{- if ne $pgNamespace "" }} -n {{ $pgNamespace }}{{- end }} --from-file=./resources/db-setup.sql -o yaml --dry-run=client | kubectl apply -f -
   - name: management-server
+    {{- if ne .Values.releases.managementServer.namespace "" }}
+    namespace: {{ .Values.releases.managementServer.namespace }}
+    {{- end }}
+    createNamespace: true
     chart: ../management-server
     installed: {{ $deployManagementServer }}
+    needs:
+      - cert-manager/cert-manager
+      {{- if ne $pgNamespace "" }}
+      - {{ $pgNamespace }}/postgresql
+      {{- else }}
+      - postgresql
+      {{- end }}
     labels:
       component: management-server
     values:
       - ./values/management-server.yaml.gotmpl
+    hooks:
+      - events: ["presync"]
+        showlogs: true
+        command: sh
+        args:
+          - -c
+          - |
+            kubectl -n cert-manager rollout status deployment/cert-manager-webhook --timeout=300s
+            kubectl -n cert-manager wait pod -l app.kubernetes.io/component=webhook --for=condition=Ready --timeout=120s

--- a/charts/helmfile/values/common.yaml
+++ b/charts/helmfile/values/common.yaml
@@ -31,6 +31,13 @@ postgres:
     storageClass: ""
   imagePullSecret: ""
 
+# configuration for the management controller image
+managementServer:
+  image:
+    repository: quay.io/skupper/vms-management-controller
+    tag: latest
+    pullPolicy: Always
+
 # Release configuration:
 # certManager: installed into the cert-manager namespace (will be created if not exists)
 # postgresql: installed into the namespace specified in the namespace key (will be created if not exists). If namespace is empty, the release will be installed into the current namespace.

--- a/charts/helmfile/values/common.yaml
+++ b/charts/helmfile/values/common.yaml
@@ -43,3 +43,4 @@ releases:
     namespace: ""
   managementServer:
     enabled: true
+    namespace: ""

--- a/charts/helmfile/values/management-server.yaml.gotmpl
+++ b/charts/helmfile/values/management-server.yaml.gotmpl
@@ -1,6 +1,12 @@
+{{- $ms := .Values.managementServer | default dict }}
+{{- $image := $ms.image | default dict }}
 postgres:
   host: {{ .Values.postgres.host | quote }}
   port: {{ .Values.postgres.port | quote }}
   database: {{ .Values.postgres.database | quote }}
   credentialsSecret:
     {{- toYaml .Values.postgres.credentialsSecret | nindent 4 }}
+image:
+  repository: {{ $image.repository | default "quay.io/skupper/vms-management-controller" | quote }}
+  tag: {{ $image.tag | default "latest" | quote }}
+  pullPolicy: {{ $image.pullPolicy | default "Always" | quote }}

--- a/charts/helmfile/values/postgres.yaml.gotmpl
+++ b/charts/helmfile/values/postgres.yaml.gotmpl
@@ -12,6 +12,21 @@ auth:
   existingSecret: {{ $sec.name | quote }}
   secretKeys:
     adminPasswordKey: {{ $sec.adminPasswordKey | quote }}
+{{- if $pg.image }}
+image:
+  {{- if hasKey $pg.image "registry" }}
+  registry: {{ $pg.image.registry | quote }}
+  {{- end }}
+  {{- if hasKey $pg.image "repository" }}
+  repository: {{ $pg.image.repository | quote }}
+  {{- end }}
+  {{- if hasKey $pg.image "tag" }}
+  tag: {{ $pg.image.tag | quote }}
+  {{- end }}
+  {{- if hasKey $pg.image "pullPolicy" }}
+  pullPolicy: {{ $pg.image.pullPolicy | quote }}
+  {{- end }}
+{{- end }}
 primary:
   initdb:
     scriptsConfigMap: db-init-configmap

--- a/charts/helmfile/values/postgres.yaml.gotmpl
+++ b/charts/helmfile/values/postgres.yaml.gotmpl
@@ -12,20 +12,9 @@ auth:
   existingSecret: {{ $sec.name | quote }}
   secretKeys:
     adminPasswordKey: {{ $sec.adminPasswordKey | quote }}
-{{- if $pg.image }}
+{{- if and (hasKey $pg "image") (hasKey $pg.image "pullPolicy") }}
 image:
-  {{- if hasKey $pg.image "registry" }}
-  registry: {{ $pg.image.registry | quote }}
-  {{- end }}
-  {{- if hasKey $pg.image "repository" }}
-  repository: {{ $pg.image.repository | quote }}
-  {{- end }}
-  {{- if hasKey $pg.image "tag" }}
-  tag: {{ $pg.image.tag | quote }}
-  {{- end }}
-  {{- if hasKey $pg.image "pullPolicy" }}
   pullPolicy: {{ $pg.image.pullPolicy | quote }}
-  {{- end }}
 {{- end }}
 primary:
   initdb:

--- a/tests/integration/kind/helmfile/values-kind.yaml
+++ b/tests/integration/kind/helmfile/values-kind.yaml
@@ -1,0 +1,19 @@
+# Kind integration overlay (helmfile -e kind). Local image, single namespace, no PV.
+postgres:
+  host: postgresql
+  persistence:
+    enabled: false
+  image:
+    pullPolicy: IfNotPresent
+
+releases:
+  postgresql:
+    namespace: vms-test
+  managementServer:
+    namespace: vms-test
+
+managementServer:
+  image:
+    repository: vms-management-controller
+    tag: kind
+    pullPolicy: Never


### PR DESCRIPTION
Define kind overlay, cert-manager webhook waits, release ordering, and local image values for Kind clusters.

This PR makes changes to the helmfile deployment of the vms stack. It is intended to allow for the creation of a testing environment (via Kind) for integration tests.

Changes:
- adds a "kind" environment that uses a custom set of values for the deployments. Used for integration testing.
- adds hooks and enforces deployment ordering to ensure the management controller's prerequisites are deployed before it is (this becomes more relevant when you run the deployment via a script vs manually in a terminal) 
- configurable management server namespace
- configurable MC image -> integration tests use a locally built image

Testing:
- default `helmfile sync` should work and deploy the same as before
- deploying via `helmfile -e kind sync` is only intended for use in conjunction with scripts in upcoming integration test PR. These scripts set up the groundwork including local image build, namespaces, keycloak secrets, postgres secrets, etc. 

Part of #126 