### PR TITLE
pin pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
     "prettier": "^3.9.5",
     "supertest": "^7.1.4",
     "vitest": "^4.1.0"
-  }
+  },
+  "packageManager": "pnpm@11.18.0"
 }


### PR DESCRIPTION
__NOTE:__ You may need to initially update your global pnpm version to a newer version first before it will be compatible with the "packageManager" key in the package.json file, depending on what your current version is.