### PR TITLE
adding AGENTS.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# SkupperVMS — Agent Guide
+
+This file provides guidance to AI coding agents working in this repository.
+
+## Project Overview
+
+SkupperVMS is a multi-tenant Virtual Application Network (VAN) management system: a pnpm monorepo with shared modules, two controllers, a React console, and Helm-based deployment.
+
+## Scope
+
+This file contains repository-wide guidance.
+
+When working in a subdirectory, also consult the nearest `AGENTS.md`, which contains package-specific instructions.
+
+## Commands
+
+**Prerequisites:** Node.js, pnpm. Optional for deploy: kubectl, Helm, Helmfile, Podman/Docker.
+
+```bash
+pnpm install                          # install all workspace packages
+pnpm test:unit                        # run all colocated unit tests
+pnpm test:integration:local           # spin up Kind cluster, run integration tests, tear down Kind cluster
+
+# Console build
+pnpm --filter vms-console run build
+```
+
+More test commands (watch, coverage, integration): [docs/notes/testing.md](docs/notes/testing.md). Use Kind/integration only when changing deploy, cross-component, or cluster-facing behavior — not for ordinary unit or controller edits.
+
+**Container builds** ([Containerfile](Containerfile)):
+
+```bash
+docker build -f Containerfile --target vms-management-controller .
+docker build -f Containerfile --target vms-site-controller .
+```
+
+## Conventions
+
+- **pnpm only** — do not use npm or yarn; workspace packages link via `workspace:*`.
+- **Apache 2.0 header** on new `.js` source files (see existing files for the standard block).
+- **Respect package boundaries** — do not move controller-specific logic into modules/. Only helpers shared by MC and SC belong there (no Express, Postgres, OIDC, or UI).
+
+## Collaboration
+
+- **Prefer correctness over agreement** — evaluate proposed approaches critically. If a design, implementation, or assumption is flawed or there is a better alternative, explain the tradeoffs and recommend the better approach with supporting reasoning.
+
+## Development guidelines
+
+- **Task-scoped diffs only** — change only what the request requires. Do not refactor, reformat, rename, or “improve” nearby code in the same file unless that change is necessary for the task. Match surrounding code style.
+- **Prefer existing patterns** — before introducing a new abstraction, helper, or dependency, look for an existing implementation in the same package and extend or reuse it when appropriate.
+- **Manage dependencies with pnpm** — if the requested change requires adding, removing, or updating dependencies, use the appropriate pnpm command rather than editing package.json or pnpm-lock.yaml by hand. If the user has not asked you to install or modify dependencies, ask before running the command.
+- **Preserve existing comments** — do not rewrite or delete comments for style or preference. Update a comment only when the code it describes has changed and the comment would otherwise be wrong or misleading (e.g. a function that used to add two values now adds three — update the comment to match). Do not expand, rephrase, or “improve” comments that remain accurate.
+- **Comments are for readers, not the agent** — add a comment only when it documents a non-obvious invariant, constraint, or workaround that the code itself does not make clear. Do not narrate what the code does, explain why the agent made a change, or refer to the conversation, the user, or the PR.
+    - Good: `// Claim cert is the only participant credential; do not add bearer auth here.`
+    - Bad: `// Updated this to use the new helper` / `// Fixed per review feedback`
+- **Never hand-edit generated files** — modify the source inputs instead. Generated files (such as pnpm-lock.yaml, dist/, and other build artifacts) may change only as the result of a user-requested command (for example, a build or install). When a generated file changes, state which command produced it.
+- **Preserve file history whenever practical** — prefer the smallest change that achieves the goal, and preserve git history whenever possible. When moving or renaming a tracked file, use `git mv` (or an equivalent tracked rename); do not delete-and-recreate.
+- **Update unit tests alongside code changes** — when changing source under `modules/` or the controllers, update the colocated `*.test.js`. When adding a new `.js` source file there, add a colocated `<name>.test.js` for exported behavior. Console is outside the Vitest unit project.
+- **Lint/format** — when finished modifying or creating a file, run `pnpm exec eslint --fix`, then `pnpm exec prettier --write`, on the modified files. Do not reformat style outside these commands.
+
+## Testing
+
+Unit tests are colocated in `modules/`, `management-controller/`, and `site-controller/` (console excluded). Run `pnpm test:unit` before considering a task complete. Do not run Kind/integration unless the change is deploy- or cluster-facing. In these cases, confirm before running integration tests.
+
+Vitest projects, mocks, helpers, and branch-diff script: [docs/notes/testing.md](docs/notes/testing.md).
+
+## Constraints
+
+- **Never commit secrets:** `.env`, `keycloak.json`, credentials, or tokens (all gitignored).
+- **Preserve OIDC/session checks** and claim-redemption flow when touching auth or bootstrap paths.
+- **DB schema changes** must update both MC code and [charts/helmfile/resources/db-setup.sql](charts/helmfile/resources/db-setup.sql).
+
+## Sources of truth
+
+Several `docs/notes/*` files describe historical designs and may be stale. When documentation conflicts with implementation, treat the code paths listed below as the source of truth.
+
+| If you change…               | Look at…                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| DB schema / objects          | `charts/helmfile/resources/db-setup.sql` and MC code that queries it                              |
+| Admin or user API            | MC `api-admin.js`, `api-user.js`, `mc-apiserver.js`                                               |
+| Certificates / PKI           | MC `certs.js`, chart cert templates                                                               |
+| Auth / OIDC                  | MC `auth/management-oidc.js`, [keycloak-setup.md](docs/notes/keycloak-setup.md)                   |
+| Backbone site bootstrap YAML | MC `site-deployment-state.js`, `mc-apiserver.js` (`backbonesite/…`), console `SiteDeployment.jsx` |
+| Member claim redemption      | SC `claim.js`                                                                                     |
+| K8s object templates         | MC `resource-templates.js` only                                                                   |
+| Helm deploy                  | [charts/helmfile/](charts/helmfile/), [charts/management-server/](charts/management-server/)      |

--- a/charts/helmfile/AGENTS.md
+++ b/charts/helmfile/AGENTS.md
@@ -1,0 +1,56 @@
+# Helmfile — Agent Guide
+
+Deploy the full SkupperVMS management plane stack via Helmfile: cert-manager, PostgreSQL, and the local management-server chart.
+
+## Scope
+
+Edit this directory for **release orchestration**, **values overlays**, and **DB init hooks**. Application chart templates belong in [../management-server/](../management-server/).
+
+Helmfile installs the management plane only (cert-manager, Postgres, MC). Site controller is applied via MC-generated bootstrap/invitation YAML, not as a Helmfile release.
+
+## Commands
+
+```bash
+cd charts/helmfile
+
+helmfile sync                              # install/sync all enabled releases
+helmfile apply                             # incremental apply with diffs
+helmfile -l component=cert-manager apply   # single release by label
+helmfile -l component=postgresql apply
+helmfile -l component=management-server apply
+helmfile destroy                           # tear down all releases
+helmfile -l component=postgresql destroy   # selective destroy
+```
+
+Uses the current `kubectl` context. Requires Helm, Helmfile, and the `helm-diff` plugin.
+
+## Key Files
+
+| Path                                   | Role                                             |
+| -------------------------------------- | ------------------------------------------------ |
+| `helmfile.yaml.gotmpl`                 | Releases, labels, needs, hooks                   |
+| `values/common.yaml`                   | Shared values for all charts                     |
+| `values/postgres.yaml.gotmpl`          | Bitnami PostgreSQL values                        |
+| `values/management-server.yaml.gotmpl` | Overlay for the MC chart                         |
+| `resources/db-setup.sql`               | Schema applied via ConfigMap on Postgres presync |
+| `resources/drop.sql`                   | Optional manual teardown (not used by Helmfile)  |
+
+Environments: `default` and `kind` (kind adds `tests/integration/kind/helmfile/values-kind.yaml`).
+
+## Conventions
+
+- **Passwords are not in values** — create Secrets before install:
+    - `postgres-credentials` (keys from `common.yaml`: `postgres-password`, `app-user-password`, `app-system-password`) in the Postgres **and** management-server namespaces if they differ
+    - `keycloak-config` with key `keycloak.json` in the management-server namespace (Helmfile does not create it)
+- **Release labels:** `component=cert-manager|postgresql|management-server`
+- **DB init:** Postgres `presync` hook applies ConfigMap `db-init-configmap` from `resources/db-setup.sql`
+- **Prefer values over template logic:** Expose configuration through values rather than adding conditional behavior directly in templates unless necessary.
+
+## Constraints
+
+- Never put credentials or Keycloak JSON into values files or commit them.
+- Schema/object changes must update `resources/db-setup.sql` **and** MC code.
+- Do not add site-controller deployment manifests here — SC is not a Helmfile release.
+- Keycloak is **not** installed here — only the adapter Secret is expected.
+- Postgres namespace may differ from the MC namespace (`releases.postgresql.namespace`); empty means current kubectl namespace
+- Align kubectl namespace with where Postgres is installed so the init ConfigMap lands correctly.

--- a/charts/management-server/AGENTS.md
+++ b/charts/management-server/AGENTS.md
@@ -1,0 +1,44 @@
+# management-server chart — Agent Guide
+
+Helm chart that packages the management controller (MC) as a Kubernetes Deployment with Service, Ingress/HTTPRoute, RBAC, and cert-manager resources.
+
+## Scope
+
+Edit this chart for **MC pod packaging**: image, env, mounts, networking, RBAC, and cert CRs. Release toggles and Postgres/image overlays live in [../helmfile/](../helmfile/AGENTS.md).
+
+## Commands
+
+```bash
+# From repo root — render with chart defaults (no cluster required)
+helm template mgmt charts/management-server
+
+# Full-stack / overlay values: use Helmfile
+cd charts/helmfile && helmfile -l component=management-server template
+cd charts/helmfile && helmfile -l component=management-server apply
+```
+
+`helmfile apply` requires a live cluster/`kubectl` context. There are no in-repo chart unit tests — validate with `helm template` and cluster apply.
+
+## Key Files
+
+| Template                    | Role                                                    |
+| --------------------------- | ------------------------------------------------------- |
+| `templates/deployment.yaml` | MC Deployment; PG* / APP_* env; `keycloak-config` mount |
+| `templates/certs.yaml`      | cert-manager Certificate / Issuer resources             |
+| `templates/rbac.yaml`       | RBAC for the controller SA                              |
+| `values.yaml`               | Chart defaults (image, postgres, ingress, probes)       |
+
+Helmfile overlay: [values/management-server.yaml.gotmpl](../helmfile/values/management-server.yaml.gotmpl) (Postgres settings + image from `common.yaml`).
+
+## Conventions
+
+- Mounts Secret **`keycloak-config`** at **`/app/keycloak.json`** (`subPath: keycloak.json`).
+- Prefer exposing configuration through `values.yaml` rather than hardcoding template values.
+
+## Constraints
+
+- Chart changes must stay aligned with MC env expectations and cert-manager CRs.
+- Do not embed secrets or Keycloak JSON in values; require pre-created Secrets (`postgres-credentials`, `keycloak-config`).
+- Do not add site-controller deployment manifests — SC is applied via MC-generated bootstrap/invitation YAML, not this chart.
+- Prefer Helmfile for multi-release installs; this chart can also be installed alone with standard Helm.
+- Keep chart env and mounts consistent with what MC expects at runtime.

--- a/components/console/AGENTS.md
+++ b/components/console/AGENTS.md
@@ -1,0 +1,38 @@
+# Console — Agent Guide
+
+React UI for SkupperVMS: backbones, VANs, TLS, and site deployment. In production it is **served by the management controller**, not a standalone backend.
+
+Workspace package name is **`vms-console`**; directory is `components/console`.
+
+## Scope
+
+Edit this package for UI pages, Carbon components, routing, and client-side API calls. Backend logic, auth, and APIs stay in the [management controller](../management-controller/AGENTS.md).
+
+## Commands
+
+```bash
+# From repo root
+pnpm --filter vms-console run build   # Vite → components/console/dist/
+
+# API-integrated local UI
+cd components/management-controller
+node index.js                         # MC hosts API + console (port 8085)
+```
+
+**Do not** use isolated `pnpm --filter vms-console run dev` for API-integrated work — that Vite server has no MC backend, so the UI appears broken.
+
+## Conventions
+
+- **Stack:** React 19, React Router 7, Vite 8, IBM Carbon (`@carbon/react`), Sass.
+- **New pages:** add under `src/pages/`, register route in `src/App.jsx`, add nav link in `src/components/Navigation/Navigation.jsx`.
+- Follow Carbon patterns; keep UI thin — call MC APIs (`/api/v1alpha1/`), no business logic in the console.
+- Build output is `dist/` (Vite `outDir`); MC serves it when `NODE_ENV=production`.
+
+## Testing
+
+`App.test.jsx` exists but is **not** in the Vitest `unit` project. Exercise the UI via MC-hosted local run (`node index.js` in management-controller).
+
+## Constraints
+
+- No backend or domain orchestration in the UI — use MC APIs.
+- For HMR / live reload, run MC with `NODE_ENV` ≠ `production` (ViteExpress inside the controller). Rebuild `dist/` before production-mode MC.

--- a/components/management-controller/.env.example
+++ b/components/management-controller/.env.example
@@ -1,5 +1,5 @@
-# Copy to `.env` at the repository root (or in the directory you run `node` from;
-# the app walks up from the current working directory to find `.env`).
+# Copy to `.env` in this directory (`components/management-controller/`)
+# before running `node index.js` / `pnpm start` from here.
 # Values in the real environment take precedence over this file.
 
 # --- PostgreSQL (used by node-pg; see management-controller `db.js`) ---

--- a/components/management-controller/AGENTS.md
+++ b/components/management-controller/AGENTS.md
@@ -1,0 +1,64 @@
+# Management controller (MC) — Agent Guide
+
+Central control plane for SkupperVMS: Postgres, admin/user APIs, certificate management, kube sync, claim server, and console host.
+
+## Scope
+
+Edit this package for **MC-specific** orchestration: REST APIs, DB access, cert lifecycle, management/colo sync, OIDC/session auth, and K8s resource templates. Shared helpers belong in [`@vms/modules`](../../modules/AGENTS.md).
+
+## Commands
+
+```bash
+# From this directory (components/management-controller/)
+node index.js          # or: pnpm start — HTTP :8085, prefix /api/v1alpha1/
+```
+
+Image packaging uses the root [Containerfile](../../Containerfile) (`pnpm deploy`), not a local `app/` bundle.
+
+Package `"test"` is a stub — always run tests from the repo root.
+`.env` must live in `components/management-controller/` (same directory as `index.js`). See README.md for supported environment variables.
+
+## Architectural ownership
+
+| Responsibility                     | Source of truth            |
+| ---------------------------------- | -------------------------- |
+| Admin/User REST APIs               | api-admin.js / api-user.js |
+| HTTP server                        | mc-apiserver.js            |
+| Authentication                     | auth/management-oidc.js    |
+| Database access / RLS              | db.js                      |
+| Certificate hierarchy and rotation | certs.js                   |
+| Kubernetes resource generation     | resource-templates.js      |
+| Management-plane state sync        | sync-management.js         |
+| Colocated namespace sync           | colo-sync.js               |
+| Postgres change notifications      | notify.js                  |
+| Live watch for console             | watch-server.js            |
+
+## Project invariants
+
+- API route definitions live in `api-admin.js`, `api-user.js`, and `mc-apiserver.js`; treat these as the source of truth over `docs/notes/api.md`.
+- Database access goes through `db.js`, which establishes the OIDC RLS context.
+
+## Conventions
+
+- **Dual PG pools** (`app_user` / `app_system`); RLS via Keycloak `clientGroups` / `sub`.
+    - System-triggered transactions → `ClientFromPool("system")`
+    - User-triggered transactions → `ClientFromPool()`
+- **Use queryWithContext for user-initiated database work** — API requests acting on behalf of a user should use queryWithContext. When writing to RLS-protected tables, pass userInfo into the callback. See src/api-admin.js for examples.
+- **Prefer watches over polling** - Where possible, prefer the watch/notify practice over polling the database.
+
+## Testing
+
+Colocated tests: `src/*.test.js`, `src/auth/*.test.js`.
+
+- Helpers: `src/test-helpers/` — `mock-db.js`, `mock-auth.js`, `build-api-app.js`.
+- Supertest + `x-test-auth: 1` (optional `x-test-roles`); mock auth sets `req.kauth` / `clientGroups`.
+
+Shared Vitest rules and layout: [docs/notes/testing.md](../../docs/notes/testing.md).
+
+## Constraints
+
+- Preserve OIDC/session checks on auth and API bootstrap paths.
+- Do not inline K8s YAML outside `resource-templates.js`.
+- DB schema changes → MC code **and** [`charts/helmfile/resources/db-setup.sql`](../../charts/helmfile/resources/db-setup.sql).
+- No shared MC/SC helpers here — put those in `modules/`.
+- Never commit `.env`, or `keycloak.json` (place `keycloak.json` here for local OIDC).

--- a/components/management-controller/README.md
+++ b/components/management-controller/README.md
@@ -2,7 +2,7 @@
 
 ## Environment Variables
 
-At startup, the process loads the .env file. Copy `.env.example` from the repository root to `.env` and adjust values. Variables already set in the environment are not overwritten.
+At startup, the process loads `.env` from the current working directory. Copy [`.env.example`](.env.example) to `.env` in this directory (`components/management-controller/`) and adjust values. Variables already set in the environment are not overwritten.
 
 - PGHOST, PGDATABASE — PostgreSQL connection
 - APP_USER_PASSWORD, APP_SYSTEM_PASSWORD — pool passwords for `app_user` / `app_system`

--- a/components/site-controller/AGENTS.md
+++ b/components/site-controller/AGENTS.md
@@ -1,0 +1,43 @@
+# Site controller (SC) — Agent Guide
+
+Per-site orchestration at backbone and member sites: claim redemption, local kube sync, ingress, and participant API.
+
+## Scope
+
+Edit this package for site-local behavior: claim assertion, member/backbone HTTP routes, router ports, ingress bundles, or site kube state sync. Shared helpers go in [`modules/`](../../modules/AGENTS.md); central DB/API/certs stay in the management controller.
+
+Member **claim redemption** (`claim.js`) is separate from **backbone site bootstrap** (MC YAML download / ingress upload / access-points finish — see MC `site-deployment-state.js` and console `SiteDeployment.jsx`).
+
+## Key modules / entry points
+
+- `claim.js` handles the one-time invitation claim flow before a site joins the VAN.
+- `sync-site-kube.js` is the authoritative implementation of Kubernetes ↔ AMQP state synchronization.
+- `ingress-v2.js` owns hostname bundle generation. Treat this as the source of truth for hostname bundle generation.
+- `api-member.js` contains participant-facing API endpoints. Administrative APIs belong in `sc-apiserver.js`.
+
+**Mode flags:** `VMS_BACKBONE=YES|NO` (default `NO`), `VMS_PLATFORM`, `VMS_STANDALONE_NAMESPACE`, `VMS_SITE_ID`.
+
+**Startup:** API always starts first. **Member** mode: `claim.Start()` blocks until claim accepted (no-op on later restarts), then `api-member`. **Backbone** mode: skip claim, run `ingress-v2`. Both wait for local `skupper-router`, then `sync-site-kube`.
+
+**Routes** (`/api/v1alpha1/`): backbone → `GET hostnames`; member → `GET site/status`, `PUT site/start`.
+
+**Scripts** (`scripts/` → container `/usr/local/bin/`): `vmsstart`, `vmsstatus`, `vmshosts`.
+
+## Testing
+
+Package `"test"` is a stub — always run tests from the repo root.
+
+Colocated unit tests: `src/*.test.js`.
+
+- Pass `backboneMode` correctly in tests — it changes which routes and subsystems run.
+- Helper: `src/test-helpers/build-site-api-app.js` — `buildSiteApiApp({ backboneMode, includeMemberApi })` mounts routes without binding a port.
+- Route tests use **supertest** (`sc-apiserver.test.js`, `api-member.test.js`).
+- Mock kube/AMQP at module boundaries for claim and sync tests.
+
+Shared Vitest rules and layout: [docs/notes/testing.md](../../docs/notes/testing.md).
+
+## Constraints
+
+- SC communicates **in-band via the backbone** — member sites may lack direct TCP to MC.
+- Preserve the **claim-redemption flow** in `claim.js` (configmap/secret → AMQP assert → member config).
+- Do not move shared protocol/kube/AMQP helpers here — put them in `modules/`.

--- a/docs/notes/testing.md
+++ b/docs/notes/testing.md
@@ -1,0 +1,88 @@
+# Testing
+
+Deep reference for unit and integration tests. Package-specific notes live in each package’s `AGENTS.md`. Cross-cutting monorepo rules: root [AGENTS.md](../../AGENTS.md).
+
+## Commands
+
+Always run Vitest from the **repo root**. Package `"test"` scripts in MC/SC are stubs.
+
+```bash
+
+# unit tests
+pnpm test:unit                        # unit tests (run before every PR)
+pnpm vitest run <path/to/file.test.js>  # single test file
+
+# Integration tests (requires Kind cluster) — only for deploy / cross-component / cluster-facing changes
+pnpm test:integration:local           # cluster up → tests → cluster down
+pnpm test:integration                 # runs integration tests against an existing Kind cluster with VMS already deployed
+pnpm cluster:up                       # start Kind cluster only
+pnpm cluster:down                     # tear down Kind cluster only
+
+# unit + integration tests
+pnpm test                             # all Vitest projects (unit + integration; requires cluster up)
+pnpm test:watch                       # watch mode
+pnpm test:coverage                    # coverage report
+```
+
+Do **not** run Kind/integration for ordinary unit or single-controller edits. `pnpm test:unit` is the default local gate.
+
+## Vitest layout
+
+Config: [vitest.config.js](../../vitest.config.js).
+
+| Project       | Include                                                                                                                        | Notes                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| `unit`        | `modules/src/**/*.test.js`, `components/management-controller/src/**/*.test.js`, `components/site-controller/src/**/*.test.js` | Default local gate before PRs                            |
+| `integration` | `tests/integration/kind/specs/**/*.test.js`                                                                                    | Needs Kind cluster; longer timeouts; no file parallelism |
+
+`globals: false` — always import `describe`, `it`, `expect`, `vi` from `vitest`. Environment is `node`.
+
+**Console is excluded.** `components/console` has `App.test.jsx` but it is not in the unit project. UI behavior is validated via MC integration / manual use.
+
+Contributors should run `pnpm test:unit` locally before opening a PR.
+
+## Colocated unit tests
+
+Place tests next to source: `foo.js` → `foo.test.js` under the same `src/` tree.
+
+| Package                  | Helpers                                        |
+| ------------------------ | ---------------------------------------------- |
+| `modules/`               | Prefer pure unit tests; mock I/O at boundaries |
+| `management-controller/` | `src/test-helpers/`                            |
+| `site-controller/`       | `src/test-helpers/build-site-api-app.js`       |
+
+### Mocking patterns
+
+- Mock at **I/O boundaries** with `vi.mock()` (DB, kube, AMQP, HTTP clients, filesystem) — not internals under test.
+- Prefer `async (importOriginal) => ({ ...await importOriginal(), ...overrides })` when only part of a module should be stubbed.
+- Controllers: mock `@vms/modules/*` and local modules like `./db.js`, `./notify.js` as neighboring tests do.
+
+### MC API tests (supertest)
+
+Helpers in `components/management-controller/src/test-helpers/`:
+
+| Helper             | Role                                                          |
+| ------------------ | ------------------------------------------------------------- |
+| `build-api-app.js` | Express app with mock OIDC + admin/user (optional MC) routers |
+| `mock-auth.js`     | Auth double: `x-test-auth` / `x-test-roles`                   |
+| `mock-db.js`       | DB doubles for query paths                                    |
+
+Authenticate requests with header `x-test-auth: 1`. Optional `x-test-roles` is a comma-separated list of realm roles (defaults come from `buildApiApp` / `createMockAuth`).
+
+```js
+import request from "supertest";
+import { buildApiApp } from "./test-helpers/build-api-app.js";
+
+const { app } = await buildApiApp();
+await request(app).get("/some/path").set("x-test-auth", "1").expect(200);
+```
+
+### SC API tests
+
+Use `buildSiteApiApp({ backboneMode, includeMemberApi })` from `components/site-controller/src/test-helpers/build-site-api-app.js`. Pass `backboneMode` correctly — it changes which routes are mounted. Drive routes with **supertest** (no port bind).
+
+## Integration tests
+
+Kind-based specs under `tests/integration/kind/specs/` (health, certs, auth API, backbone bootstrap). Use the commands above (`pnpm test:integration:local`, or `pnpm cluster:up` / `pnpm test:integration` / `pnpm cluster:down`).
+
+Prerequisites, layout, env vars, and troubleshooting: [tests/integration/kind/README.md](../../tests/integration/kind/README.md). Helmfile env `kind` overlays values from `tests/integration/kind/helmfile/values-kind.yaml`.

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -1,0 +1,44 @@
+# `@vms/modules` — Agent Guide
+
+Shared library for SkupperVMS: AMQP, kube helpers, protocol messages, state-sync, logging, and utilities. Pure, reusable code used by both MC and SC.
+
+## Scope
+
+Edit this package when adding or changing helpers shared by MC and SC. Do not put Express routes, Postgres access, OIDC, UI logic, or controller-specific orchestration here.
+
+## Key modules
+
+Library only — no standalone process.
+
+**Prefer subpath imports**. The root namespace import (@vms/modules) remains available for compatibility.
+
+| Import                    | Module                                                 |
+| ------------------------- | ------------------------------------------------------ |
+| `@vms/modules/amqp`       | AMQP connection/sender helpers                         |
+| `@vms/modules/common`     | Shared constants (addresses, annotations, state types) |
+| `@vms/modules/kube`       | Kubernetes object load/apply helpers                   |
+| `@vms/modules/log`        | Logging                                                |
+| `@vms/modules/protocol`   | Claim/protocol message builders                        |
+| `@vms/modules/router`     | Router management helpers                              |
+| `@vms/modules/state-sync` | Peer state sync (works over AMQP)                      |
+| `@vms/modules/util`       | Small utilities                                        |
+
+## Conventions
+
+- **Side-effect-free on import** — modules initialize only when `Start()` (or equivalent) is called with injected deps.
+- **No Express, `pg`, or component deps** — keep this package free of controller/UI packages.
+- **Constants live in `common.js`** — AMQP addresses, K8s annotation keys (`vms/state-*`, `vms/tls-inject`, …), state types, object names. Prefer reusing these constants rather than introducing new annotation keys or object names.
+- Prefer named exports; controllers typically use subpath imports.
+
+## Testing
+
+Colocated unit tests: `src/*.test.js`. Prefer pure unit tests; mock I/O at module boundaries when needed.
+
+Shared Vitest rules and layout: [docs/notes/testing.md](../docs/notes/testing.md).
+
+## Constraints
+
+- Do **not** add controller or console logic here — keep it in MC/SC/console.
+- Keep this package free of HTTP/API and DB concerns. `state-sync` is designed to run over AMQP, not tied to HTTP.
+- Do not introduce secrets or env-specific config; callers pass configuration in.
+- **Preserve backwards compatibility** — changes to exported modules affect both controllers. Avoid breaking public APIs unless the change is explicitly requested.


### PR DESCRIPTION
I've been looking a bit into adding AGENTS.md files to a monorepo and drafted up these files to try to guide agents to produce better output. I've tested running the same prompts in an agent both with and without these files present and so far have seen improved output and have also noticed more/better questions from the agent before it plans/implements a large change. This is still largely experimental though and will need more testing over time with different types of prompts and areas touched to figure out where any gaps and bad/vague instructions lie. For now, I tried to keep the files minimal so we can more easily see what needs to be added/removed.

I added some instructions on how to make edits in the root AGENTS.md file to address some problems that I regularly notice with agent work. If there are any specific things you have run into that I didn't cover here, let me know. 

__NOTE:__ When an agent is prompted to do something, it will read the root AGENTS.md file, and then find the nearest nested AGENTS.md file. 