### PR TITLE
CI test workflow

### DIFF
--- a/.github/workflows/publish-controller-images.yml
+++ b/.github/workflows/publish-controller-images.yml
@@ -22,20 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
       - name: Build and push management-controller
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Containerfile
@@ -47,7 +47,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=management-controller
 
       - name: Build and push site-controller
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Containerfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   unit:
+    if: github.repository == 'skupperproject/vms'
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +50,7 @@ jobs:
           path: unit-test-results.json
 
   integration:
+    if: github.repository == 'skupperproject/vms'
     name: Integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,106 @@
+name: Test Suite
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-suite-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.18.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm run test:unit --reporter=json --outputFile=unit-test-results.json
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-results
+          path: unit-test-results.json
+
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.18.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install Kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+
+      - name: Install helmfile
+        run: |
+          HELMFILE_VERSION="v1.4.2"
+          curl -fsSL "https://github.com/helmfile/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION#v}_linux_amd64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin helmfile
+          helmfile version
+
+      - name: Install helm-diff plugin
+        run: helm plugin install --verify=false https://github.com/databus23/helm-diff
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Bring up Kind cluster
+        run: pnpm run cluster:up
+
+      - name: Run integration tests
+        run: pnpm run test:integration --reporter=json --outputFile=integration-test-results.json
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-test-results
+          path: integration-test-results.json
+
+      - name: Tear down Kind cluster
+        if: always()
+        run: pnpm run cluster:down


### PR DESCRIPTION
- added CI workflow to run unit and integration tests and generate test results artifacts in JSON format
- bumped controller build workflow action versions in response to https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

fixes #191 