### PR TITLE
pin pnpm version for build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,7 +28,7 @@ RUN microdnf -y install nodejs tar gzip && \
     microdnf clean all && \
     npm install -g corepack && \
     corepack enable && \
-    corepack prepare pnpm@latest --activate
+    corepack prepare pnpm@11.18.0 --activate
 
 # Set working directory for the monorepo
 WORKDIR /monorepo


### PR DESCRIPTION
pnpm > 11.18.0 breaks the @skupperx/modules style imports. Pinning this version for now to fix the build. Will follow up by looking more into the root of the issue