### PR TITLE
remove dead ingress path

### DIFF
--- a/components/management-controller/src/mc-apiserver.js
+++ b/components/management-controller/src/mc-apiserver.js
@@ -430,13 +430,6 @@ export async function AddHostToAccessPoint(req, siteId, apid, hostname, port) {
                     await client.query("UPDATE BackboneAccessPoints SET Hostname = $1, Port=$2, Lifecycle='new' WHERE Id = $3", [hostname, port, apid]);
                     notify.update('BackboneAccessPoints', apid);
                 }
-    
-                //
-                // Alert the sync module that an access point has advanced from 'partial' state if this is a peer ingress
-                //
-                if (access.kind == 'peer') {
-                    await sync.NewIngressAvailable(siteId);
-                }
             } else {
                 throw new Error(`Access point not found for site ${siteId} (${apid})`);
             }

--- a/components/management-controller/src/mc-apiserver.test.js
+++ b/components/management-controller/src/mc-apiserver.test.js
@@ -47,7 +47,6 @@ vi.mock('./sync-management.js', async (importOriginal) => {
     const actual = await importOriginal();
     return {
         ...actual,
-        NewIngressAvailable: vi.fn(),
     };
 });
 
@@ -217,7 +216,6 @@ describe('mc-apiserver routes', () => {
             includeUser: false,
             includeMcRoutes: true,
         });
-        const { NewIngressAvailable } = await import('./sync-management.js');
 
         const res = await request(app)
             .post(`/api/v1alpha1/backbonesite/${TEST_UUIDS.site}/ingress`)
@@ -225,6 +223,5 @@ describe('mc-apiserver routes', () => {
             .expect(201);
 
         expect(res.body).toEqual({ processed: 1 });
-        expect(NewIngressAvailable).toHaveBeenCalledWith(TEST_UUIDS.site);
     });
 });

--- a/components/management-controller/src/sync-management.js
+++ b/components/management-controller/src/sync-management.js
@@ -800,28 +800,6 @@ async function onApplicationNetworkChange(action, id) {
     }
 }
 
-export async function NewIngressAvailable(siteId) {
-    //
-    // Update the links/outgoing hash for each site that connects to the indicated site
-    //
-    const client = await ClientFromPool('system');
-    try {
-        const result = await client.query("SELECT ConnectingInteriorSite FROM InterRouterLinks WHERE ListeningInteriorSite = $1", [siteId]);
-        for (const row of result.rows) {
-            const connectingSiteId = row.id;
-            if (activeBackboneSites[connectingSiteId]) {
-                const [hash, data] = await getLinksOutgoing(connectingSiteId);
-                activeBackboneSites[connectingSiteId].bbHashSet[backboneHashKeys['links/outgoing']] = hash;
-                accelerateSiteHeartbeat(connectingSiteId);
-            }
-        }
-    } catch (error) {
-        Log(`Exception in NewIngressAvailable: ${error.message}`);
-    } finally {
-        client.release();
-    }
-}
-
 export async function SiteDeleted(siteId) {
     DeletePeer(siteId);
 }


### PR DESCRIPTION
This PR is really just a question. This deleted path looks unreachable to me (other than through a direct API call). This API route only gets called when you hit the "submit ingress data" button when manually bootstrapping a site. Currently, the only call to GetBackboneAccessPoints_TX uses initialOnly = true, which makes it only return manage APs, so this "peer" AP path would never get called.

The underlying issue I was looking at was that the NewIngressAvailable function has references to non-existent functions, variables, and database column. So my question is should this path be removed entirely or adapted to fit the current code?