### PR TITLE
add configurable controller name to MC chart

### DIFF
--- a/charts/helmfile/values/common.yaml
+++ b/charts/helmfile/values/common.yaml
@@ -37,6 +37,8 @@ managementServer:
     repository: quay.io/skupper/vms-management-controller
     tag: latest
     pullPolicy: Always
+  # Stable controller identity (SKX_CONTROLLER_NAME). Empty = chart name default.
+  controllerName: ""
 
 # Release configuration:
 # certManager: installed into the cert-manager namespace (will be created if not exists)

--- a/charts/helmfile/values/management-server.yaml.gotmpl
+++ b/charts/helmfile/values/management-server.yaml.gotmpl
@@ -10,3 +10,5 @@ image:
   repository: {{ $image.repository | default "quay.io/skupper/vms-management-controller" | quote }}
   tag: {{ $image.tag | default "latest" | quote }}
   pullPolicy: {{ $image.pullPolicy | default "Always" | quote }}
+controller:
+  name: {{ $ms.controllerName | default "" | quote }}

--- a/charts/management-server/templates/deployment.yaml
+++ b/charts/management-server/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
                   key: {{ .Values.postgres.credentialsSecret.appSystemPasswordKey | quote }}
             - name: NODE_ENV
               value: production
+            - name: SKX_CONTROLLER_NAME
+              value: {{ default .Chart.Name .Values.controller.name | quote }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/management-server/values.yaml
+++ b/charts/management-server/values.yaml
@@ -19,6 +19,11 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Stable identity for the management controller (SKX_CONTROLLER_NAME).
+# If empty, defaults to the chart name.
+controller:
+  name: ""
+
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Adds configurable controller name to management server chart with default value. When the deployment is restarted, the new pod will continue to use the same logical management controller record, avoiding a buildup of new management controller entries and certs.

fixes #166 